### PR TITLE
Optimize Monte Carlo and SIMD exp for major pricing speedup

### DIFF
--- a/src/engines/monte_carlo/mc_simd.rs
+++ b/src/engines/monte_carlo/mc_simd.rs
@@ -3,7 +3,7 @@
 use crate::math::fast_rng::{FastRng, FastRngKind, sample_standard_normal};
 
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
-use crate::math::simd_math::{exp_f64x4, load_f64x4, splat_f64x4, store_f64x4};
+use crate::math::simd_math::{fast_exp_f64x4, load_f64x4, splat_f64x4, store_f64x4};
 
 /// Structure-of-arrays path storage:
 /// `levels[step][path] = S(step, path)`.
@@ -185,7 +185,7 @@ unsafe fn simulate_gbm_paths_soa_avx2(
             let s = unsafe { load_f64x4(prev, i) };
             let z_vec = unsafe { _mm256_loadu_pd(z_arr.as_ptr()) };
             let x = _mm256_fmadd_pd(diffusion_v, z_vec, drift_v);
-            let growth = unsafe { exp_f64x4(x) };
+            let growth = unsafe { fast_exp_f64x4(x) };
             let s_next = _mm256_mul_pd(s, growth);
             unsafe { store_f64x4(next, i, s_next) };
             i += 4;


### PR DESCRIPTION
Key changes:

1. Exact single-step GBM for European MC: S_T = S_0 * exp((μ-σ²/2)*T + σ√T*Z)
   replaces per-step simulation, reducing exp() calls from O(paths*steps) to
   O(paths). For 100K paths × 252 steps this eliminates 25.1M exp() calls.
   Applied to mc_european_with_arena and mc_parallel simulate_chunk.

2. Skip unused z2 normals for GBM in generic MC engine: PathGenerator now
   exposes num_normal_streams() (1 for GBM, 2 for Heston), halving inverse-CDF
   and RNG work for the most common model.

3. Add fast_exp_f64x4 with degree-7 Remez minimax polynomial (~2e-10 accuracy):
   saves 4 FMA operations per vectorized exp() vs the degree-11 version.
   Used in SoA MC simulation where pricing-grade accuracy suffices.

4. SIMD-vectorized exact MC: mc_european_with_arena dispatches to AVX2+FMA path
   that processes 4 terminal spots per iteration with fast_exp_f64x4, computing
   payoffs entirely in SIMD registers.

https://claude.ai/code/session_014JhnX1GsXe7CfZkecjjHA9