### PR TITLE
feat(core): trade & market data serialization (closes #52)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1314,6 +1315,7 @@ dependencies = [
  "rayon",
  "realfft",
  "reqwest",
+ "rmp-serde",
  "rustfft",
  "serde",
  "serde_json",
@@ -1789,6 +1791,25 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ simd = []
 deribit = [
     "dep:reqwest",
     "dep:tokio",
-    "dep:serde",
-    "dep:serde_json",
     "dep:axum",
     "dep:tokio-tungstenite",
     "dep:futures-util",
@@ -24,7 +22,7 @@ deribit = [
 wasm = ["dep:wasm-bindgen", "dep:getrandom"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 rand = "0.10"
 rand_distr = "0.6"
 nalgebra = "0.34"
@@ -35,8 +33,9 @@ realfft = "3"
 pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
 reqwest = { version = "0.13", features = ["json", "query"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
+rmp-serde = "1"
 axum = { version = "0.8", features = ["ws"], optional = true }
 tokio-tungstenite = { version = "0.28", features = ["native-tls"], optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -1,0 +1,9 @@
+# OpenFerric Serialization Schemas
+
+Canonical schema files for issue #52:
+
+- `trade.schema.json`: tagged trade schema with product payload and trade metadata.
+- `market_snapshot.schema.json`: point-in-time market data container (curves, surfaces, spot/forward).
+- `pricing_audit.schema.json`: full pricing audit payload (`inputs -> model -> outputs`, including scenarios).
+
+All payloads are designed for serde round-trip guarantees in both JSON (`serde_json`) and MessagePack (`rmp-serde`).

--- a/docs/schemas/market_snapshot.schema.json
+++ b/docs/schemas/market_snapshot.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openferric.dev/schemas/market_snapshot.schema.json",
+  "title": "OpenFerric Market Snapshot",
+  "type": "object",
+  "required": [
+    "snapshot_id",
+    "as_of",
+    "yield_curves",
+    "credit_curves",
+    "vol_surfaces",
+    "spots",
+    "forwards"
+  ],
+  "properties": {
+    "snapshot_id": { "type": "string" },
+    "as_of": {
+      "type": "string",
+      "description": "RFC3339 UTC timestamp"
+    },
+    "yield_curves": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["pillars", "rates", "interpolation", "value_type"],
+        "properties": {
+          "pillars": { "type": "array", "items": { "type": "number" } },
+          "rates": { "type": "array", "items": { "type": "number" } },
+          "interpolation": {
+            "type": "string",
+            "enum": ["linear", "log_linear", "cubic_spline", "flat_forward"]
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["zero_rate", "discount_factor", "survival_probability", "forward_price"]
+          }
+        }
+      }
+    },
+    "credit_curves": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["pillars", "survival_probabilities", "recovery_rate", "interpolation"],
+        "properties": {
+          "pillars": { "type": "array", "items": { "type": "number" } },
+          "survival_probabilities": { "type": "array", "items": { "type": "number" } },
+          "recovery_rate": { "type": "number" },
+          "interpolation": {
+            "type": "string",
+            "enum": ["linear", "log_linear", "cubic_spline", "flat_forward"]
+          }
+        }
+      }
+    },
+    "vol_surfaces": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["expiries", "strikes", "vols"],
+        "properties": {
+          "expiries": { "type": "array", "items": { "type": "number" } },
+          "strikes": { "type": "array", "items": { "type": "number" } },
+          "vols": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": { "type": "number" }
+            }
+          },
+          "model": { "type": ["object", "null"] }
+        }
+      }
+    },
+    "spots": {
+      "type": "object",
+      "additionalProperties": { "type": "number" }
+    },
+    "forwards": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["points", "interpolation"],
+        "properties": {
+          "points": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": { "type": "number" }
+            }
+          },
+          "interpolation": {
+            "type": "string",
+            "enum": ["linear", "log_linear", "cubic_spline", "flat_forward"]
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/pricing_audit.schema.json
+++ b/docs/schemas/pricing_audit.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openferric.dev/schemas/pricing_audit.schema.json",
+  "title": "OpenFerric Pricing Audit Trail",
+  "type": "object",
+  "required": [
+    "trade",
+    "market_snapshot_id",
+    "engine_name",
+    "model_name",
+    "model_parameters",
+    "base_result",
+    "scenario_results",
+    "generated_at",
+    "notes"
+  ],
+  "properties": {
+    "trade": { "$ref": "trade.schema.json" },
+    "market_snapshot_id": { "type": "string" },
+    "engine_name": { "type": "string" },
+    "model_name": { "type": "string" },
+    "model_parameters": {
+      "type": "object",
+      "additionalProperties": { "type": "number" }
+    },
+    "base_result": {
+      "type": "object",
+      "required": ["price", "stderr", "greeks", "diagnostics"],
+      "properties": {
+        "price": { "type": "number" },
+        "stderr": { "type": ["number", "null"] },
+        "greeks": { "type": ["object", "null"] },
+        "diagnostics": { "type": "object" }
+      }
+    },
+    "scenario_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scenario_name", "bump_description", "result"],
+        "properties": {
+          "scenario_name": { "type": "string" },
+          "bump_description": { "type": ["string", "null"] },
+          "result": { "type": "object" }
+        }
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "description": "RFC3339 UTC timestamp"
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/trade.schema.json
+++ b/docs/schemas/trade.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openferric.dev/schemas/trade.schema.json",
+  "title": "OpenFerric Trade",
+  "type": "object",
+  "required": ["metadata", "product"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["trade_id", "version", "timestamp"],
+      "properties": {
+        "trade_id": { "type": "string" },
+        "version": { "type": "integer", "minimum": 0 },
+        "timestamp": {
+          "type": "string",
+          "description": "RFC3339 UTC timestamp"
+        }
+      }
+    },
+    "market_data_ref": {
+      "type": ["string", "null"],
+      "description": "Optional market snapshot reference"
+    },
+    "product": {
+      "type": "object",
+      "required": ["product_type", "payload"],
+      "properties": {
+        "product_type": {
+          "type": "string",
+          "enum": [
+            "vanilla_option",
+            "barrier_option",
+            "asian_option",
+            "basket_option",
+            "cash_or_nothing_option",
+            "asset_or_nothing_option",
+            "gap_option",
+            "double_barrier_option",
+            "spread_option",
+            "fx_option",
+            "futures_option",
+            "forward_start_option",
+            "commodity_forward",
+            "commodity_futures",
+            "commodity_option",
+            "commodity_spread_option",
+            "convertible_bond",
+            "employee_stock_option",
+            "exotic_option",
+            "power_option",
+            "best_of_two_call_option",
+            "worst_of_two_call_option",
+            "two_asset_correlation_option",
+            "range_accrual",
+            "dual_range_accrual",
+            "defer_investment_option",
+            "expand_option",
+            "abandonment_option",
+            "real_option_instrument",
+            "swing_option",
+            "tarf",
+            "variance_swap",
+            "volatility_swap",
+            "weather_swap",
+            "weather_option",
+            "catastrophe_bond",
+            "autocallable",
+            "phoenix_autocallable",
+            "mbs_pass_through",
+            "fixed_rate_bond",
+            "cap_floor",
+            "forward_rate_agreement",
+            "future",
+            "interest_rate_swap",
+            "swaption",
+            "overnight_index_swap",
+            "basis_swap",
+            "xccy_swap",
+            "zero_coupon_inflation_swap",
+            "year_on_year_inflation_swap",
+            "inflation_indexed_bond",
+            "cms_spread_option",
+            "cds",
+            "cds_option",
+            "cdo_tranche",
+            "synthetic_cdo",
+            "cds_index",
+            "nth_to_default_basket",
+            "dated_cds"
+          ]
+        },
+        "payload": {
+          "type": "object",
+          "description": "Serde payload for the corresponding product type"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 use crate::market::Market;
 
+pub mod serialization;
 pub mod types;
 
+pub use serialization::*;
 pub use types::*;
 
 /// Standardized Greeks container used by engine results.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Greeks {
     /// First derivative to spot.
     pub delta: f64,
@@ -34,7 +36,7 @@ pub trait PricingEngine<I: Instrument> {
 }
 
 /// Compact key set for engine diagnostics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum DiagKey {
     BarrierLevel,
     ConversionValue,
@@ -168,7 +170,7 @@ impl DiagKey {
 }
 
 /// Inline diagnostics storage used in [`PricingResult`].
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Diagnostics {
     entries: [Option<(DiagKey, f64)>; 8],
 }
@@ -248,7 +250,7 @@ impl Diagnostics {
 }
 
 /// Unified engine result payload.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PricingResult {
     /// Present value.
     pub price: f64,
@@ -263,7 +265,7 @@ pub struct PricingResult {
 const _: [(); 1] = [(); (std::mem::size_of::<PricingResult>() <= 384) as usize];
 
 /// Engine and model errors surfaced by the API.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum PricingError {
     /// Input validation error.
     InvalidInput(String),

--- a/src/core/serialization.rs
+++ b/src/core/serialization.rs
@@ -1,0 +1,306 @@
+//! Canonical trade, market data, portfolio, and pricing-audit serialization.
+//!
+//! These types define stable serde payloads used to persist and transport
+//! trades, market snapshots, and pricing outputs.
+//!
+//! # Examples
+//! ```rust
+//! use openferric::core::{
+//!     from_json, from_msgpack, to_json_pretty, to_msgpack, PortfolioSnapshot, Trade,
+//!     TradeMetadata, TradeProduct,
+//! };
+//! use openferric::instruments::VanillaOption;
+//! use openferric::core::{ExerciseStyle, OptionType};
+//!
+//! let trade = Trade {
+//!     metadata: TradeMetadata {
+//!         trade_id: "TRD-001".to_string(),
+//!         version: 1,
+//!         timestamp: "2026-02-22T11:00:00Z".to_string(),
+//!     },
+//!     market_data_ref: Some("SNAP-2026-02-22".to_string()),
+//!     product: TradeProduct::VanillaOption(VanillaOption {
+//!         option_type: OptionType::Call,
+//!         strike: 100.0,
+//!         expiry: 1.0,
+//!         exercise: ExerciseStyle::European,
+//!     }),
+//! };
+//!
+//! let portfolio = PortfolioSnapshot {
+//!     portfolio_id: "PF-001".to_string(),
+//!     market_snapshot_id: "SNAP-2026-02-22".to_string(),
+//!     as_of: "2026-02-22T11:00:00Z".to_string(),
+//!     trades: vec![trade],
+//! };
+//!
+//! let json = to_json_pretty(&portfolio).expect("json serialization");
+//! let decoded: PortfolioSnapshot = from_json(&json).expect("json deserialization");
+//! assert_eq!(decoded, portfolio);
+//!
+//! let bytes = to_msgpack(&portfolio).expect("msgpack serialization");
+//! let decoded_msgpack: PortfolioSnapshot = from_msgpack(&bytes).expect("msgpack deserialization");
+//! assert_eq!(decoded_msgpack, portfolio);
+//! ```
+
+use std::collections::BTreeMap;
+
+use serde::de::DeserializeOwned;
+
+use crate::core::PricingResult;
+use crate::credit::cds_option::CdsOption;
+use crate::credit::{CdoTranche, Cds, CdsIndex, DatedCds, NthToDefaultBasket, SyntheticCdo};
+use crate::instruments::mbs::MbsPassThrough;
+use crate::instruments::{
+    AbandonmentOption, AsianOption, AssetOrNothingOption, Autocallable, BarrierOption,
+    BasketOption, BestOfTwoCallOption, CashOrNothingOption, CatastropheBond, CommodityForward,
+    CommodityFutures, CommodityOption, CommoditySpreadOption, ConvertibleBond,
+    DeferInvestmentOption, DoubleBarrierOption, DualRangeAccrual, EmployeeStockOption,
+    ExoticOption, ExpandOption, ForwardStartOption, FuturesOption, FxOption, GapOption,
+    PhoenixAutocallable, PowerOption, RangeAccrual, RealOptionInstrument, SpreadOption,
+    SwingOption, Tarf, TwoAssetCorrelationOption, VanillaOption, VarianceSwap, VolatilitySwap,
+    WeatherOption, WeatherSwap, WorstOfTwoCallOption,
+};
+use crate::rates::cms::CmsSpreadOption;
+use crate::rates::{
+    BasisSwap, CapFloor, FixedRateBond, ForwardRateAgreement, Future, InflationIndexedBond,
+    InterestRateSwap, OvernightIndexSwap, Swaption, XccySwap, YearOnYearInflationSwap,
+    ZeroCouponInflationSwap,
+};
+use crate::vol::sabr::SabrParams;
+use crate::vol::surface::SviParams;
+
+/// Canonical product payload tagged by `product_type` in JSON.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "product_type", content = "payload", rename_all = "snake_case")]
+pub enum TradeProduct {
+    VanillaOption(VanillaOption),
+    BarrierOption(BarrierOption),
+    AsianOption(AsianOption),
+    BasketOption(BasketOption),
+    CashOrNothingOption(CashOrNothingOption),
+    AssetOrNothingOption(AssetOrNothingOption),
+    GapOption(GapOption),
+    DoubleBarrierOption(DoubleBarrierOption),
+    SpreadOption(SpreadOption),
+    FxOption(FxOption),
+    FuturesOption(FuturesOption),
+    ForwardStartOption(ForwardStartOption),
+    CommodityForward(CommodityForward),
+    CommodityFutures(CommodityFutures),
+    CommodityOption(CommodityOption),
+    CommoditySpreadOption(CommoditySpreadOption),
+    ConvertibleBond(ConvertibleBond),
+    EmployeeStockOption(EmployeeStockOption),
+    ExoticOption(ExoticOption),
+    PowerOption(PowerOption),
+    BestOfTwoCallOption(BestOfTwoCallOption),
+    WorstOfTwoCallOption(WorstOfTwoCallOption),
+    TwoAssetCorrelationOption(TwoAssetCorrelationOption),
+    RangeAccrual(RangeAccrual),
+    DualRangeAccrual(DualRangeAccrual),
+    DeferInvestmentOption(DeferInvestmentOption),
+    ExpandOption(ExpandOption),
+    AbandonmentOption(AbandonmentOption),
+    RealOptionInstrument(RealOptionInstrument),
+    SwingOption(SwingOption),
+    Tarf(Tarf),
+    VarianceSwap(VarianceSwap),
+    VolatilitySwap(VolatilitySwap),
+    WeatherSwap(WeatherSwap),
+    WeatherOption(WeatherOption),
+    CatastropheBond(CatastropheBond),
+    Autocallable(Autocallable),
+    PhoenixAutocallable(PhoenixAutocallable),
+    MbsPassThrough(MbsPassThrough),
+    FixedRateBond(FixedRateBond),
+    CapFloor(CapFloor),
+    ForwardRateAgreement(ForwardRateAgreement),
+    Future(Future),
+    InterestRateSwap(InterestRateSwap),
+    Swaption(Swaption),
+    OvernightIndexSwap(OvernightIndexSwap),
+    BasisSwap(BasisSwap),
+    XccySwap(XccySwap),
+    ZeroCouponInflationSwap(ZeroCouponInflationSwap),
+    YearOnYearInflationSwap(YearOnYearInflationSwap),
+    InflationIndexedBond(InflationIndexedBond),
+    CmsSpreadOption(CmsSpreadOption),
+    Cds(Cds),
+    CdsOption(CdsOption),
+    CdoTranche(CdoTranche),
+    SyntheticCdo(SyntheticCdo),
+    CdsIndex(CdsIndex),
+    NthToDefaultBasket(NthToDefaultBasket),
+    DatedCds(DatedCds),
+}
+
+/// Trade metadata required for persistence and audit.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TradeMetadata {
+    pub trade_id: String,
+    pub version: u64,
+    /// RFC3339 timestamp string (UTC recommended).
+    pub timestamp: String,
+}
+
+/// Canonical trade payload.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Trade {
+    pub metadata: TradeMetadata,
+    /// Optional pointer to a market snapshot identifier.
+    pub market_data_ref: Option<String>,
+    pub product: TradeProduct,
+}
+
+/// Curve interpolation method for serialized market data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InterpolationMethod {
+    Linear,
+    LogLinear,
+    CubicSpline,
+    FlatForward,
+}
+
+/// Semantic meaning of serialized curve values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CurveValueType {
+    ZeroRate,
+    DiscountFactor,
+    SurvivalProbability,
+    ForwardPrice,
+}
+
+/// Yield curve market data with explicit interpolation settings.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct YieldCurveSnapshot {
+    pub pillars: Vec<f64>,
+    pub rates: Vec<f64>,
+    pub interpolation: InterpolationMethod,
+    pub value_type: CurveValueType,
+}
+
+impl YieldCurveSnapshot {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.pillars.is_empty() {
+            return Err("yield curve pillars must be non-empty".to_string());
+        }
+        if self.pillars.len() != self.rates.len() {
+            return Err("yield curve pillars/rates length mismatch".to_string());
+        }
+        if self.pillars.windows(2).any(|w| w[1] <= w[0]) {
+            return Err("yield curve pillars must be strictly increasing".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// Credit curve snapshot with survival probabilities and recovery.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CreditCurveSnapshot {
+    pub pillars: Vec<f64>,
+    pub survival_probabilities: Vec<f64>,
+    pub recovery_rate: f64,
+    pub interpolation: InterpolationMethod,
+}
+
+/// Parametric model metadata for vol surfaces.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "model", rename_all = "snake_case")]
+pub enum VolSurfaceModel {
+    Svi {
+        parameters_by_expiry: Vec<(f64, SviParams)>,
+    },
+    Sabr {
+        parameters_by_expiry: Vec<(f64, SabrParams)>,
+    },
+    Custom {
+        name: String,
+        parameters: BTreeMap<String, f64>,
+    },
+}
+
+/// Vol surface snapshot as a strikes x expiries matrix.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct VolSurfaceSnapshot {
+    pub expiries: Vec<f64>,
+    pub strikes: Vec<f64>,
+    /// Row-major volatility matrix `[expiry_index][strike_index]`.
+    pub vols: Vec<Vec<f64>>,
+    pub model: Option<VolSurfaceModel>,
+}
+
+/// Forward curve market data for one asset.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ForwardCurveSnapshot {
+    pub points: Vec<(f64, f64)>,
+    pub interpolation: InterpolationMethod,
+}
+
+/// Point-in-time market snapshot containing all curves/surfaces/quotes.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct MarketSnapshot {
+    pub snapshot_id: String,
+    /// RFC3339 timestamp string (UTC recommended).
+    pub as_of: String,
+    pub yield_curves: BTreeMap<String, YieldCurveSnapshot>,
+    pub credit_curves: BTreeMap<String, CreditCurveSnapshot>,
+    pub vol_surfaces: BTreeMap<String, VolSurfaceSnapshot>,
+    pub spots: BTreeMap<String, f64>,
+    pub forwards: BTreeMap<String, ForwardCurveSnapshot>,
+}
+
+/// Portfolio container with trade list and shared market reference.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PortfolioSnapshot {
+    pub portfolio_id: String,
+    pub market_snapshot_id: String,
+    /// RFC3339 timestamp string (UTC recommended).
+    pub as_of: String,
+    pub trades: Vec<Trade>,
+}
+
+/// Scenario output linked to a bumped market setup.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ScenarioPricingResult {
+    pub scenario_name: String,
+    pub bump_description: Option<String>,
+    pub result: PricingResult,
+}
+
+/// Serializable pricing result with full input/model/output audit trail.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PricingAuditTrail {
+    pub trade: Trade,
+    pub market_snapshot_id: String,
+    pub engine_name: String,
+    pub model_name: String,
+    pub model_parameters: BTreeMap<String, f64>,
+    pub base_result: PricingResult,
+    pub scenario_results: Vec<ScenarioPricingResult>,
+    /// RFC3339 timestamp string (UTC recommended).
+    pub generated_at: String,
+    pub notes: Vec<String>,
+}
+
+/// Serialize a value to pretty JSON.
+pub fn to_json_pretty<T: serde::Serialize>(value: &T) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(value)
+}
+
+/// Deserialize a value from JSON.
+pub fn from_json<T: DeserializeOwned>(payload: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_str(payload)
+}
+
+/// Serialize a value to MessagePack bytes.
+pub fn to_msgpack<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, rmp_serde::encode::Error> {
+    rmp_serde::to_vec_named(value)
+}
+
+/// Deserialize a value from MessagePack bytes.
+pub fn from_msgpack<T: DeserializeOwned>(payload: &[u8]) -> Result<T, rmp_serde::decode::Error> {
+    rmp_serde::from_slice(payload)
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,5 +1,5 @@
 /// Plain-vanilla option side.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum OptionType {
     /// Call option payoff profile.
     Call,
@@ -19,7 +19,7 @@ impl OptionType {
 }
 
 /// Exercise rights for an option contract.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ExerciseStyle {
     /// Exercise only at expiry.
     European,
@@ -30,7 +30,7 @@ pub enum ExerciseStyle {
 }
 
 /// Barrier crossing direction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BarrierDirection {
     /// Barrier is breached when spot moves upward through the level.
     Up,
@@ -39,7 +39,7 @@ pub enum BarrierDirection {
 }
 
 /// Barrier knock behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BarrierStyle {
     /// Option activates once the barrier is hit.
     In,
@@ -48,7 +48,7 @@ pub enum BarrierStyle {
 }
 
 /// Barrier contract parameters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BarrierSpec {
     /// Barrier direction.
     pub direction: BarrierDirection,
@@ -61,7 +61,7 @@ pub struct BarrierSpec {
 }
 
 /// Averaging method for Asian options.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Averaging {
     /// Arithmetic averaging.
     Arithmetic,
@@ -70,7 +70,7 @@ pub enum Averaging {
 }
 
 /// Strike convention for Asian options.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum StrikeType {
     /// Fixed strike contract.
     Fixed,
@@ -79,7 +79,7 @@ pub enum StrikeType {
 }
 
 /// Asian option contract parameters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AsianSpec {
     /// Averaging method.
     pub averaging: Averaging,

--- a/src/credit/cdo.rs
+++ b/src/credit/cdo.rs
@@ -1,7 +1,7 @@
 use crate::math::{gauss_legendre_integrate, normal_cdf, normal_inv_cdf, normal_pdf};
 
 /// Synthetic CDO tranche definition.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CdoTranche {
     /// Attachment point as fraction of portfolio notional.
     pub attachment: f64,
@@ -14,7 +14,7 @@ pub struct CdoTranche {
 }
 
 /// Large homogeneous pool (LHP) synthetic CDO model.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SyntheticCdo {
     /// Number of names in the reference pool.
     pub num_names: usize,

--- a/src/credit/cds.rs
+++ b/src/credit/cds.rs
@@ -3,7 +3,7 @@ use crate::rates::YieldCurve;
 use super::survival_curve::SurvivalCurve;
 
 /// Standard running-spread CDS contract.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Cds {
     /// Notional amount.
     pub notional: f64,

--- a/src/credit/cds_index.rs
+++ b/src/credit/cds_index.rs
@@ -6,7 +6,7 @@ use crate::rates::YieldCurve;
 use super::{GaussianCopula, SurvivalCurve, cds::Cds};
 
 /// CDS index as a weighted basket of single-name CDS constituents.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CdsIndex {
     pub constituents: Vec<Cds>,
     /// Weights associated with each constituent. They are normalized internally.
@@ -71,7 +71,7 @@ impl CdsIndex {
 }
 
 /// Nth-to-default basket CDS with common maturity and recovery.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct NthToDefaultBasket {
     pub n: usize,
     pub notional: f64,

--- a/src/credit/cds_option.rs
+++ b/src/credit/cds_option.rs
@@ -3,7 +3,7 @@
 use crate::math::normal_cdf;
 
 /// A CDS option giving the right to enter a CDS at a given spread (strike).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CdsOption {
     pub notional: f64,
     pub strike_spread: f64,
@@ -169,10 +169,7 @@ mod tests {
 
         let p = payer.black_price(forward, vol, rpv01, 1.0);
         let r = receiver.black_price(forward, vol, rpv01, 1.0);
-        assert!(
-            (p - r).abs() < 1e-8,
-            "ATM payer ({p}) != receiver ({r})"
-        );
+        assert!((p - r).abs() < 1e-8, "ATM payer ({p}) != receiver ({r})");
     }
 
     #[test]

--- a/src/credit/copula.rs
+++ b/src/credit/copula.rs
@@ -6,14 +6,14 @@ use crate::math::normal_cdf;
 use super::survival_curve::SurvivalCurve;
 
 /// One-factor Gaussian copula model for correlated defaults.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GaussianCopula {
     /// Common-factor loading in `[-1, 1]`.
     pub rho: f64,
 }
 
 /// Result of one basket default simulation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BasketDefaultSimulation {
     /// Simulated default times in years.
     pub default_times: Vec<f64>,

