### PR TITLE
perf: optimize hot loops across pricing engines

### DIFF
--- a/src/engines/monte_carlo/mc_engine.rs
+++ b/src/engines/monte_carlo/mc_engine.rs
@@ -157,6 +157,9 @@ pub fn mc_european_with_arena(
     let sqrt_dt = dt.sqrt();
     let mu = market.rate - market.dividend_yield;
     let discount = (-market.rate * instrument.expiry).exp();
+    // Exact log-Euler GBM step: always positive, no clamp needed.
+    let drift = (mu - 0.5 * vol * vol) * dt;
+    let diffusion = vol * sqrt_dt;
 
     let _ = arena.path_slice(n_steps + 1);
     let _ = arena.payoff_slice(n_paths);
@@ -177,8 +180,7 @@ pub fn mc_european_with_arena(
         for j in 0..n_steps {
             let z = sample_standard_normal(&mut rng);
             let _ = sample_standard_normal(&mut rng);
-            s += mu * s * dt + vol * s * sqrt_dt * z;
-            s = s.max(1.0e-12);
+            s *= (drift + diffusion * z).exp();
             path[j + 1] = s;
         }
 

--- a/src/engines/tree/binomial.rs
+++ b/src/engines/tree/binomial.rs
@@ -87,32 +87,44 @@ impl PricingEngine<VanillaOption> for BinomialTreeEngine {
             _ => None,
         };
 
+        // Multiplicative recurrence replaces O(steps^2) powf() calls with multiplications.
+        // spot * u^j * d^(steps-j) = spot * d^steps * (u/d)^j
+        let ratio = u / d;
+        let one_minus_p = 1.0 - p;
+
         let mut values = vec![0.0_f64; self.steps + 1];
-        for (j, value) in values.iter_mut().enumerate().take(self.steps + 1) {
-            let st = market.spot * u.powf(j as f64) * d.powf((self.steps - j) as f64);
-            *value = intrinsic(instrument.option_type, st, instrument.strike);
+        {
+            let mut st = market.spot * d.powi(self.steps as i32);
+            for j in 0..=self.steps {
+                values[j] = intrinsic(instrument.option_type, st, instrument.strike);
+                st *= ratio;
+            }
         }
 
+        let mut base = market.spot * d.powi((self.steps - 1) as i32);
         for i in (0..self.steps).rev() {
-            for j in 0..=i {
-                let continuation = disc * (p * values[j + 1] + (1.0 - p) * values[j]);
+            let can_exercise = match &instrument.exercise {
+                ExerciseStyle::European => false,
+                ExerciseStyle::American => true,
+                ExerciseStyle::Bermudan { .. } => {
+                    bermudan_flags.as_ref().is_some_and(|flags| flags[i])
+                }
+            };
 
-                let can_exercise = match &instrument.exercise {
-                    ExerciseStyle::European => false,
-                    ExerciseStyle::American => true,
-                    ExerciseStyle::Bermudan { .. } => {
-                        bermudan_flags.as_ref().is_some_and(|flags| flags[i])
-                    }
-                };
-
-                if can_exercise {
-                    let st = market.spot * u.powf(j as f64) * d.powf((i - j) as f64);
+            if can_exercise {
+                let mut st = base;
+                for j in 0..=i {
+                    let continuation = disc * (p * values[j + 1] + one_minus_p * values[j]);
                     let exercise = intrinsic(instrument.option_type, st, instrument.strike);
                     values[j] = continuation.max(exercise);
-                } else {
-                    values[j] = continuation;
+                    st *= ratio;
+                }
+            } else {
+                for j in 0..=i {
+                    values[j] = disc * (p * values[j + 1] + one_minus_p * values[j]);
                 }
             }
+            base *= u;
         }
 
         let mut diagnostics = crate::core::Diagnostics::new();

--- a/src/engines/tree/two_asset_tree.rs
+++ b/src/engines/tree/two_asset_tree.rs
@@ -113,14 +113,20 @@ where
 
     let n = steps + 1;
 
-    // Terminal payoffs: values[i][j] = payoff at node where
-    // S1 = s1 * u1^i * d1^(steps-i), S2 = s2 * u2^j * d2^(steps-j)
+    // Terminal payoffs using multiplicative recurrence to eliminate powf().
+    // S1 = s1 * d1^steps * (u1/d1)^i, S2 = s2 * d2^steps * (u2/d2)^j
+    let ratio1 = u1 / d1;
+    let ratio2 = u2 / d2;
     let mut values = vec![vec![0.0_f64; n]; n];
-    for i in 0..n {
-        let s1_t = s1 * u1.powf(i as f64) * d1.powf((steps - i) as f64);
-        for j in 0..n {
-            let s2_t = s2 * u2.powf(j as f64) * d2.powf((steps - j) as f64);
-            values[i][j] = payoff_fn(s1_t, s2_t);
+    {
+        let mut s1_t = s1 * d1.powi(steps as i32);
+        for i in 0..n {
+            let mut s2_t = s2 * d2.powi(steps as i32);
+            for j in 0..n {
+                values[i][j] = payoff_fn(s1_t, s2_t);
+                s2_t *= ratio2;
+            }
+            s1_t *= ratio1;
         }
     }
 


### PR DESCRIPTION
- Tree engines (binomial, trinomial, generalized, convertible, swing,
  two-asset): replace O(n²) powf() calls with multiplicative recurrence.
  powf is ~50-100ns per call; for 500-step trees this eliminates ~125K
  expensive transcendental calls, replacing them with simple multiplies.

- PDE solvers (Crank-Nicolson, implicit FD, hopscotch, explicit FD):
  eliminate per-timestep heap allocations. CN/implicit now use in-place
  tridiagonal solves with pre-allocated scratch buffers, removing ~1400
  allocations per 200-step solve. Explicit FD precomputes spatial
  coefficients once instead of recomputing per grid point per timestep.

- Heston engine: precompute adjusted Gauss-Laguerre weights (w*exp(x))
  via LazyLock, eliminating 32 exp() calls per pricing invocation.

- Monte Carlo: switch GBM path generator from Euler to exact log-Euler
  discretization (s *= exp(drift + diffusion*z)), which is both more
  accurate and always positive (no clamp needed). Antithetic variates
  now negate z-vectors in-place instead of allocating new vectors.

All 366 tests pass unchanged.

https://claude.ai/code/session_01S2Af7e79bALvQvcoDoq63c