### PR TITLE
Add tests for openferric-wasm exported functions

### DIFF
--- a/openferric-wasm/src/credit.rs
+++ b/openferric-wasm/src/credit.rs
@@ -38,3 +38,39 @@ pub fn cds_fair_spread(
     };
     cds.fair_spread(&discount_curve, &survival_curve)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cds_fair_spread_positive() {
+        let spread = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.02, 0.03);
+        assert!(spread > 0.0);
+    }
+
+    #[test]
+    fn cds_fair_spread_approx_lgd_times_hazard() {
+        // Fair spread ≈ (1-R)*λ for flat curves
+        let hazard = 0.02;
+        let recovery = 0.40;
+        let spread = cds_fair_spread(1_000_000.0, 5.0, recovery, hazard, 0.03);
+        let approx = (1.0 - recovery) * hazard;
+        assert!((spread - approx).abs() < 0.005);
+    }
+
+    #[test]
+    fn cds_fair_spread_higher_hazard() {
+        let spread_low = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.01, 0.03);
+        let spread_high = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.05, 0.03);
+        assert!(spread_high > spread_low);
+    }
+
+    #[test]
+    fn cds_fair_spread_lower_recovery() {
+        // Lower recovery → higher spread
+        let spread_high_r = cds_fair_spread(1_000_000.0, 5.0, 0.60, 0.02, 0.03);
+        let spread_low_r = cds_fair_spread(1_000_000.0, 5.0, 0.20, 0.02, 0.03);
+        assert!(spread_low_r > spread_high_r);
+    }
+}

--- a/openferric-wasm/src/helpers.rs
+++ b/openferric-wasm/src/helpers.rs
@@ -23,3 +23,47 @@ pub(crate) fn option_price_from_call(
         call_price - spot * (-div_yield * maturity).exp() + strike * (-rate * maturity).exp()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heston_intrinsic_call_itm() {
+        assert!((heston_intrinsic(110.0, 100.0, true) - 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn heston_intrinsic_call_otm() {
+        assert!((heston_intrinsic(90.0, 100.0, true)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn heston_intrinsic_put_itm() {
+        assert!((heston_intrinsic(90.0, 100.0, false) - 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn heston_intrinsic_put_otm() {
+        assert!((heston_intrinsic(110.0, 100.0, false)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn option_price_from_call_returns_call_for_is_call() {
+        assert!((option_price_from_call(10.0, 100.0, 100.0, 0.05, 0.0, 1.0, true) - 10.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn option_price_from_call_parity() {
+        let call = 10.0;
+        let s = 100.0;
+        let k = 100.0;
+        let r = 0.05;
+        let q = 0.02;
+        let t = 1.0;
+        let put = option_price_from_call(call, s, k, r, q, t, false);
+        // put = call - S*exp(-qT) + K*exp(-rT)
+        let expected = call - s * (-q * t).exp() + k * (-r * t).exp();
+        assert!((put - expected).abs() < 1e-10);
+    }
+}

--- a/openferric-wasm/src/payoff.rs
+++ b/openferric-wasm/src/payoff.rs
@@ -13,3 +13,63 @@ pub fn strategy_intrinsic_pnl_wasm(
         spot_axis, strikes, quantities, is_calls, total_cost,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn long_call_pnl() {
+        // Long 1 call at K=100, cost=5
+        let spots = [80.0, 90.0, 100.0, 110.0, 120.0];
+        let pnl = strategy_intrinsic_pnl_wasm(
+            &spots, &[100.0], &[1.0], &[1u8], 5.0,
+        );
+        assert_eq!(pnl.len(), 5);
+        // Below strike: PnL = -cost
+        assert!((pnl[0] - (-5.0)).abs() < 1e-10);
+        assert!((pnl[1] - (-5.0)).abs() < 1e-10);
+        assert!((pnl[2] - (-5.0)).abs() < 1e-10);
+        // Above strike: PnL = intrinsic - cost
+        assert!((pnl[3] - 5.0).abs() < 1e-10);  // 110-100-5
+        assert!((pnl[4] - 15.0).abs() < 1e-10); // 120-100-5
+    }
+
+    #[test]
+    fn long_put_pnl() {
+        // Long 1 put at K=100, cost=5
+        let spots = [80.0, 90.0, 100.0, 110.0, 120.0];
+        let pnl = strategy_intrinsic_pnl_wasm(
+            &spots, &[100.0], &[1.0], &[0u8], 5.0,
+        );
+        assert_eq!(pnl.len(), 5);
+        assert!((pnl[0] - 15.0).abs() < 1e-10);  // 100-80-5
+        assert!((pnl[1] - 5.0).abs() < 1e-10);   // 100-90-5
+        assert!((pnl[2] - (-5.0)).abs() < 1e-10); // 0-5
+        assert!((pnl[3] - (-5.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn bull_call_spread() {
+        // Long call K=100, short call K=110, net debit=3
+        let spots = [90.0, 100.0, 105.0, 110.0, 120.0];
+        let pnl = strategy_intrinsic_pnl_wasm(
+            &spots, &[100.0, 110.0], &[1.0, -1.0], &[1u8, 1u8], 3.0,
+        );
+        assert_eq!(pnl.len(), 5);
+        // Below both strikes: max loss = -cost
+        assert!((pnl[0] - (-3.0)).abs() < 1e-10);
+        // Between strikes: partial gain
+        assert!((pnl[2] - 2.0).abs() < 1e-10); // 5-3
+        // Above both: max gain = spread width - cost = 10 - 3 = 7
+        assert!((pnl[4] - 7.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn empty_spot_axis() {
+        let pnl = strategy_intrinsic_pnl_wasm(
+            &[], &[100.0], &[1.0], &[1u8], 5.0,
+        );
+        assert!(pnl.is_empty());
+    }
+}

--- a/openferric-wasm/src/risk.rs
+++ b/openferric-wasm/src/risk.rs
@@ -10,3 +10,35 @@ pub fn var_historical(returns_flat: &[f64], confidence: f64) -> f64 {
     }
     historical_var(returns_flat, confidence)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn var_historical_positive_for_losses() {
+        let returns = [-0.10, -0.05, -0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.05];
+        let var = var_historical(&returns, 0.95);
+        assert!(var > 0.0);
+    }
+
+    #[test]
+    fn var_historical_higher_confidence_higher_var() {
+        let returns = [-0.10, -0.05, -0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.05];
+        let var_90 = var_historical(&returns, 0.90);
+        let var_99 = var_historical(&returns, 0.99);
+        assert!(var_99 >= var_90);
+    }
+
+    #[test]
+    fn var_historical_empty_returns_nan() {
+        assert!(var_historical(&[], 0.95).is_nan());
+    }
+
+    #[test]
+    fn var_historical_all_positive() {
+        let returns = [0.01, 0.02, 0.03, 0.04, 0.05];
+        let var = var_historical(&returns, 0.95);
+        assert!(var <= 0.01);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 64 unit tests covering all non-GPU WASM exports in `openferric-wasm`
- 7 modules tested: pricing (23), heston (10), vol (16), credit (4), risk (4), payoff (4), helpers (6)
- Tests include QuantLib-validated reference values (Alan Lewis Heston), put-call parity checks, round-trip implied vol, batch vs scalar consistency, and invalid input handling
- Bond pricing tests cover par/premium/discount and edge cases

## Test plan
- [x] `cargo test -p openferric-wasm` — 68 passed (64 new + 4 existing), 0 failures (0.13s)
- [ ] Verify CI picks up the new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)