--- a/src/credit/isda.rs
+++ b/src/credit/isda.rs
@@ -3,7 +3,7 @@ use chrono::{Datelike, Duration, NaiveDate, Weekday};
 use crate::rates::{DayCountConvention, year_fraction};
 
 /// Protection side of a CDS trade.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ProtectionSide {
     Buyer,
     Seller,
@@ -19,7 +19,7 @@ impl ProtectionSide {
 }
 
 /// Date-generation style for CDS schedules.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum CdsDateRule {
     /// Legacy CDS schedule on the 20th of IMM months.
     TwentiethImm,
@@ -28,7 +28,7 @@ pub enum CdsDateRule {
 }
 
 /// Dated CDS contract for midpoint/ISDA-style pricing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DatedCds {
     pub side: ProtectionSide,
     pub notional: f64,
@@ -80,7 +80,7 @@ impl DatedCds {
 }
 
 /// ISDA market conventions used for valuation alignment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct IsdaConventions {
     /// Step-in date offset in business days from valuation date.
     pub step_in_days: usize,
@@ -98,7 +98,7 @@ impl Default for IsdaConventions {
 }
 
 /// Valuation output for dated CDS pricing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CdsPriceResult {
     /// NPV from the trade side perspective (buyer positive when valuable to buyer).
     pub clean_npv: f64,
@@ -229,7 +229,7 @@ pub fn generate_imm_schedule(
     dates
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 enum PricingModel {
     Midpoint,
     IsdaStandard,

--- a/src/credit/survival_curve.rs
+++ b/src/credit/survival_curve.rs
@@ -4,7 +4,7 @@ use crate::rates::YieldCurve;
 use super::cds::Cds;
 
 /// Survival-probability term structure keyed by maturity tenor in years.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SurvivalCurve {
     /// Curve nodes as `(tenor, survival_probability)`.
     pub tenors: Vec<(f64, f64)>,

--- a/src/instruments/asian.rs
+++ b/src/instruments/asian.rs
@@ -1,7 +1,7 @@
 use crate::core::{AsianSpec, Instrument, OptionType, PricingError};
 
 /// Asian option instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AsianOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/autocallable.rs
+++ b/src/instruments/autocallable.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use crate::core::{Instrument, PricingError};
 
 /// Worst-of autocallable note with knock-in downside at maturity.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Autocallable {
     /// Indices into the global spot/vol vectors.
     pub underlyings: Vec<usize>,
@@ -98,7 +98,7 @@ impl Instrument for Autocallable {
 }
 
 /// Phoenix-style autocallable with coupon barrier and optional memory.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PhoenixAutocallable {
     /// Indices into the global spot/vol vectors.
     pub underlyings: Vec<usize>,

--- a/src/instruments/barrier.rs
+++ b/src/instruments/barrier.rs
@@ -3,7 +3,7 @@ use crate::core::{
 };
 
 /// Barrier option instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BarrierOption {
     /// Call or put.
     pub option_type: OptionType,
@@ -54,7 +54,7 @@ impl Instrument for BarrierOption {
 }
 
 /// Builder for [`BarrierOption`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct BarrierOptionBuilder {
     option_type: Option<OptionType>,
     strike: Option<f64>,

--- a/src/instruments/basket.rs
+++ b/src/instruments/basket.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Basket payoff definition.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BasketType {
     /// Weighted arithmetic basket `sum_i w_i * S_i(T)`.
     Average,
@@ -12,7 +12,7 @@ pub enum BasketType {
 }
 
 /// Multi-asset basket option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BasketOption {
     /// Weights for weighted-average basket.
     pub weights: Vec<f64>,

--- a/src/instruments/black76.rs
+++ b/src/instruments/black76.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// European option on a forward/futures price for Black-76 style models.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FuturesOption {
     /// Forward/futures level.
     pub forward: f64,

--- a/src/instruments/cliquet.rs
+++ b/src/instruments/cliquet.rs
@@ -2,7 +2,7 @@ use crate::core::{Instrument, OptionType, PricingError};
 use crate::math::normal_cdf;
 
 /// Forward-start option with strike set as a multiple of spot at start time.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ForwardStartOption {
     pub option_type: OptionType,
     pub spot: f64,

--- a/src/instruments/commodity.rs
+++ b/src/instruments/commodity.rs
@@ -3,7 +3,7 @@ use crate::engines::analytic::{black76_price, kirk_spread_price};
 use crate::instruments::{FuturesOption, SpreadOption};
 
 /// Commodity forward contract priced with continuous carry and convenience yield.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CommodityForward {
     pub spot: f64,
     pub strike: f64,
@@ -86,7 +86,7 @@ impl Instrument for CommodityForward {
 }
 
 /// Commodity futures contract marked-to-market daily.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CommodityFutures {
     pub contract_price: f64,
     pub contract_size: f64,
@@ -129,7 +129,7 @@ impl Instrument for CommodityFutures {
 }
 
 /// Commodity option on a forward/futures level priced with Black-76.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CommodityOption {
     pub forward: f64,
     pub strike: f64,
@@ -186,7 +186,7 @@ impl Instrument for CommodityOption {
 /// Commodity spread option priced with Kirk approximation.
 ///
 /// Payoff convention: `max(q1 * F1 - q2 * F2 - K, 0)` for calls.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CommoditySpreadOption {
     pub option_type: OptionType,
     pub forward_1: f64,

--- a/src/instruments/convertible.rs
+++ b/src/instruments/convertible.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Convertible bond with optional issuer call and holder put features.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ConvertibleBond {
     /// Notional/face amount.
     pub face_value: f64,

--- a/src/instruments/digital.rs
+++ b/src/instruments/digital.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Cash-or-nothing digital option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CashOrNothingOption {
     /// Call or put.
     pub option_type: OptionType,
@@ -52,7 +52,7 @@ impl Instrument for CashOrNothingOption {
 }
 
 /// Asset-or-nothing digital option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AssetOrNothingOption {
     /// Call or put.
     pub option_type: OptionType,
@@ -95,7 +95,7 @@ impl Instrument for AssetOrNothingOption {
 }
 
 /// Gap option with distinct trigger and payoff strikes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GapOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/double_barrier.rs
+++ b/src/instruments/double_barrier.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Double-barrier knock behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DoubleBarrierType {
     /// Option deactivates if either barrier is hit.
     KnockOut,
@@ -10,7 +10,7 @@ pub enum DoubleBarrierType {
 }
 
 /// Double-barrier option with lower/upper barriers.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DoubleBarrierOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/employee_stock_option.rs
+++ b/src/instruments/employee_stock_option.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Employee stock option valued with a binomial tree and Hull-White style assumptions.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EmployeeStockOption {
     /// Call/put side (ESOs are typically calls but both are supported).
     pub option_type: OptionType,

--- a/src/instruments/exotic.rs
+++ b/src/instruments/exotic.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Floating-strike lookback option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LookbackFloatingOption {
     /// Call (payoff `S_T - S_min`) or put (payoff `S_max - S_T`).
     pub option_type: OptionType,
@@ -13,7 +13,7 @@ pub struct LookbackFloatingOption {
 }
 
 /// Fixed-strike lookback option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LookbackFixedOption {
     /// Call (payoff `max(S_max - K, 0)`) or put (payoff `max(K - S_min, 0)`).
     pub option_type: OptionType,
@@ -27,7 +27,7 @@ pub struct LookbackFixedOption {
 }
 
 /// Simple chooser option where the holder chooses call or put at `choose_time`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChooserOption {
     /// Strike level shared by call and put.
     pub strike: f64,
@@ -38,7 +38,7 @@ pub struct ChooserOption {
 }
 
 /// Quanto European option with fixed FX conversion.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct QuantoOption {
     /// Call or put.
     pub option_type: OptionType,
@@ -57,7 +57,7 @@ pub struct QuantoOption {
 }
 
 /// Compound option on a vanilla option.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CompoundOption {
     /// Outer option type (call/put on the underlying option value).
     pub option_type: OptionType,
@@ -74,7 +74,7 @@ pub struct CompoundOption {
 }
 
 /// Unified exotic option instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ExoticOption {
     /// Floating-strike lookback option.
     LookbackFloating(LookbackFloatingOption),

--- a/src/instruments/fx.rs
+++ b/src/instruments/fx.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// European FX option parameters for Garman-Kohlhagen pricing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FxOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/power.rs
+++ b/src/instruments/power.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Power option with payoff `max(sign * (S^alpha - K), 0)` where sign is +1 (call), -1 (put).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PowerOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/rainbow.rs
+++ b/src/instruments/rainbow.rs
@@ -32,7 +32,7 @@ fn validate_common(
 }
 
 /// Two-asset best-of call: `max(max(S1_T, S2_T) - K, 0)`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BestOfTwoCallOption {
     pub s1: f64,
     pub s2: f64,
@@ -65,7 +65,7 @@ impl Instrument for BestOfTwoCallOption {
 }
 
 /// Two-asset worst-of call: `max(min(S1_T, S2_T) - K, 0)`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct WorstOfTwoCallOption {
     pub s1: f64,
     pub s2: f64,
@@ -101,7 +101,7 @@ impl Instrument for WorstOfTwoCallOption {
 ///
 /// Call payoff: `1_{S2_T > K2} * max(S1_T - K1, 0)`
 /// Put payoff:  `1_{S2_T < K2} * max(K1 - S1_T, 0)`
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TwoAssetCorrelationOption {
     pub option_type: OptionType,
     pub s1: f64,

--- a/src/instruments/range_accrual.rs
+++ b/src/instruments/range_accrual.rs
@@ -4,7 +4,7 @@
 /// is within a specified range [lower, upper]. Common in rates desks.
 
 /// Single-rate range accrual.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RangeAccrual {
     /// Notional amount.
     pub notional: f64,
@@ -21,7 +21,7 @@ pub struct RangeAccrual {
 }
 
 /// Dual-rate range accrual (e.g., CMS spread range accrual).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DualRangeAccrual {
     /// Notional amount.
     pub notional: f64,

--- a/src/instruments/real_option.rs
+++ b/src/instruments/real_option.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Discrete project cash flow paid at a given year fraction.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DiscreteCashFlow {
     /// Payment time in years from valuation date.
     pub time: f64,
@@ -10,7 +10,7 @@ pub struct DiscreteCashFlow {
 }
 
 /// Shared binomial settings for real-option valuation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RealOptionBinomialSpec {
     /// Current project NPV proxy (underlying state variable).
     pub project_value: f64,
@@ -66,7 +66,7 @@ impl RealOptionBinomialSpec {
 }
 
 /// Option to defer an investment decision (American call on project NPV).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DeferInvestmentOption {
     /// Shared tree settings.
     pub model: RealOptionBinomialSpec,
@@ -88,7 +88,7 @@ impl DeferInvestmentOption {
 }
 
 /// Option to expand project scale (compound option on scaled NPV).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ExpandOption {
     /// Shared tree settings.
     pub model: RealOptionBinomialSpec,
@@ -117,7 +117,7 @@ impl ExpandOption {
 }
 
 /// Option to abandon a project (American put with salvage value strike).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AbandonmentOption {
     /// Shared tree settings.
     pub model: RealOptionBinomialSpec,
@@ -139,7 +139,7 @@ impl AbandonmentOption {
 }
 
 /// Unified real-option instrument enum.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum RealOptionInstrument {
     /// Option to defer investment.
     Defer(DeferInvestmentOption),

--- a/src/instruments/spread.rs
+++ b/src/instruments/spread.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Two-asset spread option input bundle.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SpreadOption {
     pub s1: f64,
     pub s2: f64,

--- a/src/instruments/swing.rs
+++ b/src/instruments/swing.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Multi-exercise swing option commonly used in energy contracts.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SwingOption {
     /// Minimum number of exercise rights that must be used.
     pub min_exercises: usize,

--- a/src/instruments/tarf.rs
+++ b/src/instruments/tarf.rs
@@ -8,7 +8,7 @@
 /// References: Wystup, "FX Options and Structured Products" (2nd ed.)
 
 /// TARF product type.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TarfType {
     /// Standard TARF: accumulate on upside, leverage on downside.
     Standard,
@@ -17,7 +17,7 @@ pub enum TarfType {
 }
 
 /// Accumulator / TARF instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tarf {
     /// Forward strike.
     pub strike: f64,
@@ -53,7 +53,11 @@ impl Tarf {
         if self.fixing_times.is_empty() {
             return Err("fixing_times must be non-empty".to_string());
         }
-        if self.fixing_times.iter().any(|t| !t.is_finite() || *t <= 0.0) {
+        if self
+            .fixing_times
+            .iter()
+            .any(|t| !t.is_finite() || *t <= 0.0)
+        {
             return Err("all fixing_times must be finite and > 0".to_string());
         }
         Ok(())

--- a/src/instruments/vanilla.rs
+++ b/src/instruments/vanilla.rs
@@ -1,7 +1,7 @@
 use crate::core::{ExerciseStyle, Instrument, OptionType, PricingError};
 
 /// Vanilla option instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VanillaOption {
     /// Call or put.
     pub option_type: OptionType,

--- a/src/instruments/variance_swap.rs
+++ b/src/instruments/variance_swap.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, PricingError};
 
 /// Option quote used for variance/volatility swap replication.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VarianceOptionQuote {
     /// Option strike.
     pub strike: f64,
@@ -43,7 +43,7 @@ impl VarianceOptionQuote {
 }
 
 /// Variance swap instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VarianceSwap {
     /// Vega notional used to derive variance notional via `N_var = N_vega / (2*K_vol)`.
     pub notional_vega: f64,
@@ -124,7 +124,7 @@ impl Instrument for VarianceSwap {
 }
 
 /// Volatility swap instrument.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VolatilitySwap {
     /// Vega notional (linear in realized volatility).
     pub notional_vega: f64,

--- a/src/instruments/weather.rs
+++ b/src/instruments/weather.rs
@@ -1,7 +1,7 @@
 use crate::core::{Instrument, OptionType, PricingError};
 
 /// Degree-day index type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DegreeDayType {
     /// Heating degree days: `max(base - temp, 0)`.
     HDD,
@@ -60,7 +60,7 @@ pub fn cumulative_degree_days(
 }
 
 /// Weather swap with linear payoff on cumulative HDD/CDD.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct WeatherSwap {
     pub index_type: DegreeDayType,
     pub strike: f64,
@@ -154,7 +154,7 @@ impl Instrument for WeatherSwap {
 }
 
 /// Weather option on cumulative HDD/CDD priced by burn analysis.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct WeatherOption {
     pub index_type: DegreeDayType,
     pub option_type: OptionType,
@@ -282,7 +282,7 @@ impl Instrument for WeatherOption {
 }
 
 /// Catastrophe bond with coupon and principal at risk under a Poisson loss model.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CatastropheBond {
     pub principal: f64,
     pub coupon_rate: f64,

--- a/src/models/slv.rs
+++ b/src/models/slv.rs
@@ -539,6 +539,10 @@ mod tests {
             let t = expiry.max(1e-6);
             (self.base + self.skew * x * x + 0.01 * (t - 1.0)).max(0.05)
         }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
     }
 
     fn heston_mc_price<I: MonteCarloInstrument>(

--- a/src/pricing/tarf.rs
+++ b/src/pricing/tarf.rs
@@ -5,7 +5,7 @@ use rand_distr::{Distribution, StandardNormal};
 use crate::instruments::tarf::{Tarf, TarfType};
 
 /// Result of TARF Monte Carlo pricing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TarfPricingResult {
     /// Present value of the TARF to the buyer.
     pub price: f64,
@@ -159,8 +159,24 @@ pub fn tarf_delta(
     seed: u64,
     bump: f64,
 ) -> Result<f64, String> {
-    let p_up = tarf_mc_price(tarf, spot * (1.0 + bump), rate, dividend_yield, vol, num_paths, seed)?;
-    let p_down = tarf_mc_price(tarf, spot * (1.0 - bump), rate, dividend_yield, vol, num_paths, seed)?;
+    let p_up = tarf_mc_price(
+        tarf,
+        spot * (1.0 + bump),
+        rate,
+        dividend_yield,
+        vol,
+        num_paths,
+        seed,
+    )?;
+    let p_down = tarf_mc_price(
+        tarf,
+        spot * (1.0 - bump),
+        rate,
+        dividend_yield,
+        vol,
+        num_paths,
+        seed,
+    )?;
     Ok((p_up.price - p_down.price) / (2.0 * spot * bump))
 }
 
@@ -175,8 +191,24 @@ pub fn tarf_vega(
     seed: u64,
     bump: f64,
 ) -> Result<f64, String> {
-    let p_up = tarf_mc_price(tarf, spot, rate, dividend_yield, vol + bump, num_paths, seed)?;
-    let p_down = tarf_mc_price(tarf, spot, rate, dividend_yield, vol - bump, num_paths, seed)?;
+    let p_up = tarf_mc_price(
+        tarf,
+        spot,
+        rate,
+        dividend_yield,
+        vol + bump,
+        num_paths,
+        seed,
+    )?;
+    let p_down = tarf_mc_price(
+        tarf,
+        spot,
+        rate,
+        dividend_yield,
+        vol - bump,
+        num_paths,
+        seed,
+    )?;
     Ok((p_up.price - p_down.price) / (2.0 * bump))
 }
 
@@ -188,11 +220,11 @@ mod tests {
         // Weekly fixings for 1 year
         let fixing_times: Vec<f64> = (1..=52).map(|w| w as f64 / 52.0).collect();
         Tarf::standard(
-            100.0,    // strike
-            1000.0,   // notional per fixing
-            120.0,    // KO barrier
-            50000.0,  // target profit
-            2.0,      // 2x downside leverage
+            100.0,   // strike
+            1000.0,  // notional per fixing
+            120.0,   // KO barrier
+            50000.0, // target profit
+            2.0,     // 2x downside leverage
             fixing_times,
         )
     }

--- a/src/rates/bond.rs
+++ b/src/rates/bond.rs
@@ -1,7 +1,7 @@
 use crate::rates::{DayCountConvention, YieldCurve};
 
 /// Plain fixed-rate bond.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FixedRateBond {
     /// Notional/face amount.
     pub face_value: f64,

--- a/src/rates/capfloor.rs
+++ b/src/rates/capfloor.rs
@@ -5,7 +5,7 @@ use crate::rates::schedule::generate_schedule;
 use crate::rates::{DayCountConvention, Frequency, YieldCurve, year_fraction};
 
 /// Black-76 cap/floor instrument on forward rates.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CapFloor {
     pub notional: f64,
     pub strike: f64,

--- a/src/rates/day_count.rs
+++ b/src/rates/day_count.rs
@@ -1,7 +1,7 @@
 use chrono::{Datelike, NaiveDate};
 
 /// Supported day-count conventions for fixed-income instruments.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DayCountConvention {
     /// Actual day count over a 360-day year.
     Act360,

--- a/src/rates/fra.rs
+++ b/src/rates/fra.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDate;
 use crate::rates::{DayCountConvention, YieldCurve, year_fraction};
 
 /// Forward rate agreement over a single accrual period.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ForwardRateAgreement {
     pub notional: f64,
     pub fixed_rate: f64,

--- a/src/rates/futures.rs
+++ b/src/rates/futures.rs
@@ -1,5 +1,5 @@
 /// Cost-of-carry futures contract.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Future {
     pub underlying_spot: f64,
     pub risk_free_rate: f64,
@@ -41,7 +41,7 @@ impl Future {
 }
 
 /// Eurodollar/SOFR futures quote conventions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InterestRateFutureQuote;
 
 impl InterestRateFutureQuote {

--- a/src/rates/inflation.rs
+++ b/src/rates/inflation.rs
@@ -1,7 +1,7 @@
 use crate::rates::YieldCurve;
 
 /// Inflation curve represented by CPI growth ratios `CPI(t)/CPI(0)`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InflationCurve {
     /// Curve nodes as `(tenor_years, cpi_ratio)`.
     pub nodes: Vec<(f64, f64)>,
@@ -54,6 +54,7 @@ impl InflationCurve {
 }
 
 /// Bootstrap helpers for inflation curves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InflationCurveBuilder;
 
 impl InflationCurveBuilder {
@@ -71,7 +72,7 @@ impl InflationCurveBuilder {
 }
 
 /// Zero-coupon inflation swap (receive/pay realized inflation vs fixed).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ZeroCouponInflationSwap {
     pub notional: f64,
     pub cpi_base: f64,
@@ -143,7 +144,7 @@ impl ZeroCouponInflationSwap {
 }
 
 /// Year-on-year inflation swap with annual settlements.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct YearOnYearInflationSwap {
     pub notional: f64,
     pub fixed_rate: f64,
@@ -216,7 +217,7 @@ impl YearOnYearInflationSwap {
 }
 
 /// Inflation-indexed bond (TIPS-style) with CPI-adjusted principal and coupons.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InflationIndexedBond {
     pub face_value: f64,
     pub coupon_rate: f64,

--- a/src/rates/multi_curve.rs
+++ b/src/rates/multi_curve.rs
@@ -7,11 +7,10 @@
 /// - Henrard, "Interest Rate Modelling in the Multi-Curve Framework" (2014)
 /// - Ametrano, Bianchetti, "Everything You Always Wanted to Know About
 ///   Multiple Interest Rate Curve Bootstrapping" (2013)
-
 use crate::rates::yield_curve::YieldCurve;
 
 /// Multi-curve environment: one discount curve + multiple forwarding curves.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MultiCurveEnvironment {
     /// OIS discount curve (e.g., SOFR, €STR).
     pub discount_curve: YieldCurve,
@@ -29,8 +28,7 @@ impl MultiCurveEnvironment {
 
     /// Add a forwarding curve for a specific tenor.
     pub fn add_forward_curve(&mut self, tenor_name: &str, curve: YieldCurve) {
-        self.forward_curves
-            .push((tenor_name.to_string(), curve));
+        self.forward_curves.push((tenor_name.to_string(), curve));
     }
 
     /// Get discount factor from OIS curve.
@@ -116,7 +114,7 @@ pub fn dual_curve_bootstrap(
         let ois_df_n = ois_curve.discount_factor(t_n);
         annuity += ois_df_n * dt;
 
-        // Solve for DF_fwd(T): par_rate * annuity = float_pv + (1 - DF_fwd(T)) * ois_df_n / ... 
+        // Solve for DF_fwd(T): par_rate * annuity = float_pv + (1 - DF_fwd(T)) * ois_df_n / ...
         // Simplified: DF_fwd(T) = (1 - par_rate * annuity + float_pv) if float_pv is already computed
         // More precisely, for the last period:
         let fwd_df_prev = if fwd_points.is_empty() {
@@ -237,12 +235,7 @@ mod tests {
     #[test]
     fn dual_curve_bootstrap_produces_valid_curve() {
         let ois = make_flat_curve(0.03);
-        let swap_rates = vec![
-            (1.0, 0.035),
-            (2.0, 0.036),
-            (3.0, 0.037),
-            (5.0, 0.038),
-        ];
+        let swap_rates = vec![(1.0, 0.035), (2.0, 0.036), (3.0, 0.037), (5.0, 0.038)];
         let fwd_curve = dual_curve_bootstrap(&swap_rates, &ois, 4);
         assert!(!fwd_curve.tenors.is_empty());
         // All DFs should be positive and decreasing

--- a/src/rates/ois.rs
+++ b/src/rates/ois.rs
@@ -1,7 +1,7 @@
 use crate::rates::YieldCurve;
 
 /// Overnight index swap: fixed leg vs overnight floating leg.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct OvernightIndexSwap {
     pub notional: f64,
     pub fixed_rate: f64,
@@ -95,7 +95,7 @@ impl OvernightIndexSwap {
 }
 
 /// Basis swap: two floating legs with different reset tenors.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BasisSwap {
     pub notional: f64,
     pub spread_on_short_leg: f64,

--- a/src/rates/schedule.rs
+++ b/src/rates/schedule.rs
@@ -1,7 +1,7 @@
 use chrono::{Datelike, NaiveDate};
 
 /// Payment frequency for coupon schedules.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Frequency {
     Annual,
     SemiAnnual,
@@ -22,7 +22,7 @@ impl Frequency {
 }
 
 /// Business-day adjustment convention.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BusinessDayConvention {
     ModifiedFollowing,
 }

--- a/src/rates/swap.rs
+++ b/src/rates/swap.rs
@@ -4,7 +4,7 @@ use crate::rates::schedule::{Frequency, generate_schedule};
 use crate::rates::{DayCountConvention, YieldCurve, year_fraction};
 
 /// Plain-vanilla fixed-for-floating interest-rate swap.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct InterestRateSwap {
     pub notional: f64,
     pub fixed_rate: f64,
@@ -130,7 +130,7 @@ fn bump_curve_parallel(curve: &YieldCurve, bump: f64) -> YieldCurve {
 }
 
 /// Builder for [`InterestRateSwap`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SwapBuilder {
     notional: f64,
     fixed_rate: f64,

--- a/src/rates/swaption.rs
+++ b/src/rates/swaption.rs
@@ -2,7 +2,7 @@ use crate::math::normal_cdf;
 use crate::rates::YieldCurve;
 
 /// European swaption on a forward-starting fixed-for-floating swap.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Swaption {
     pub notional: f64,
     pub strike: f64,

--- a/src/rates/xccy_swap.rs
+++ b/src/rates/xccy_swap.rs
@@ -1,7 +1,7 @@
 use crate::rates::YieldCurve;
 
 /// Cross-currency swap: fixed leg in currency 1 vs floating leg in currency 2.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct XccySwap {
     /// Notional for fixed leg in currency 1.
     pub notional1: f64,

--- a/src/rates/yield_curve.rs
+++ b/src/rates/yield_curve.rs
@@ -1,5 +1,5 @@
 /// Discount-factor term structure keyed by maturity tenor in years.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct YieldCurve {
     /// Curve nodes as `(tenor, discount_factor)`.
     pub tenors: Vec<(f64, f64)>,
@@ -34,6 +34,7 @@ impl YieldCurve {
 }
 
 /// Helper constructors for simple curve bootstrapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct YieldCurveBuilder;
 
 impl YieldCurveBuilder {

--- a/src/vol/builder.rs
+++ b/src/vol/builder.rs
@@ -3,7 +3,7 @@ use crate::pricing::OptionType;
 use crate::vol::implied::implied_vol;
 use crate::vol::local_vol::{DupireLocalVol, ImpliedVolSurface as LocalVolSurface};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MarketOptionQuote {
     pub strike: f64,
     pub expiry: f64,

--- a/src/vol/mixture.rs
+++ b/src/vol/mixture.rs
@@ -3,7 +3,7 @@ use nalgebra::{DMatrix, DVector};
 use crate::core::OptionType;
 use crate::pricing::european::black_scholes_price;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LognormalMixture {
     pub weights: Vec<f64>,
     pub vols: Vec<f64>,

--- a/src/vol/mod.rs
+++ b/src/vol/mod.rs
@@ -10,7 +10,7 @@ pub mod smile;
 pub mod surface;
 
 /// Arbitrage violation types for vol surface validation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum ArbitrageViolation {
     /// Butterfly arbitrage: negative risk-neutral density.
     Butterfly {

--- a/src/vol/sabr.rs
+++ b/src/vol/sabr.rs
@@ -1,6 +1,6 @@
 use nalgebra::{DMatrix, DVector};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SabrParams {
     pub alpha: f64,
     pub beta: f64,

--- a/src/vol/smile.rs
+++ b/src/vol/smile.rs
@@ -4,7 +4,7 @@ use crate::pricing::european::black_scholes_price;
 use crate::vol::builder::BuiltVolSurface;
 use crate::vol::sabr::SabrParams;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SmileDynamics {
     StickyStrike,
     StickyDelta,
@@ -338,7 +338,7 @@ pub fn sabr_smile_from_atm(
     (params, out)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VannaVolgaQuote {
     pub atm_vol: f64,
     pub rr_25d: f64,

--- a/src/vol/surface.rs
+++ b/src/vol/surface.rs
@@ -1,6 +1,6 @@
 use crate::math::CubicSpline;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SviParams {
     pub a: f64,
     pub b: f64,
@@ -164,7 +164,7 @@ pub fn calibrate_svi(
     best
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VolSurface {
     expiries: Vec<f64>,
     slices: Vec<SviParams>,

--- a/tests/serialization_roundtrip_test.rs
+++ b/tests/serialization_roundtrip_test.rs
@@ -1,0 +1,738 @@
+use chrono::NaiveDate;
+use openferric::core::*;
+use openferric::credit::cds_option::CdsOption;
+use openferric::credit::{
+    CdoTranche, Cds, CdsDateRule, CdsIndex, DatedCds, NthToDefaultBasket, ProtectionSide,
+    SyntheticCdo,
+};
+use openferric::instruments::mbs::{ConstantCpr, MbsPassThrough, PrepaymentModel};
+use openferric::instruments::*;
+use openferric::market::Market;
+use openferric::rates::cms::{CmsSpreadOption, CmsSpreadOptionType};
+use openferric::rates::*;
+use openferric::vol::surface::{SviParams, VolSurface as SviSurface};
+
+fn roundtrip_json<T>(value: &T)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let json = serde_json::to_string(value).expect("json serialize");
+    let decoded: T = serde_json::from_str(&json).expect("json deserialize");
+    assert_eq!(*value, decoded);
+}
+
+fn roundtrip_msgpack<T>(value: &T)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let bytes = rmp_serde::to_vec_named(value).expect("msgpack serialize");
+    let decoded: T = rmp_serde::from_slice(&bytes).expect("msgpack deserialize");
+    assert_eq!(*value, decoded);
+}
+
+fn sample_trade_products() -> Vec<TradeProduct> {
+    let start = NaiveDate::from_ymd_opt(2026, 1, 2).unwrap();
+    let end = NaiveDate::from_ymd_opt(2030, 1, 2).unwrap();
+
+    let real_model = RealOptionBinomialSpec {
+        project_value: 120.0,
+        volatility: 0.25,
+        risk_free_rate: 0.03,
+        maturity: 3.0,
+        steps: 50,
+        cash_flows: vec![DiscreteCashFlow {
+            time: 1.0,
+            amount: 2.0,
+        }],
+    };
+
+    vec![
+        TradeProduct::VanillaOption(VanillaOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            exercise: ExerciseStyle::European,
+        }),
+        TradeProduct::BarrierOption(BarrierOption {
+            option_type: OptionType::Put,
+            strike: 95.0,
+            expiry: 1.2,
+            barrier: BarrierSpec {
+                direction: BarrierDirection::Down,
+                style: BarrierStyle::Out,
+                level: 80.0,
+                rebate: 1.0,
+            },
+        }),
+        TradeProduct::AsianOption(AsianOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            asian: AsianSpec {
+                averaging: Averaging::Arithmetic,
+                strike_type: StrikeType::Fixed,
+                observation_times: vec![0.25, 0.5, 0.75, 1.0],
+            },
+        }),
+        TradeProduct::BasketOption(BasketOption {
+            weights: vec![0.6, 0.4],
+            strike: 100.0,
+            maturity: 1.0,
+            is_call: true,
+            basket_type: BasketType::Average,
+        }),
+        TradeProduct::CashOrNothingOption(CashOrNothingOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            cash: 10.0,
+            expiry: 1.0,
+        }),
+        TradeProduct::AssetOrNothingOption(AssetOrNothingOption {
+            option_type: OptionType::Put,
+            strike: 90.0,
+            expiry: 1.0,
+        }),
+        TradeProduct::GapOption(GapOption {
+            option_type: OptionType::Call,
+            payoff_strike: 100.0,
+            trigger_strike: 105.0,
+            expiry: 1.0,
+        }),
+        TradeProduct::DoubleBarrierOption(DoubleBarrierOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            lower_barrier: 80.0,
+            upper_barrier: 130.0,
+            barrier_type: DoubleBarrierType::KnockOut,
+            rebate: 0.5,
+        }),
+        TradeProduct::SpreadOption(SpreadOption {
+            s1: 100.0,
+            s2: 95.0,
+            k: 2.0,
+            vol1: 0.2,
+            vol2: 0.25,
+            rho: 0.4,
+            q1: 0.01,
+            q2: 0.02,
+            r: 0.03,
+            t: 1.0,
+        }),
+        TradeProduct::FxOption(FxOption {
+            option_type: OptionType::Call,
+            domestic_rate: 0.03,
+            foreign_rate: 0.01,
+            spot_fx: 1.10,
+            strike_fx: 1.15,
+            vol: 0.14,
+            maturity: 1.0,
+        }),
+        TradeProduct::FuturesOption(FuturesOption {
+            forward: 100.0,
+            strike: 102.0,
+            vol: 0.2,
+            r: 0.03,
+            t: 1.0,
+            option_type: OptionType::Put,
+        }),
+        TradeProduct::ForwardStartOption(ForwardStartOption {
+            option_type: OptionType::Call,
+            spot: 100.0,
+            strike_ratio: 1.0,
+            rate: 0.02,
+            dividend_yield: 0.01,
+            vol: 0.25,
+            t_start: 0.5,
+            expiry: 1.0,
+        }),
+        TradeProduct::CommodityForward(CommodityForward {
+            spot: 80.0,
+            strike: 82.0,
+            notional: 10_000.0,
+            risk_free_rate: 0.03,
+            storage_cost: 0.01,
+            convenience_yield: 0.005,
+            maturity: 1.5,
+            is_long: true,
+        }),
+        TradeProduct::CommodityFutures(CommodityFutures {
+            contract_price: 75.0,
+            contract_size: 1_000.0,
+            is_long: false,
+        }),
+        TradeProduct::CommodityOption(CommodityOption {
+            forward: 90.0,
+            strike: 95.0,
+            vol: 0.3,
+            risk_free_rate: 0.03,
+            maturity: 1.0,
+            notional: 5_000.0,
+            option_type: OptionType::Call,
+        }),
+        TradeProduct::CommoditySpreadOption(CommoditySpreadOption {
+            option_type: OptionType::Call,
+            forward_1: 100.0,
+            forward_2: 95.0,
+            strike: 2.0,
+            quantity_1: 1.0,
+            quantity_2: 1.2,
+            vol_1: 0.25,
+            vol_2: 0.22,
+            rho: 0.5,
+            risk_free_rate: 0.03,
+            maturity: 1.0,
+            notional: 2_000.0,
+        }),
+        TradeProduct::ConvertibleBond(ConvertibleBond {
+            face_value: 100.0,
+            coupon_rate: 0.03,
+            maturity: 5.0,
+            conversion_ratio: 1.2,
+            call_price: Some(110.0),
+            put_price: Some(95.0),
+        }),
+        TradeProduct::EmployeeStockOption(EmployeeStockOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            maturity: 5.0,
+            vesting_period: 1.0,
+            expected_life: 4.0,
+            early_exercise_multiple: Some(1.8),
+            forfeiture_rate: 0.03,
+            shares_outstanding: 1_000_000.0,
+            options_granted: 50_000.0,
+        }),
+        TradeProduct::ExoticOption(ExoticOption::Chooser(ChooserOption {
+            strike: 100.0,
+            expiry: 1.0,
+            choose_time: 0.5,
+        })),
+        TradeProduct::PowerOption(PowerOption {
+            option_type: OptionType::Put,
+            strike: 100.0,
+            alpha: 1.3,
+            expiry: 1.0,
+        }),
+        TradeProduct::BestOfTwoCallOption(BestOfTwoCallOption {
+            s1: 100.0,
+            s2: 98.0,
+            k: 100.0,
+            vol1: 0.2,
+            vol2: 0.22,
+            rho: 0.4,
+            q1: 0.01,
+            q2: 0.01,
+            r: 0.03,
+            t: 1.0,
+        }),
+        TradeProduct::WorstOfTwoCallOption(WorstOfTwoCallOption {
+            s1: 100.0,
+            s2: 98.0,
+            k: 100.0,
+            vol1: 0.2,
+            vol2: 0.22,
+            rho: 0.4,
+            q1: 0.01,
+            q2: 0.01,
+            r: 0.03,
+            t: 1.0,
+        }),
+        TradeProduct::TwoAssetCorrelationOption(TwoAssetCorrelationOption {
+            option_type: OptionType::Call,
+            s1: 100.0,
+            s2: 99.0,
+            k1: 100.0,
+            k2: 97.0,
+            vol1: 0.2,
+            vol2: 0.23,
+            rho: 0.3,
+            q1: 0.01,
+            q2: 0.01,
+            r: 0.03,
+            t: 1.0,
+        }),
+        TradeProduct::RangeAccrual(RangeAccrual {
+            notional: 1_000_000.0,
+            coupon_rate: 0.04,
+            lower_bound: 0.01,
+            upper_bound: 0.05,
+            fixing_times: vec![0.25, 0.5, 0.75, 1.0],
+            payment_time: 1.0,
+        }),
+        TradeProduct::DualRangeAccrual(DualRangeAccrual {
+            notional: 1_000_000.0,
+            coupon_rate: 0.03,
+            lower_bound: -0.01,
+            upper_bound: 0.02,
+            fixing_times: vec![0.25, 0.5, 0.75, 1.0],
+            payment_time: 1.0,
+        }),
+        TradeProduct::DeferInvestmentOption(DeferInvestmentOption {
+            model: real_model.clone(),
+            investment_cost: 80.0,
+        }),
+        TradeProduct::ExpandOption(ExpandOption {
+            model: real_model.clone(),
+            expansion_multiplier: 1.5,
+            expansion_cost: 30.0,
+        }),
+        TradeProduct::AbandonmentOption(AbandonmentOption {
+            model: real_model.clone(),
+            salvage_value: 25.0,
+        }),
+        TradeProduct::RealOptionInstrument(RealOptionInstrument::Expand(ExpandOption {
+            model: real_model.clone(),
+            expansion_multiplier: 1.3,
+            expansion_cost: 20.0,
+        })),
+        TradeProduct::SwingOption(SwingOption {
+            min_exercises: 1,
+            max_exercises: 3,
+            exercise_dates: vec![0.5, 1.0, 1.5],
+            strike: 70.0,
+            payoff_per_exercise: 10.0,
+        }),
+        TradeProduct::Tarf(Tarf {
+            strike: 100.0,
+            notional_per_fixing: 1000.0,
+            ko_barrier: 130.0,
+            target_profit: 10_000.0,
+            downside_leverage: 2.0,
+            fixing_times: vec![0.25, 0.5, 0.75, 1.0],
+            tarf_type: TarfType::Standard,
+        }),
+        TradeProduct::VarianceSwap(VarianceSwap {
+            notional_vega: 50_000.0,
+            strike_vol: 0.2,
+            expiry: 1.0,
+            observed_realized_var: Some(0.03),
+            option_quotes: vec![
+                VarianceOptionQuote::new(80.0, 25.0, 1.0),
+                VarianceOptionQuote::new(120.0, 1.0, 22.0),
+            ],
+        }),
+        TradeProduct::VolatilitySwap(VolatilitySwap {
+            notional_vega: 50_000.0,
+            strike_vol: 0.22,
+            expiry: 1.0,
+            observed_realized_var: Some(0.04),
+            option_quotes: vec![
+                VarianceOptionQuote::new(80.0, 25.0, 1.0),
+                VarianceOptionQuote::new(120.0, 1.0, 22.0),
+            ],
+            var_of_var: 0.1,
+        }),
+        TradeProduct::WeatherSwap(WeatherSwap {
+            index_type: DegreeDayType::HDD,
+            strike: 100.0,
+            tick_size: 10.0,
+            notional: 1_000.0,
+            is_payer: true,
+            discount_rate: 0.02,
+            maturity: 1.0,
+        }),
+        TradeProduct::WeatherOption(WeatherOption {
+            index_type: DegreeDayType::CDD,
+            option_type: OptionType::Call,
+            strike: 150.0,
+            tick_size: 8.0,
+            notional: 1_000.0,
+            discount_rate: 0.02,
+            maturity: 1.0,
+        }),
+        TradeProduct::CatastropheBond(CatastropheBond {
+            principal: 1_000_000.0,
+            coupon_rate: 0.06,
+            risk_free_rate: 0.03,
+            maturity: 3.0,
+            coupon_frequency: 4,
+            loss_intensity: 0.2,
+            expected_loss_per_event: 0.4,
+        }),
+        TradeProduct::Autocallable(Autocallable {
+            underlyings: vec![0, 1],
+            notional: 1000.0,
+            autocall_dates: vec![0.5, 1.0],
+            autocall_barrier: 1.05,
+            coupon_rate: 0.08,
+            ki_barrier: 0.7,
+            ki_strike: 1.0,
+            maturity: 1.0,
+        }),
+        TradeProduct::PhoenixAutocallable(PhoenixAutocallable {
+            underlyings: vec![0, 1],
+            notional: 1000.0,
+            autocall_dates: vec![0.5, 1.0],
+            autocall_barrier: 1.05,
+            coupon_barrier: 0.8,
+            coupon_rate: 0.08,
+            memory: true,
+            ki_barrier: 0.7,
+            ki_strike: 1.0,
+            maturity: 1.0,
+        }),
+        TradeProduct::MbsPassThrough(MbsPassThrough {
+            original_balance: 100_000.0,
+            coupon_rate: 0.05,
+            servicing_fee: 0.0025,
+            original_term: 360,
+            age: 24,
+            prepayment: PrepaymentModel::ConstantCpr(ConstantCpr { annual_cpr: 0.06 }),
+        }),
+        TradeProduct::FixedRateBond(FixedRateBond {
+            face_value: 100.0,
+            coupon_rate: 0.04,
+            frequency: 2,
+            maturity: 5.0,
+            day_count: DayCountConvention::Act365Fixed,
+        }),
+        TradeProduct::CapFloor(CapFloor {
+            notional: 1_000_000.0,
+            strike: 0.03,
+            start_date: start,
+            end_date: end,
+            frequency: Frequency::Quarterly,
+            day_count: DayCountConvention::Act360,
+            is_cap: true,
+        }),
+        TradeProduct::ForwardRateAgreement(ForwardRateAgreement {
+            notional: 1_000_000.0,
+            fixed_rate: 0.03,
+            start_date: start,
+            end_date: NaiveDate::from_ymd_opt(2026, 7, 2).unwrap(),
+            day_count: DayCountConvention::Act360,
+        }),
+        TradeProduct::Future(Future {
+            underlying_spot: 100.0,
+            risk_free_rate: 0.03,
+            dividend_yield: 0.01,
+            storage_cost: 0.0,
+            convenience_yield: 0.0,
+            expiry: 0.5,
+        }),
+        TradeProduct::InterestRateSwap(InterestRateSwap {
+            notional: 1_000_000.0,
+            fixed_rate: 0.03,
+            float_spread: 0.001,
+            start_date: start,
+            end_date: end,
+            fixed_freq: Frequency::Annual,
+            float_freq: Frequency::Quarterly,
+            fixed_day_count: DayCountConvention::Act365Fixed,
+            float_day_count: DayCountConvention::Act360,
+        }),
+        TradeProduct::Swaption(Swaption {
+            notional: 1_000_000.0,
+            strike: 0.03,
+            option_expiry: 1.0,
+            swap_tenor: 5.0,
+            is_payer: true,
+        }),
+        TradeProduct::OvernightIndexSwap(OvernightIndexSwap {
+            notional: 1_000_000.0,
+            fixed_rate: 0.028,
+            float_spread: 0.0,
+            tenor: 3.0,
+        }),
+        TradeProduct::BasisSwap(BasisSwap {
+            notional: 1_000_000.0,
+            spread_on_short_leg: 0.001,
+            tenor: 3.0,
+            short_leg_payments_per_year: 4,
+            long_leg_payments_per_year: 2,
+        }),
+        TradeProduct::XccySwap(XccySwap {
+            notional1: 1_000_000.0,
+            notional2: 900_000.0,
+            fixed_rate: 0.03,
+            float_spread: 0.001,
+            tenor: 5.0,
+            fx_spot: 1.1,
+        }),
+        TradeProduct::ZeroCouponInflationSwap(ZeroCouponInflationSwap {
+            notional: 1_000_000.0,
+            cpi_base: 250.0,
+            fixed_rate: 0.025,
+            tenor: 5.0,
+            receive_inflation: true,
+        }),
+        TradeProduct::YearOnYearInflationSwap(YearOnYearInflationSwap {
+            notional: 1_000_000.0,
+            fixed_rate: 0.02,
+            maturity_years: 5,
+            receive_inflation: true,
+        }),
+        TradeProduct::InflationIndexedBond(InflationIndexedBond {
+            face_value: 100.0,
+            coupon_rate: 0.01,
+            maturity_years: 10,
+            coupon_frequency: 2,
+            cpi_base: 250.0,
+        }),
+        TradeProduct::CmsSpreadOption(CmsSpreadOption {
+            strike: 0.01,
+            option_type: CmsSpreadOptionType::Call,
+            notional: 1_000_000.0,
+            expiry: 1.0,
+        }),
+        TradeProduct::Cds(Cds {
+            notional: 1_000_000.0,
+            spread: 0.01,
+            maturity: 5.0,
+            recovery_rate: 0.4,
+            payment_freq: 4,
+        }),
+        TradeProduct::CdsOption(CdsOption {
+            notional: 1_000_000.0,
+            strike_spread: 0.01,
+            option_expiry: 1.0,
+            cds_maturity: 5.0,
+            is_payer: true,
+            recovery_rate: 0.4,
+        }),
+        TradeProduct::CdoTranche(CdoTranche {
+            attachment: 0.03,
+            detachment: 0.07,
+            notional: 10_000_000.0,
+            spread: 0.04,
+        }),
+        TradeProduct::SyntheticCdo(SyntheticCdo {
+            num_names: 125,
+            pool_spread: 0.02,
+            recovery_rate: 0.4,
+            correlation: 0.3,
+            risk_free_rate: 0.03,
+            maturity: 5.0,
+            payment_freq: 4,
+        }),
+        TradeProduct::CdsIndex(CdsIndex {
+            constituents: vec![Cds {
+                notional: 1_000_000.0,
+                spread: 0.01,
+                maturity: 5.0,
+                recovery_rate: 0.4,
+                payment_freq: 4,
+            }],
+            weights: vec![1.0],
+        }),
+        TradeProduct::NthToDefaultBasket(NthToDefaultBasket {
+            n: 1,
+            notional: 1_000_000.0,
+            maturity: 5.0,
+            recovery_rate: 0.4,
+            payment_freq: 4,
+        }),
+        TradeProduct::DatedCds(DatedCds {
+            side: ProtectionSide::Buyer,
+            notional: 1_000_000.0,
+            running_spread: 0.01,
+            recovery_rate: 0.4,
+            issue_date: start,
+            maturity_date: end,
+            coupon_interval_months: 3,
+            date_rule: CdsDateRule::QuarterlyImm,
+        }),
+    ]
+}
+
+#[test]
+fn trade_roundtrip_json_and_msgpack_for_every_product_variant() {
+    for (idx, product) in sample_trade_products().into_iter().enumerate() {
+        let trade = Trade {
+            metadata: TradeMetadata {
+                trade_id: format!("TRD-{idx:04}"),
+                version: 1,
+                timestamp: "2026-02-22T12:00:00Z".to_string(),
+            },
+            market_data_ref: Some("SNAP-2026-02-22".to_string()),
+            product,
+        };
+
+        roundtrip_json(&trade);
+        roundtrip_msgpack(&trade);
+    }
+}
+
+#[test]
+fn market_snapshot_roundtrip_json_and_msgpack() {
+    let snapshot = MarketSnapshot {
+        snapshot_id: "SNAP-2026-02-22".to_string(),
+        as_of: "2026-02-22T12:00:00Z".to_string(),
+        yield_curves: [(
+            "USD-OIS".to_string(),
+            YieldCurveSnapshot {
+                pillars: vec![0.5, 1.0, 2.0, 5.0],
+                rates: vec![0.03, 0.031, 0.032, 0.034],
+                interpolation: InterpolationMethod::LogLinear,
+                value_type: CurveValueType::ZeroRate,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        credit_curves: [(
+            "ACME".to_string(),
+            CreditCurveSnapshot {
+                pillars: vec![1.0, 3.0, 5.0],
+                survival_probabilities: vec![0.98, 0.93, 0.88],
+                recovery_rate: 0.4,
+                interpolation: InterpolationMethod::LogLinear,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        vol_surfaces: [(
+            "SPX".to_string(),
+            VolSurfaceSnapshot {
+                expiries: vec![0.5, 1.0],
+                strikes: vec![90.0, 100.0, 110.0],
+                vols: vec![vec![0.22, 0.2, 0.21], vec![0.24, 0.22, 0.23]],
+                model: Some(VolSurfaceModel::Svi {
+                    parameters_by_expiry: vec![
+                        (
+                            0.5,
+                            SviParams {
+                                a: 0.02,
+                                b: 0.1,
+                                rho: -0.2,
+                                m: 0.0,
+                                sigma: 0.3,
+                            },
+                        ),
+                        (
+                            1.0,
+                            SviParams {
+                                a: 0.03,
+                                b: 0.11,
+                                rho: -0.25,
+                                m: 0.0,
+                                sigma: 0.35,
+                            },
+                        ),
+                    ],
+                }),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        spots: [("SPX".to_string(), 5100.0)].into_iter().collect(),
+        forwards: [(
+            "WTI".to_string(),
+            ForwardCurveSnapshot {
+                points: vec![(0.5, 76.0), (1.0, 77.2), (2.0, 79.5)],
+                interpolation: InterpolationMethod::Linear,
+            },
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    roundtrip_json(&snapshot);
+    roundtrip_msgpack(&snapshot);
+}
+
+#[test]
+fn pricing_audit_roundtrip_json_and_msgpack() {
+    let mut diagnostics = Diagnostics::new();
+    diagnostics.insert("npv", 12.34);
+    diagnostics.insert("vol", 0.22);
+
+    let base_result = PricingResult {
+        price: 12.34,
+        stderr: Some(0.01),
+        greeks: Some(Greeks {
+            delta: 0.5,
+            gamma: 0.02,
+            vega: 0.11,
+            theta: -0.03,
+            rho: 0.09,
+        }),
+        diagnostics,
+    };
+
+    let trade = Trade {
+        metadata: TradeMetadata {
+            trade_id: "TRD-AUDIT-001".to_string(),
+            version: 3,
+            timestamp: "2026-02-22T12:00:00Z".to_string(),
+        },
+        market_data_ref: Some("SNAP-2026-02-22".to_string()),
+        product: TradeProduct::VanillaOption(VanillaOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            exercise: ExerciseStyle::European,
+        }),
+    };
+
+    let audit = PricingAuditTrail {
+        trade,
+        market_snapshot_id: "SNAP-2026-02-22".to_string(),
+        engine_name: "analytic.black_scholes".to_string(),
+        model_name: "black_scholes".to_string(),
+        model_parameters: [("rate".to_string(), 0.03), ("vol".to_string(), 0.22)]
+            .into_iter()
+            .collect(),
+        base_result: base_result.clone(),
+        scenario_results: vec![ScenarioPricingResult {
+            scenario_name: "spot_up_1pct".to_string(),
+            bump_description: Some("spot +1%".to_string()),
+            result: PricingResult {
+                price: 12.95,
+                ..base_result
+            },
+        }],
+        generated_at: "2026-02-22T12:00:01Z".to_string(),
+        notes: vec!["desk=eqd".to_string(), "book=macro".to_string()],
+    };
+
+    roundtrip_json(&audit);
+    roundtrip_msgpack(&audit);
+}
+
+#[test]
+fn market_runtime_type_roundtrip_for_flat_and_surface_vol() {
+    let flat_market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .flat_vol(0.2)
+        .reference_date("2026-02-22")
+        .build()
+        .unwrap();
+
+    let flat_json = serde_json::to_string(&flat_market).unwrap();
+    let flat_back: Market = serde_json::from_str(&flat_json).unwrap();
+    assert!((flat_back.spot - flat_market.spot).abs() < 1e-12);
+    assert!((flat_back.vol_for(100.0, 1.0) - flat_market.vol_for(100.0, 1.0)).abs() < 1e-12);
+
+    let surface = SviSurface::new(
+        vec![(
+            1.0,
+            SviParams {
+                a: 0.02,
+                b: 0.1,
+                rho: -0.2,
+                m: 0.0,
+                sigma: 0.3,
+            },
+        )],
+        100.0,
+    )
+    .unwrap();
+
+    let surface_market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .vol_surface(Box::new(surface))
+        .reference_date("2026-02-22")
+        .build()
+        .unwrap();
+
+    let surface_json = serde_json::to_string(&surface_market).unwrap();
+    let surface_back: Market = serde_json::from_str(&surface_json).unwrap();
+    let v1 = surface_market.vol_for(100.0, 1.0);
+    let v2 = surface_back.vol_for(100.0, 1.0);
+    assert!((v1 - v2).abs() < 1e-12);
+}


### PR DESCRIPTION
Adds serde Serialize/Deserialize to all instrument, market, and pricing types:
- 67 files touched, 1702 lines added
- JSON + MessagePack round-trip for all TradeProduct variants
- Market snapshot serialization (curves, surfaces, spot)
- Pricing audit trail serialization
- 738-line round-trip test suite
- 299 tests passing