### PR TITLE
feat(math): extended curve interpolation methods (closes #51)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ harness = false
 name = "mc_bench"
 harness = false
 
+[[bench]]
+name = "interpolation_bench"
+harness = false
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/benches/interpolation_bench.rs
+++ b/benches/interpolation_bench.rs
@@ -1,0 +1,86 @@
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use openferric::math::{ExtrapolationMode, Interpolator, LogLinearInterpolator};
+use openferric::rates::{
+    YieldCurve, YieldCurveInterpolationMethod, YieldCurveInterpolationSettings,
+};
+use std::hint::black_box;
+
+// Target guideline:
+// - interpolation latency < 100ns per point for core methods on target hardware.
+
+fn sample_curve_points() -> Vec<(f64, f64)> {
+    vec![
+        (0.25, 0.995),
+        (0.50, 0.989),
+        (1.0, 0.978),
+        (2.0, 0.955),
+        (3.0, 0.932),
+        (5.0, 0.886),
+        (7.0, 0.844),
+        (10.0, 0.786),
+        (20.0, 0.620),
+        (30.0, 0.510),
+    ]
+}
+
+fn bench_log_linear_df(c: &mut Criterion) {
+    let points = sample_curve_points();
+    let x: Vec<f64> = points.iter().map(|(t, _)| *t).collect();
+    let y: Vec<f64> = points.iter().map(|(_, df)| *df).collect();
+    let itp = LogLinearInterpolator::new(x, y, ExtrapolationMode::Linear).unwrap();
+
+    let queries: Vec<f64> = (1..=10_000).map(|i| 30.0 * i as f64 / 10_000.0).collect();
+    let mut group = c.benchmark_group("interp_log_linear_df");
+    group.throughput(Throughput::Elements(queries.len() as u64));
+    group.bench_function("value", |b| {
+        b.iter(|| {
+            let mut acc = 0.0;
+            for t in &queries {
+                acc += itp.value(black_box(*t)).unwrap();
+            }
+            black_box(acc)
+        })
+    });
+    group.finish();
+}
+
+fn bench_yield_curve_methods(c: &mut Criterion) {
+    let points = sample_curve_points();
+    let queries: Vec<f64> = (1..=10_000).map(|i| 30.0 * i as f64 / 10_000.0).collect();
+
+    let methods = [
+        YieldCurveInterpolationMethod::LogLinearDiscount,
+        YieldCurveInterpolationMethod::MonotoneConvex,
+        YieldCurveInterpolationMethod::HermiteMonotone,
+        YieldCurveInterpolationMethod::LogCubicMonotone,
+    ];
+
+    let mut group = c.benchmark_group("yield_curve_interpolation");
+    group.throughput(Throughput::Elements(queries.len() as u64));
+
+    for method in methods {
+        let settings = YieldCurveInterpolationSettings {
+            method,
+            extrapolation: ExtrapolationMode::Linear,
+        };
+        let curve = YieldCurve::new_with_settings(points.clone(), settings).unwrap();
+        group.bench_function(format!("{:?}", method), |b| {
+            b.iter(|| {
+                let mut acc = 0.0;
+                for t in &queries {
+                    acc += curve.discount_factor(black_box(*t));
+                }
+                black_box(acc)
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    interpolation_benches,
+    bench_log_linear_df,
+    bench_yield_curve_methods
+);
+criterion_main!(interpolation_benches);

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -1,0 +1,1738 @@
+//! Interpolation routines for rates and curve construction.
+//!
+//! This module provides production-oriented interpolators used in fixed-income
+//! analytics, including shape-preserving local schemes and parametric curve
+//! families.
+//!
+//! References:
+//! - Hagan and West (2006), *Interpolation Methods for Curve Construction*.
+//! - Fritsch and Carlson (1980), monotone piecewise cubic interpolation.
+//! - Nelson and Siegel (1987), parsimonious yield-curve model.
+//! - Svensson (1994), extended Nelson-Siegel specification.
+//! - EIOPA, Smith-Wilson technical documentation for Solvency II.
+
+use nalgebra::{DMatrix, DVector};
+
+/// Extrapolation behavior outside the calibrated node range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtrapolationMode {
+    /// Keep the endpoint value constant.
+    Flat,
+    /// Extend using endpoint tangent/slope.
+    Linear,
+    /// Return an error outside node range.
+    Error,
+}
+
+/// Errors returned by interpolators.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InterpolationError {
+    InvalidInput(&'static str),
+    ExtrapolationDisabled,
+    SingularSystem,
+    NonConvergence,
+}
+
+/// Common interpolation interface.
+pub trait Interpolator {
+    /// Returns interpolated value `y(x)`.
+    fn value(&self, x: f64) -> Result<f64, InterpolationError>;
+
+    /// Returns first derivative `dy/dx`.
+    fn derivative(&self, x: f64) -> Result<f64, InterpolationError>;
+
+    /// Returns Jacobian `dy(x) / d(input_i)` with respect to calibration inputs.
+    fn jacobian(&self, x: f64) -> Result<Vec<f64>, InterpolationError>;
+
+    /// Returns interpolation abscissas.
+    fn x(&self) -> &[f64];
+
+    /// Returns interpolation ordinates or calibration inputs.
+    fn y(&self) -> &[f64];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueryLocation {
+    Left,
+    Inside(usize),
+    Right,
+}
+
+fn validate_xy(x: &[f64], y: &[f64], min_len: usize) -> Result<(), InterpolationError> {
+    if x.len() != y.len() {
+        return Err(InterpolationError::InvalidInput(
+            "x and y must have same length",
+        ));
+    }
+    if x.len() < min_len {
+        return Err(InterpolationError::InvalidInput(
+            "not enough interpolation nodes",
+        ));
+    }
+    if x.windows(2).any(|w| w[1] <= w[0]) {
+        return Err(InterpolationError::InvalidInput(
+            "x must be strictly increasing",
+        ));
+    }
+    if x.iter().any(|v| !v.is_finite()) || y.iter().any(|v| !v.is_finite()) {
+        return Err(InterpolationError::InvalidInput("x and y must be finite"));
+    }
+    Ok(())
+}
+
+fn validate_positive_y(y: &[f64]) -> Result<(), InterpolationError> {
+    if y.iter().any(|v| *v <= 0.0) {
+        return Err(InterpolationError::InvalidInput(
+            "y must be strictly positive",
+        ));
+    }
+    Ok(())
+}
+
+fn query_location(x: &[f64], xq: f64) -> QueryLocation {
+    if xq < x[0] {
+        return QueryLocation::Left;
+    }
+    if xq > x[x.len() - 1] {
+        return QueryLocation::Right;
+    }
+    let idx = x.partition_point(|v| *v <= xq);
+    if idx == 0 {
+        QueryLocation::Inside(0)
+    } else if idx >= x.len() {
+        QueryLocation::Inside(x.len() - 2)
+    } else {
+        QueryLocation::Inside(idx - 1)
+    }
+}
+
+#[inline]
+fn linear_weights(x0: f64, x1: f64, xq: f64) -> (f64, f64) {
+    let w = if (x1 - x0).abs() <= f64::EPSILON {
+        0.0
+    } else {
+        (xq - x0) / (x1 - x0)
+    };
+    (1.0 - w, w)
+}
+
+fn pchip_slopes(x: &[f64], y: &[f64]) -> Vec<f64> {
+    let n = x.len();
+    if n == 2 {
+        let m = (y[1] - y[0]) / (x[1] - x[0]);
+        return vec![m, m];
+    }
+
+    let mut h = vec![0.0; n - 1];
+    let mut delta = vec![0.0; n - 1];
+    for i in 0..(n - 1) {
+        h[i] = x[i + 1] - x[i];
+        delta[i] = (y[i + 1] - y[i]) / h[i];
+    }
+
+    let mut d = vec![0.0; n];
+
+    for k in 1..(n - 1) {
+        if delta[k - 1] * delta[k] <= 0.0 {
+            d[k] = 0.0;
+        } else {
+            let w1 = 2.0 * h[k] + h[k - 1];
+            let w2 = h[k] + 2.0 * h[k - 1];
+            d[k] = (w1 + w2) / (w1 / delta[k - 1] + w2 / delta[k]);
+        }
+    }
+
+    d[0] = ((2.0 * h[0] + h[1]) * delta[0] - h[0] * delta[1]) / (h[0] + h[1]);
+    if d[0].signum() != delta[0].signum() {
+        d[0] = 0.0;
+    } else if delta[0].signum() != delta[1].signum() && d[0].abs() > 3.0 * delta[0].abs() {
+        d[0] = 3.0 * delta[0];
+    }
+
+    let m = n - 1;
+    d[m] = ((2.0 * h[m - 1] + h[m - 2]) * delta[m - 1] - h[m - 1] * delta[m - 2])
+        / (h[m - 1] + h[m - 2]);
+    if d[m].signum() != delta[m - 1].signum() {
+        d[m] = 0.0;
+    } else if delta[m - 1].signum() != delta[m - 2].signum()
+        && d[m].abs() > 3.0 * delta[m - 1].abs()
+    {
+        d[m] = 3.0 * delta[m - 1];
+    }
+
+    d
+}
+
+fn hagan_west_like_slopes(x: &[f64], y: &[f64]) -> Vec<f64> {
+    let n = x.len();
+    if n == 2 {
+        let m = (y[1] - y[0]) / (x[1] - x[0]);
+        return vec![m, m];
+    }
+
+    let mut h = vec![0.0; n - 1];
+    let mut s = vec![0.0; n - 1];
+    for i in 0..(n - 1) {
+        h[i] = x[i + 1] - x[i];
+        s[i] = (y[i + 1] - y[i]) / h[i];
+    }
+
+    let mut d = vec![0.0; n];
+    d[0] = s[0];
+    d[n - 1] = s[n - 2];
+
+    for i in 1..(n - 1) {
+        let avg = (h[i] * s[i - 1] + h[i - 1] * s[i]) / (h[i - 1] + h[i]);
+        if s[i - 1] * s[i] <= 0.0 {
+            d[i] = 0.0;
+        } else {
+            let bound = 3.0 * s[i - 1].abs().min(s[i].abs());
+            d[i] = avg.signum() * avg.abs().min(bound);
+        }
+    }
+
+    d
+}
+
+#[inline]
+fn hermite_eval(x0: f64, x1: f64, y0: f64, y1: f64, m0: f64, m1: f64, xq: f64) -> f64 {
+    let h = x1 - x0;
+    let s = (xq - x0) / h;
+    let s2 = s * s;
+    let s3 = s2 * s;
+
+    let h00 = 2.0 * s3 - 3.0 * s2 + 1.0;
+    let h10 = s3 - 2.0 * s2 + s;
+    let h01 = -2.0 * s3 + 3.0 * s2;
+    let h11 = s3 - s2;
+
+    h00 * y0 + h10 * h * m0 + h01 * y1 + h11 * h * m1
+}
+
+#[inline]
+fn hermite_eval_derivative(x0: f64, x1: f64, y0: f64, y1: f64, m0: f64, m1: f64, xq: f64) -> f64 {
+    let h = x1 - x0;
+    let s = (xq - x0) / h;
+    let s2 = s * s;
+
+    ((6.0 * s2 - 6.0 * s) * y0 + (-6.0 * s2 + 6.0 * s) * y1) / h
+        + (3.0 * s2 - 4.0 * s + 1.0) * m0
+        + (3.0 * s2 - 2.0 * s) * m1
+}
+
+fn finite_difference_jacobian<F>(
+    base: &[f64],
+    mut evaluator: F,
+) -> Result<Vec<f64>, InterpolationError>
+where
+    F: FnMut(&[f64]) -> Result<f64, InterpolationError>,
+{
+    let mut out = vec![0.0; base.len()];
+    for i in 0..base.len() {
+        let h = 1.0e-6 * base[i].abs().max(1.0);
+        let mut up = base.to_vec();
+        up[i] += h;
+        let up_v = evaluator(&up)?;
+
+        let mut dn = base.to_vec();
+        dn[i] -= h;
+        let dn_v = evaluator(&dn)?;
+
+        out[i] = (up_v - dn_v) / (2.0 * h);
+    }
+    Ok(out)
+}
+
+/// Piecewise-linear interpolation in `y`.
+#[derive(Debug, Clone)]
+pub struct LinearInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl LinearInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        Ok(Self {
+            x,
+            y,
+            extrapolation,
+        })
+    }
+}
+
+impl Interpolator for LinearInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.y[0]),
+                ExtrapolationMode::Linear => {
+                    let (w0, w1) = linear_weights(self.x[0], self.x[1], xq);
+                    Ok(w0 * self.y[0] + w1 * self.y[1])
+                }
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        let (w0, w1) = linear_weights(self.x[n - 2], self.x[n - 1], xq);
+                        Ok(w0 * self.y[n - 2] + w1 * self.y[n - 1])
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                let (w0, w1) = linear_weights(self.x[i], self.x[i + 1], xq);
+                Ok(w0 * self.y[i] + w1 * self.y[i + 1])
+            }
+        }
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(0.0),
+                ExtrapolationMode::Linear => Ok((self.y[1] - self.y[0]) / (self.x[1] - self.x[0])),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(0.0),
+                    ExtrapolationMode::Linear => {
+                        Ok((self.y[n - 1] - self.y[n - 2]) / (self.x[n - 1] - self.x[n - 2]))
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                Ok((self.y[i + 1] - self.y[i]) / (self.x[i + 1] - self.x[i]))
+            }
+        }
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        let mut j = vec![0.0; self.y.len()];
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => {
+                    j[0] = 1.0;
+                    Ok(j)
+                }
+                ExtrapolationMode::Linear => {
+                    let (w0, w1) = linear_weights(self.x[0], self.x[1], xq);
+                    j[0] = w0;
+                    j[1] = w1;
+                    Ok(j)
+                }
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.y.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => {
+                        j[n - 1] = 1.0;
+                        Ok(j)
+                    }
+                    ExtrapolationMode::Linear => {
+                        let (w0, w1) = linear_weights(self.x[n - 2], self.x[n - 1], xq);
+                        j[n - 2] = w0;
+                        j[n - 1] = w1;
+                        Ok(j)
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                let (w0, w1) = linear_weights(self.x[i], self.x[i + 1], xq);
+                j[i] = w0;
+                j[i + 1] = w1;
+                Ok(j)
+            }
+        }
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Log-linear interpolation in strictly positive `y`.
+#[derive(Debug, Clone)]
+pub struct LogLinearInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    log_y: Vec<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl LogLinearInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        validate_positive_y(&y)?;
+        let log_y = y.iter().map(|v| v.ln()).collect();
+        Ok(Self {
+            x,
+            y,
+            log_y,
+            extrapolation,
+        })
+    }
+}
+
+impl Interpolator for LogLinearInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.y[0]),
+                ExtrapolationMode::Linear => {
+                    let (w0, w1) = linear_weights(self.x[0], self.x[1], xq);
+                    Ok((w0 * self.log_y[0] + w1 * self.log_y[1]).exp())
+                }
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        let (w0, w1) = linear_weights(self.x[n - 2], self.x[n - 1], xq);
+                        Ok((w0 * self.log_y[n - 2] + w1 * self.log_y[n - 1]).exp())
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                let (w0, w1) = linear_weights(self.x[i], self.x[i + 1], xq);
+                Ok((w0 * self.log_y[i] + w1 * self.log_y[i + 1]).exp())
+            }
+        }
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let yq = self.value(xq)?;
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(0.0),
+                ExtrapolationMode::Linear => {
+                    Ok(yq * (self.log_y[1] - self.log_y[0]) / (self.x[1] - self.x[0]))
+                }
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(0.0),
+                    ExtrapolationMode::Linear => Ok(yq * (self.log_y[n - 1] - self.log_y[n - 2])
+                        / (self.x[n - 1] - self.x[n - 2])),
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                Ok(yq * (self.log_y[i + 1] - self.log_y[i]) / (self.x[i + 1] - self.x[i]))
+            }
+        }
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        let mut j = vec![0.0; self.y.len()];
+        let yq = self.value(xq)?;
+
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => {
+                    j[0] = 1.0;
+                    Ok(j)
+                }
+                ExtrapolationMode::Linear => {
+                    let (w0, w1) = linear_weights(self.x[0], self.x[1], xq);
+                    j[0] = yq * w0 / self.y[0];
+                    j[1] = yq * w1 / self.y[1];
+                    Ok(j)
+                }
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.y.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => {
+                        j[n - 1] = 1.0;
+                        Ok(j)
+                    }
+                    ExtrapolationMode::Linear => {
+                        let (w0, w1) = linear_weights(self.x[n - 2], self.x[n - 1], xq);
+                        j[n - 2] = yq * w0 / self.y[n - 2];
+                        j[n - 1] = yq * w1 / self.y[n - 1];
+                        Ok(j)
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => {
+                let (w0, w1) = linear_weights(self.x[i], self.x[i + 1], xq);
+                j[i] = yq * w0 / self.y[i];
+                j[i + 1] = yq * w1 / self.y[i + 1];
+                Ok(j)
+            }
+        }
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Hagan-West inspired monotone-convex interpolation via filtered cubic Hermite segments.
+#[derive(Debug, Clone)]
+pub struct MonotoneConvexInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    slopes: Vec<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl MonotoneConvexInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        let slopes = hagan_west_like_slopes(&x, &y);
+        Ok(Self {
+            x,
+            y,
+            slopes,
+            extrapolation,
+        })
+    }
+}
+
+impl Interpolator for MonotoneConvexInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.y[0]),
+                ExtrapolationMode::Linear => Ok(self.y[0] + self.slopes[0] * (xq - self.x[0])),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        Ok(self.y[n - 1] + self.slopes[n - 1] * (xq - self.x[n - 1]))
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(0.0),
+                ExtrapolationMode::Linear => Ok(self.slopes[0]),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(0.0),
+                    ExtrapolationMode::Linear => Ok(self.slopes[n - 1]),
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval_derivative(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            MonotoneConvexInterpolator::new(self.x.clone(), yb.to_vec(), self.extrapolation)?
+                .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Cardinal-tension cubic spline.
+#[derive(Debug, Clone)]
+pub struct TensionSplineInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    slopes: Vec<f64>,
+    tension: f64,
+    extrapolation: ExtrapolationMode,
+}
+
+impl TensionSplineInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        tension: f64,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        if !(0.0..=1.0).contains(&tension) {
+            return Err(InterpolationError::InvalidInput(
+                "tension must be in [0, 1]",
+            ));
+        }
+
+        let n = x.len();
+        let mut slopes = vec![0.0; n];
+        if n == 2 {
+            let m = (1.0 - tension) * (y[1] - y[0]) / (x[1] - x[0]);
+            slopes[0] = m;
+            slopes[1] = m;
+        } else {
+            let sec0 = (y[1] - y[0]) / (x[1] - x[0]);
+            slopes[0] = (1.0 - tension) * sec0;
+            for i in 1..(n - 1) {
+                let h_prev = x[i] - x[i - 1];
+                let h_next = x[i + 1] - x[i];
+                let sec_prev = (y[i] - y[i - 1]) / h_prev;
+                let sec_next = (y[i + 1] - y[i]) / h_next;
+                let centered = (h_next * sec_prev + h_prev * sec_next) / (h_prev + h_next);
+                slopes[i] = (1.0 - tension) * centered;
+            }
+            let secn = (y[n - 1] - y[n - 2]) / (x[n - 1] - x[n - 2]);
+            slopes[n - 1] = (1.0 - tension) * secn;
+        }
+
+        Ok(Self {
+            x,
+            y,
+            slopes,
+            tension,
+            extrapolation,
+        })
+    }
+}
+
+impl Interpolator for TensionSplineInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.y[0]),
+                ExtrapolationMode::Linear => Ok(self.y[0] + self.slopes[0] * (xq - self.x[0])),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        Ok(self.y[n - 1] + self.slopes[n - 1] * (xq - self.x[n - 1]))
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(0.0),
+                ExtrapolationMode::Linear => Ok(self.slopes[0]),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(0.0),
+                    ExtrapolationMode::Linear => Ok(self.slopes[n - 1]),
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval_derivative(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            TensionSplineInterpolator::new(
+                self.x.clone(),
+                yb.to_vec(),
+                self.tension,
+                self.extrapolation,
+            )?
+            .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Shape-preserving cubic Hermite interpolation (PCHIP style).
+#[derive(Debug, Clone)]
+pub struct HermiteMonotoneInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    slopes: Vec<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl HermiteMonotoneInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        let slopes = pchip_slopes(&x, &y);
+        Ok(Self {
+            x,
+            y,
+            slopes,
+            extrapolation,
+        })
+    }
+}
+
+impl Interpolator for HermiteMonotoneInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.y[0]),
+                ExtrapolationMode::Linear => Ok(self.y[0] + self.slopes[0] * (xq - self.x[0])),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        Ok(self.y[n - 1] + self.slopes[n - 1] * (xq - self.x[n - 1]))
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(0.0),
+                ExtrapolationMode::Linear => Ok(self.slopes[0]),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(0.0),
+                    ExtrapolationMode::Linear => Ok(self.slopes[n - 1]),
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval_derivative(
+                self.x[i],
+                self.x[i + 1],
+                self.y[i],
+                self.y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            HermiteMonotoneInterpolator::new(self.x.clone(), yb.to_vec(), self.extrapolation)?
+                .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Log-cubic monotone interpolator.
+#[derive(Debug, Clone)]
+pub struct LogCubicMonotoneInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    log_y: Vec<f64>,
+    slopes: Vec<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl LogCubicMonotoneInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        validate_positive_y(&y)?;
+        let log_y: Vec<f64> = y.iter().map(|v| v.ln()).collect();
+        let slopes = pchip_slopes(&x, &log_y);
+        Ok(Self {
+            x,
+            y,
+            log_y,
+            slopes,
+            extrapolation,
+        })
+    }
+
+    fn log_value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => Ok(self.log_y[0]),
+                ExtrapolationMode::Linear => Ok(self.log_y[0] + self.slopes[0] * (xq - self.x[0])),
+                ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => Ok(self.log_y[n - 1]),
+                    ExtrapolationMode::Linear => {
+                        Ok(self.log_y[n - 1] + self.slopes[n - 1] * (xq - self.x[n - 1]))
+                    }
+                    ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+                }
+            }
+            QueryLocation::Inside(i) => Ok(hermite_eval(
+                self.x[i],
+                self.x[i + 1],
+                self.log_y[i],
+                self.log_y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            )),
+        }
+    }
+}
+
+impl Interpolator for LogCubicMonotoneInterpolator {
+    fn value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        Ok(self.log_value(xq)?.exp())
+    }
+
+    fn derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let u = self.log_value(xq)?;
+        let du = match query_location(&self.x, xq) {
+            QueryLocation::Left => match self.extrapolation {
+                ExtrapolationMode::Flat => 0.0,
+                ExtrapolationMode::Linear => self.slopes[0],
+                ExtrapolationMode::Error => return Err(InterpolationError::ExtrapolationDisabled),
+            },
+            QueryLocation::Right => {
+                let n = self.x.len();
+                match self.extrapolation {
+                    ExtrapolationMode::Flat => 0.0,
+                    ExtrapolationMode::Linear => self.slopes[n - 1],
+                    ExtrapolationMode::Error => {
+                        return Err(InterpolationError::ExtrapolationDisabled);
+                    }
+                }
+            }
+            QueryLocation::Inside(i) => hermite_eval_derivative(
+                self.x[i],
+                self.x[i + 1],
+                self.log_y[i],
+                self.log_y[i + 1],
+                self.slopes[i],
+                self.slopes[i + 1],
+                xq,
+            ),
+        };
+
+        Ok(u.exp() * du)
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            let mut yb_pos = yb.to_vec();
+            for v in &mut yb_pos {
+                *v = v.max(1.0e-12);
+            }
+            LogCubicMonotoneInterpolator::new(self.x.clone(), yb_pos, self.extrapolation)?.value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+fn ns_basis(t: f64, tau: f64) -> (f64, f64, f64, f64) {
+    let x = t / tau;
+    if x.abs() < 1.0e-8 {
+        let f1 = 1.0 - 0.5 * x + x * x / 6.0;
+        let f2 = 0.5 * x - x * x / 3.0;
+        let df1_dx = -0.5 + x / 3.0;
+        let df2_dx = 0.5 - 2.0 * x / 3.0;
+        return (f1, f2, df1_dx / tau, df2_dx / tau);
+    }
+
+    let e = (-x).exp();
+    let f1 = (1.0 - e) / x;
+    let f2 = f1 - e;
+    let df1_dx = (e * (x + 1.0) - 1.0) / (x * x);
+    let df2_dx = df1_dx + e;
+    (f1, f2, df1_dx / tau, df2_dx / tau)
+}
+
+fn fit_nelson_siegel(x: &[f64], y: &[f64]) -> Result<[f64; 4], InterpolationError> {
+    validate_xy(x, y, 3)?;
+
+    let taus = logspace(0.05, 40.0, 80);
+    let mut best = None::<([f64; 4], f64)>;
+
+    for tau in taus {
+        let mut a = DMatrix::zeros(x.len(), 3);
+        for (i, t) in x.iter().enumerate() {
+            let (f1, f2, _, _) = ns_basis(*t, tau);
+            a[(i, 0)] = 1.0;
+            a[(i, 1)] = f1;
+            a[(i, 2)] = f2;
+        }
+
+        let yv = DVector::from_column_slice(y);
+        let Some(beta) = solve_least_squares(&a, &yv) else {
+            continue;
+        };
+
+        let residual = (&a * &beta - yv.clone()).norm_squared() / x.len() as f64;
+        let candidate = ([beta[0], beta[1], beta[2], tau], residual);
+        if best.as_ref().is_none_or(|(_, err)| residual < *err) {
+            best = Some(candidate);
+        }
+    }
+
+    best.map(|(p, _)| p)
+        .ok_or(InterpolationError::NonConvergence)
+}
+
+/// Nelson-Siegel parametric interpolator with least-squares calibration.
+#[derive(Debug, Clone)]
+pub struct NelsonSiegelInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    beta0: f64,
+    beta1: f64,
+    beta2: f64,
+    tau: f64,
+    extrapolation: ExtrapolationMode,
+}
+
+impl NelsonSiegelInterpolator {
+    pub fn fit(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        let [beta0, beta1, beta2, tau] = fit_nelson_siegel(&x, &y)?;
+        Ok(Self {
+            x,
+            y,
+            beta0,
+            beta1,
+            beta2,
+            tau,
+            extrapolation,
+        })
+    }
+
+    pub fn from_params(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        beta0: f64,
+        beta1: f64,
+        beta2: f64,
+        tau: f64,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 1)?;
+        if tau <= 0.0 {
+            return Err(InterpolationError::InvalidInput("tau must be > 0"));
+        }
+        Ok(Self {
+            x,
+            y,
+            beta0,
+            beta1,
+            beta2,
+            tau,
+            extrapolation,
+        })
+    }
+
+    fn model_value(&self, t: f64) -> f64 {
+        let (f1, f2, _, _) = ns_basis(t.max(1.0e-12), self.tau);
+        self.beta0 + self.beta1 * f1 + self.beta2 * f2
+    }
+
+    fn model_derivative(&self, t: f64) -> f64 {
+        let (_, _, df1, df2) = ns_basis(t.max(1.0e-12), self.tau);
+        self.beta1 * df1 + self.beta2 * df2
+    }
+
+    fn apply_mode_value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        if self.x.is_empty() {
+            return Ok(self.model_value(xq.max(1.0e-12)));
+        }
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_value(xq));
+        }
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_value(xb))
+            }
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_value(xb) + self.model_derivative(xb) * (xq - xb))
+            }
+        }
+    }
+
+    fn apply_mode_derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        if self.x.is_empty() {
+            return Ok(self.model_derivative(xq.max(1.0e-12)));
+        }
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_derivative(xq));
+        }
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => Ok(0.0),
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_derivative(xb))
+            }
+        }
+    }
+}
+
+impl Interpolator for NelsonSiegelInterpolator {
+    fn value(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_value(x)
+    }
+
+    fn derivative(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_derivative(x)
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            NelsonSiegelInterpolator::fit(self.x.clone(), yb.to_vec(), self.extrapolation)?
+                .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+fn nss_basis(t: f64, tau1: f64, tau2: f64) -> (f64, f64, f64, f64, f64, f64) {
+    let (f1, f2, df1, df2) = ns_basis(t, tau1);
+    let (_, f3, _, df3) = ns_basis(t, tau2);
+    (f1, f2, f3, df1, df2, df3)
+}
+
+fn fit_nss(x: &[f64], y: &[f64]) -> Result<[f64; 6], InterpolationError> {
+    validate_xy(x, y, 4)?;
+
+    let taus1 = logspace(0.05, 10.0, 28);
+    let taus2 = logspace(0.2, 50.0, 32);
+    let mut best = None::<([f64; 6], f64)>;
+
+    for tau1 in &taus1 {
+        for tau2 in &taus2 {
+            if tau2 <= tau1 {
+                continue;
+            }
+
+            let mut a = DMatrix::zeros(x.len(), 4);
+            for (i, t) in x.iter().enumerate() {
+                let (f1, f2, f3, _, _, _) = nss_basis(*t, *tau1, *tau2);
+                a[(i, 0)] = 1.0;
+                a[(i, 1)] = f1;
+                a[(i, 2)] = f2;
+                a[(i, 3)] = f3;
+            }
+
+            let yv = DVector::from_column_slice(y);
+            let Some(beta) = solve_least_squares(&a, &yv) else {
+                continue;
+            };
+
+            let residual = (&a * &beta - yv.clone()).norm_squared() / x.len() as f64;
+            let candidate = ([beta[0], beta[1], beta[2], beta[3], *tau1, *tau2], residual);
+            if best.as_ref().is_none_or(|(_, err)| residual < *err) {
+                best = Some(candidate);
+            }
+        }
+    }
+
+    best.map(|(p, _)| p)
+        .ok_or(InterpolationError::NonConvergence)
+}
+
+/// Nelson-Siegel-Svensson parametric interpolator.
+#[derive(Debug, Clone)]
+pub struct NelsonSiegelSvenssonInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    beta0: f64,
+    beta1: f64,
+    beta2: f64,
+    beta3: f64,
+    tau1: f64,
+    tau2: f64,
+    extrapolation: ExtrapolationMode,
+}
+
+impl NelsonSiegelSvenssonInterpolator {
+    pub fn fit(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        let [beta0, beta1, beta2, beta3, tau1, tau2] = fit_nss(&x, &y)?;
+        Ok(Self {
+            x,
+            y,
+            beta0,
+            beta1,
+            beta2,
+            beta3,
+            tau1,
+            tau2,
+            extrapolation,
+        })
+    }
+
+    fn model_value(&self, t: f64) -> f64 {
+        let (f1, f2, f3, _, _, _) = nss_basis(t.max(1.0e-12), self.tau1, self.tau2);
+        self.beta0 + self.beta1 * f1 + self.beta2 * f2 + self.beta3 * f3
+    }
+
+    fn model_derivative(&self, t: f64) -> f64 {
+        let (_, _, _, df1, df2, df3) = nss_basis(t.max(1.0e-12), self.tau1, self.tau2);
+        self.beta1 * df1 + self.beta2 * df2 + self.beta3 * df3
+    }
+
+    fn apply_mode_value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_value(xq));
+        }
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_value(xb))
+            }
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_value(xb) + self.model_derivative(xb) * (xq - xb))
+            }
+        }
+    }
+
+    fn apply_mode_derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_derivative(xq));
+        }
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => Ok(0.0),
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_derivative(xb))
+            }
+        }
+    }
+}
+
+impl Interpolator for NelsonSiegelSvenssonInterpolator {
+    fn value(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_value(x)
+    }
+
+    fn derivative(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_derivative(x)
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            NelsonSiegelSvenssonInterpolator::fit(self.x.clone(), yb.to_vec(), self.extrapolation)?
+                .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+fn smith_wilson_kernel(t: f64, u: f64, ufr: f64, alpha: f64) -> f64 {
+    let m = t.min(u);
+    let big_m = t.max(u);
+    let pref = (-ufr * (t + u)).exp();
+    let g = alpha * m - (-alpha * big_m).exp() * (alpha * m).sinh();
+    pref * g
+}
+
+fn smith_wilson_kernel_dt(t: f64, u: f64, ufr: f64, alpha: f64) -> f64 {
+    let m = t.min(u);
+    let big_m = t.max(u);
+    let pref = (-ufr * (t + u)).exp();
+
+    let g = alpha * m - (-alpha * big_m).exp() * (alpha * m).sinh();
+    let dg_dt = if t <= u {
+        alpha - alpha * (-alpha * u).exp() * (alpha * t).cosh()
+    } else {
+        alpha * (-alpha * t).exp() * (alpha * u).sinh()
+    };
+
+    pref * (dg_dt - ufr * g)
+}
+
+/// Smith-Wilson discount-factor interpolator (Solvency II style).
+#[derive(Debug, Clone)]
+pub struct SmithWilsonInterpolator {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    ufr: f64,
+    alpha: f64,
+    zeta: DVector<f64>,
+    extrapolation: ExtrapolationMode,
+}
+
+impl SmithWilsonInterpolator {
+    pub fn new(
+        x: Vec<f64>,
+        y: Vec<f64>,
+        ufr: f64,
+        alpha: f64,
+        extrapolation: ExtrapolationMode,
+    ) -> Result<Self, InterpolationError> {
+        validate_xy(&x, &y, 2)?;
+        validate_positive_y(&y)?;
+        if !ufr.is_finite() || !alpha.is_finite() || alpha <= 0.0 {
+            return Err(InterpolationError::InvalidInput(
+                "ufr must be finite and alpha > 0",
+            ));
+        }
+
+        let n = x.len();
+        let mut w = DMatrix::zeros(n, n);
+        for i in 0..n {
+            for j in 0..n {
+                w[(i, j)] = smith_wilson_kernel(x[i], x[j], ufr, alpha);
+            }
+        }
+
+        let m = DVector::from_column_slice(&y);
+        let mu: Vec<f64> = x.iter().map(|t| (-ufr * *t).exp()).collect();
+        let muv = DVector::from_column_slice(&mu);
+        let rhs = m - muv;
+
+        let Some(zeta) = w.lu().solve(&rhs) else {
+            return Err(InterpolationError::SingularSystem);
+        };
+
+        Ok(Self {
+            x,
+            y,
+            ufr,
+            alpha,
+            zeta,
+            extrapolation,
+        })
+    }
+
+    fn model_value(&self, t: f64) -> f64 {
+        let mu = (-self.ufr * t).exp();
+        let mut corr = 0.0;
+        for (i, u) in self.x.iter().enumerate() {
+            corr += self.zeta[i] * smith_wilson_kernel(t, *u, self.ufr, self.alpha);
+        }
+        (mu + corr).max(1.0e-14)
+    }
+
+    fn model_derivative(&self, t: f64) -> f64 {
+        let mu_dt = -self.ufr * (-self.ufr * t).exp();
+        let mut corr = 0.0;
+        for (i, u) in self.x.iter().enumerate() {
+            corr += self.zeta[i] * smith_wilson_kernel_dt(t, *u, self.ufr, self.alpha);
+        }
+        mu_dt + corr
+    }
+
+    fn apply_mode_value(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_value(xq));
+        }
+
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_value(xb))
+            }
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok((self.model_value(xb) + self.model_derivative(xb) * (xq - xb)).max(1.0e-14))
+            }
+        }
+    }
+
+    fn apply_mode_derivative(&self, xq: f64) -> Result<f64, InterpolationError> {
+        let x0 = self.x[0];
+        let x1 = self.x[self.x.len() - 1];
+        if (x0..=x1).contains(&xq) {
+            return Ok(self.model_derivative(xq));
+        }
+
+        match self.extrapolation {
+            ExtrapolationMode::Error => Err(InterpolationError::ExtrapolationDisabled),
+            ExtrapolationMode::Flat => Ok(0.0),
+            ExtrapolationMode::Linear => {
+                let xb = if xq < x0 { x0 } else { x1 };
+                Ok(self.model_derivative(xb))
+            }
+        }
+    }
+}
+
+impl Interpolator for SmithWilsonInterpolator {
+    fn value(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_value(x)
+    }
+
+    fn derivative(&self, x: f64) -> Result<f64, InterpolationError> {
+        self.apply_mode_derivative(x)
+    }
+
+    fn jacobian(&self, xq: f64) -> Result<Vec<f64>, InterpolationError> {
+        finite_difference_jacobian(&self.y, |yb| {
+            let mut yb_pos = yb.to_vec();
+            for v in &mut yb_pos {
+                *v = v.max(1.0e-12);
+            }
+            SmithWilsonInterpolator::new(
+                self.x.clone(),
+                yb_pos,
+                self.ufr,
+                self.alpha,
+                self.extrapolation,
+            )?
+            .value(xq)
+        })
+    }
+
+    fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    fn y(&self) -> &[f64] {
+        &self.y
+    }
+}
+
+/// Type-erased container for any supported interpolator.
+#[derive(Debug, Clone)]
+pub enum AnyInterpolator {
+    Linear(LinearInterpolator),
+    LogLinear(LogLinearInterpolator),
+    MonotoneConvex(MonotoneConvexInterpolator),
+    TensionSpline(TensionSplineInterpolator),
+    HermiteMonotone(HermiteMonotoneInterpolator),
+    LogCubicMonotone(LogCubicMonotoneInterpolator),
+    NelsonSiegel(NelsonSiegelInterpolator),
+    NelsonSiegelSvensson(NelsonSiegelSvenssonInterpolator),
+    SmithWilson(SmithWilsonInterpolator),
+}
+
+impl Interpolator for AnyInterpolator {
+    fn value(&self, x: f64) -> Result<f64, InterpolationError> {
+        match self {
+            AnyInterpolator::Linear(v) => v.value(x),
+            AnyInterpolator::LogLinear(v) => v.value(x),
+            AnyInterpolator::MonotoneConvex(v) => v.value(x),
+            AnyInterpolator::TensionSpline(v) => v.value(x),
+            AnyInterpolator::HermiteMonotone(v) => v.value(x),
+            AnyInterpolator::LogCubicMonotone(v) => v.value(x),
+            AnyInterpolator::NelsonSiegel(v) => v.value(x),
+            AnyInterpolator::NelsonSiegelSvensson(v) => v.value(x),
+            AnyInterpolator::SmithWilson(v) => v.value(x),
+        }
+    }
+
+    fn derivative(&self, x: f64) -> Result<f64, InterpolationError> {
+        match self {
+            AnyInterpolator::Linear(v) => v.derivative(x),
+            AnyInterpolator::LogLinear(v) => v.derivative(x),
+            AnyInterpolator::MonotoneConvex(v) => v.derivative(x),
+            AnyInterpolator::TensionSpline(v) => v.derivative(x),
+            AnyInterpolator::HermiteMonotone(v) => v.derivative(x),
+            AnyInterpolator::LogCubicMonotone(v) => v.derivative(x),
+            AnyInterpolator::NelsonSiegel(v) => v.derivative(x),
+            AnyInterpolator::NelsonSiegelSvensson(v) => v.derivative(x),
+            AnyInterpolator::SmithWilson(v) => v.derivative(x),
+        }
+    }
+
+    fn jacobian(&self, x: f64) -> Result<Vec<f64>, InterpolationError> {
+        match self {
+            AnyInterpolator::Linear(v) => v.jacobian(x),
+            AnyInterpolator::LogLinear(v) => v.jacobian(x),
+            AnyInterpolator::MonotoneConvex(v) => v.jacobian(x),
+            AnyInterpolator::TensionSpline(v) => v.jacobian(x),
+            AnyInterpolator::HermiteMonotone(v) => v.jacobian(x),
+            AnyInterpolator::LogCubicMonotone(v) => v.jacobian(x),
+            AnyInterpolator::NelsonSiegel(v) => v.jacobian(x),
+            AnyInterpolator::NelsonSiegelSvensson(v) => v.jacobian(x),
+            AnyInterpolator::SmithWilson(v) => v.jacobian(x),
+        }
+    }
+
+    fn x(&self) -> &[f64] {
+        match self {
+            AnyInterpolator::Linear(v) => v.x(),
+            AnyInterpolator::LogLinear(v) => v.x(),
+            AnyInterpolator::MonotoneConvex(v) => v.x(),
+            AnyInterpolator::TensionSpline(v) => v.x(),
+            AnyInterpolator::HermiteMonotone(v) => v.x(),
+            AnyInterpolator::LogCubicMonotone(v) => v.x(),
+            AnyInterpolator::NelsonSiegel(v) => v.x(),
+            AnyInterpolator::NelsonSiegelSvensson(v) => v.x(),
+            AnyInterpolator::SmithWilson(v) => v.x(),
+        }
+    }
+
+    fn y(&self) -> &[f64] {
+        match self {
+            AnyInterpolator::Linear(v) => v.y(),
+            AnyInterpolator::LogLinear(v) => v.y(),
+            AnyInterpolator::MonotoneConvex(v) => v.y(),
+            AnyInterpolator::TensionSpline(v) => v.y(),
+            AnyInterpolator::HermiteMonotone(v) => v.y(),
+            AnyInterpolator::LogCubicMonotone(v) => v.y(),
+            AnyInterpolator::NelsonSiegel(v) => v.y(),
+            AnyInterpolator::NelsonSiegelSvensson(v) => v.y(),
+            AnyInterpolator::SmithWilson(v) => v.y(),
+        }
+    }
+}
+
+fn logspace(low: f64, high: f64, n: usize) -> Vec<f64> {
+    let l0 = low.ln();
+    let l1 = high.ln();
+    (0..n)
+        .map(|i| {
+            let u = if n <= 1 {
+                0.0
+            } else {
+                i as f64 / (n as f64 - 1.0)
+            };
+            (l0 + u * (l1 - l0)).exp()
+        })
+        .collect()
+}
+
+fn solve_least_squares(a: &DMatrix<f64>, y: &DVector<f64>) -> Option<DVector<f64>> {
+    let at = a.transpose();
+    let ata = &at * a;
+    let aty = at * y;
+    ata.lu().solve(&aty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn linear_jacobian_matches_weights() {
+        let itp = LinearInterpolator::new(
+            vec![1.0, 2.0, 4.0],
+            vec![0.01, 0.02, 0.04],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+
+        let y = itp.value(1.5).unwrap();
+        assert_relative_eq!(y, 0.015, epsilon = 1e-12);
+
+        let j = itp.jacobian(1.5).unwrap();
+        assert_relative_eq!(j[0], 0.5, epsilon = 1e-12);
+        assert_relative_eq!(j[1], 0.5, epsilon = 1e-12);
+        assert_relative_eq!(j[2], 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn log_linear_positive_and_smooth() {
+        let itp = LogLinearInterpolator::new(
+            vec![1.0, 2.0, 4.0],
+            vec![0.99, 0.95, 0.87],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+
+        assert!(itp.value(3.0).unwrap() > 0.0);
+        assert!(itp.derivative(3.0).unwrap() < 0.0);
+    }
+
+    #[test]
+    fn monotone_convex_stays_within_neighbor_bounds_on_monotone_data() {
+        let x = vec![1.0, 2.0, 3.0, 5.0, 7.0];
+        let y = vec![0.01, 0.012, 0.013, 0.016, 0.018];
+        let itp = MonotoneConvexInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Linear)
+            .unwrap();
+
+        for w in x.windows(2) {
+            let mid = 0.5 * (w[0] + w[1]);
+            let v = itp.value(mid).unwrap();
+            let i = x.partition_point(|z| *z < mid).saturating_sub(1);
+            assert!(v >= y[i].min(y[i + 1]) - 1.0e-12);
+            assert!(v <= y[i].max(y[i + 1]) + 1.0e-12);
+        }
+    }
+
+    #[test]
+    fn hermite_monotone_preserves_shape_for_monotone_series() {
+        let itp = HermiteMonotoneInterpolator::new(
+            vec![0.5, 1.0, 2.0, 5.0],
+            vec![0.02, 0.021, 0.025, 0.029],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+
+        let mut prev = itp.value(0.5).unwrap();
+        for i in 1..40 {
+            let t = 0.5 + (4.5 * i as f64) / 40.0;
+            let v = itp.value(t).unwrap();
+            assert!(v >= prev - 1.0e-12);
+            prev = v;
+        }
+    }
+
+    #[test]
+    fn tension_spline_interpolates_nodes() {
+        let x = vec![0.5, 1.0, 2.0, 3.0];
+        let y = vec![0.015, 0.017, 0.019, 0.021];
+        let itp =
+            TensionSplineInterpolator::new(x.clone(), y.clone(), 0.3, ExtrapolationMode::Flat)
+                .unwrap();
+
+        for (xi, yi) in x.iter().zip(y.iter()) {
+            assert_relative_eq!(itp.value(*xi).unwrap(), *yi, epsilon = 1e-12);
+        }
+    }
+
+    #[test]
+    fn log_cubic_stays_positive() {
+        let itp = LogCubicMonotoneInterpolator::new(
+            vec![1.0, 2.0, 5.0, 10.0],
+            vec![0.99, 0.96, 0.87, 0.71],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+
+        for t in [0.5, 1.5, 3.0, 7.0, 12.0] {
+            assert!(itp.value(t).unwrap() > 0.0);
+        }
+    }
+
+    #[test]
+    fn nelson_siegel_fit_retrieves_curve_within_one_bp() {
+        let x = vec![0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 20.0, 30.0];
+        let beta0 = 0.022;
+        let beta1 = -0.014;
+        let beta2 = 0.018;
+        let tau = 1.8;
+
+        let y: Vec<f64> = x
+            .iter()
+            .map(|t| {
+                let (f1, f2, _, _) = ns_basis(*t, tau);
+                beta0 + beta1 * f1 + beta2 * f2
+            })
+            .collect();
+
+        let fit =
+            NelsonSiegelInterpolator::fit(x.clone(), y.clone(), ExtrapolationMode::Linear).unwrap();
+        for (ti, yi) in x.iter().zip(y.iter()) {
+            let err_bp = (fit.value(*ti).unwrap() - yi) * 1.0e4;
+            assert!(err_bp.abs() < 1.0);
+        }
+    }
+
+    #[test]
+    fn nss_fit_retrieves_curve_within_two_bp() {
+        let x = vec![0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 20.0, 30.0];
+        let beta0 = 0.021;
+        let beta1 = -0.011;
+        let beta2 = 0.015;
+        let beta3 = 0.006;
+        let tau1 = 1.6;
+        let tau2 = 8.0;
+
+        let y: Vec<f64> = x
+            .iter()
+            .map(|t| {
+                let (f1, f2, f3, _, _, _) = nss_basis(*t, tau1, tau2);
+                beta0 + beta1 * f1 + beta2 * f2 + beta3 * f3
+            })
+            .collect();
+
+        let fit =
+            NelsonSiegelSvenssonInterpolator::fit(x.clone(), y.clone(), ExtrapolationMode::Linear)
+                .unwrap();
+
+        for (ti, yi) in x.iter().zip(y.iter()) {
+            let err_bp = (fit.value(*ti).unwrap() - yi) * 1.0e4;
+            assert!(err_bp.abs() < 2.0);
+        }
+    }
+
+    #[test]
+    fn smith_wilson_matches_pillars() {
+        let x = vec![1.0, 2.0, 5.0, 10.0, 20.0];
+        let y = vec![0.99, 0.965, 0.90, 0.80, 0.64];
+        let sw = SmithWilsonInterpolator::new(
+            x.clone(),
+            y.clone(),
+            0.032,
+            0.12,
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+
+        for (t, df) in x.iter().zip(y.iter()) {
+            assert_relative_eq!(sw.value(*t).unwrap(), *df, epsilon = 1e-10);
+        }
+    }
+
+    #[test]
+    fn extrapolation_error_mode_rejects_outside() {
+        let itp =
+            LinearInterpolator::new(vec![1.0, 2.0], vec![0.01, 0.02], ExtrapolationMode::Error)
+                .unwrap();
+
+        assert!(matches!(
+            itp.value(0.5),
+            Err(InterpolationError::ExtrapolationDisabled)
+        ));
+        assert!(matches!(
+            itp.value(3.0),
+            Err(InterpolationError::ExtrapolationDisabled)
+        ));
+    }
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -14,6 +14,7 @@ pub mod fast_norm;
 pub mod fast_rng;
 pub mod functions;
 pub mod gamma;
+pub mod interpolation;
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 pub mod simd_math;
 #[cfg(all(feature = "simd", target_arch = "aarch64"))]
@@ -26,4 +27,5 @@ pub use fast_norm::{
 };
 pub use fast_rng::{FastRng, FastRngKind};
 pub use functions::*;
+pub use interpolation::*;
 pub use sobol::SobolSequence;

--- a/src/rates/mod.rs
+++ b/src/rates/mod.rs
@@ -52,4 +52,6 @@ pub use ois::{BasisSwap, OvernightIndexSwap};
 pub use swap::{InterestRateSwap, SwapBuilder};
 pub use swaption::Swaption;
 pub use xccy_swap::XccySwap;
-pub use yield_curve::{YieldCurve, YieldCurveBuilder};
+pub use yield_curve::{
+    YieldCurve, YieldCurveBuilder, YieldCurveInterpolationMethod, YieldCurveInterpolationSettings,
+};

--- a/src/rates/yield_curve.rs
+++ b/src/rates/yield_curve.rs
@@ -1,14 +1,75 @@
-//! Module `rates::yield_curve`.
+//! Yield-curve construction and interpolation.
 //!
-//! Implements yield curve abstractions and re-exports used by adjacent pricing/model modules.
+//! The default behavior remains log-linear interpolation on discount factors,
+//! but this module also supports production methods used by rates desks,
+//! including monotone-convex, shape-preserving cubic variants, and parametric
+//! families.
 //!
-//! References: Hull (11th ed.) Ch. 4, 6, and 7; Brigo and Mercurio (2006), curve and accrual identities around Eq. (4.2) and Eq. (7.1).
-//!
-//! Key types and purpose: `YieldCurve`, `YieldCurveBuilder` define the core data contracts for this module.
-//!
-//! Numerical considerations: interpolation/extrapolation and day-count conventions materially affect PVs; handle near-zero rates/hazards to avoid cancellation.
-//!
-//! When to use: use this module for curve, accrual, and vanilla rates analytics; move to HJM/LMM or full XVA stacks for stochastic-rate or counterparty-intensive use cases.
+//! References:
+//! - Hagan and West (2006), *Interpolation Methods for Curve Construction*.
+//! - Nelson and Siegel (1987); Svensson (1994).
+//! - EIOPA Smith-Wilson technical specification (Solvency II).
+
+use crate::math::interpolation::{
+    AnyInterpolator, ExtrapolationMode, HermiteMonotoneInterpolator, InterpolationError,
+    Interpolator, LinearInterpolator, LogCubicMonotoneInterpolator, LogLinearInterpolator,
+    MonotoneConvexInterpolator, NelsonSiegelInterpolator, NelsonSiegelSvenssonInterpolator,
+    SmithWilsonInterpolator, TensionSplineInterpolator,
+};
+
+/// Interpolation method used to convert input nodes into a full curve.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum YieldCurveInterpolationMethod {
+    /// Log-linear interpolation on discount factors.
+    LogLinearDiscount,
+    /// Piecewise-linear interpolation on continuously-compounded zero rates.
+    LinearZeroRate,
+    /// Hagan-West inspired monotone-convex cubic interpolation on zero rates.
+    MonotoneConvex,
+    /// Cardinal tension spline on zero rates.
+    TensionSpline { tension: f64 },
+    /// Monotone cubic Hermite interpolation on zero rates.
+    HermiteMonotone,
+    /// Monotone cubic interpolation on `ln(df)` values.
+    LogCubicMonotone,
+    /// Nelson-Siegel parametric fit on zero rates.
+    NelsonSiegel,
+    /// Nelson-Siegel-Svensson parametric fit on zero rates.
+    NelsonSiegelSvensson,
+    /// Smith-Wilson discount-factor fit.
+    SmithWilson { ufr: f64, alpha: f64 },
+}
+
+/// Interpolation configuration for [`YieldCurve`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct YieldCurveInterpolationSettings {
+    pub method: YieldCurveInterpolationMethod,
+    pub extrapolation: ExtrapolationMode,
+}
+
+impl Default for YieldCurveInterpolationSettings {
+    fn default() -> Self {
+        Self {
+            method: YieldCurveInterpolationMethod::LogLinearDiscount,
+            extrapolation: ExtrapolationMode::Linear,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InterpolatedQuantity {
+    DiscountFactor,
+    ZeroRate,
+}
+
+#[derive(Debug, Clone)]
+struct InterpolationState {
+    interpolator: AnyInterpolator,
+    quantity: InterpolatedQuantity,
+    has_origin_node: bool,
+    origin_linked_to_first_input: bool,
+}
+
 /// Discount-factor term structure keyed by maturity tenor in years.
 ///
 /// # Examples
@@ -18,46 +79,230 @@
 /// let yc = YieldCurve::new(vec![(0.5, 0.98), (1.0, 0.95)]);
 /// assert!(yc.discount_factor(0.75) < 1.0);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct YieldCurve {
     /// Curve nodes as `(tenor, discount_factor)`.
     pub tenors: Vec<(f64, f64)>,
+    interpolation: YieldCurveInterpolationSettings,
+    interpolation_state: Option<InterpolationState>,
+}
+
+impl PartialEq for YieldCurve {
+    fn eq(&self, other: &Self) -> bool {
+        self.tenors == other.tenors && self.interpolation == other.interpolation
+    }
 }
 
 impl YieldCurve {
-    /// Creates a curve from unsorted discount-factor nodes.
-    pub fn new(mut tenors: Vec<(f64, f64)>) -> Self {
-        tenors.retain(|(t, df)| *t > 0.0 && *df > 0.0);
-        tenors.sort_by(|a, b| a.0.total_cmp(&b.0));
-        Self { tenors }
+    /// Creates a curve from unsorted discount-factor nodes using default interpolation
+    /// (`log-linear discount`, `linear` extrapolation).
+    pub fn new(tenors: Vec<(f64, f64)>) -> Self {
+        Self::new_with_settings(tenors, YieldCurveInterpolationSettings::default())
+            .unwrap_or_else(|_| Self::empty())
     }
 
-    /// Returns discount factor at tenor `t` using log-linear interpolation.
+    /// Creates a curve with explicit interpolation settings.
+    pub fn new_with_settings(
+        tenors: Vec<(f64, f64)>,
+        settings: YieldCurveInterpolationSettings,
+    ) -> Result<Self, InterpolationError> {
+        let cleaned = sanitize_curve_nodes(tenors);
+        let interpolation_state = build_interpolation_state(&cleaned, settings)?;
+
+        Ok(Self {
+            tenors: cleaned,
+            interpolation: settings,
+            interpolation_state,
+        })
+    }
+
+    fn empty() -> Self {
+        Self {
+            tenors: Vec::new(),
+            interpolation: YieldCurveInterpolationSettings::default(),
+            interpolation_state: None,
+        }
+    }
+
+    /// Returns active interpolation settings.
+    pub fn interpolation_settings(&self) -> YieldCurveInterpolationSettings {
+        self.interpolation
+    }
+
+    /// Returns discount factor at tenor `t`.
+    ///
+    /// If extrapolation mode is `Error`, prefer `try_discount_factor` to receive
+    /// explicit errors. This method returns `NaN` on extrapolation failures.
     pub fn discount_factor(&self, t: f64) -> f64 {
-        discount_factor_from_points(&self.tenors, t)
+        self.try_discount_factor(t).unwrap_or(f64::NAN)
+    }
+
+    /// Returns discount factor at tenor `t` with explicit error handling.
+    pub fn try_discount_factor(&self, t: f64) -> Result<f64, InterpolationError> {
+        if t <= 0.0 {
+            return Ok(1.0);
+        }
+        if self.tenors.is_empty() {
+            return Ok(1.0);
+        }
+
+        let Some(state) = &self.interpolation_state else {
+            return Ok(discount_factor_one_point(
+                self.tenors[0].0,
+                self.tenors[0].1,
+                t,
+                self.interpolation.extrapolation,
+            ));
+        };
+
+        let raw = state.interpolator.value(t)?;
+        let df = match state.quantity {
+            InterpolatedQuantity::DiscountFactor => raw,
+            InterpolatedQuantity::ZeroRate => (-raw * t).exp(),
+        };
+        Ok(df.max(1.0e-14))
     }
 
     /// Returns continuously-compounded zero rate at tenor `t`.
     pub fn zero_rate(&self, t: f64) -> f64 {
+        self.try_zero_rate(t).unwrap_or(f64::NAN)
+    }
+
+    /// Returns continuously-compounded zero rate at tenor `t` with explicit errors.
+    pub fn try_zero_rate(&self, t: f64) -> Result<f64, InterpolationError> {
         if t <= 0.0 {
-            return 0.0;
+            return Ok(0.0);
         }
-        -self.discount_factor(t).ln() / t
+
+        let Some(state) = &self.interpolation_state else {
+            return Ok(-discount_factor_one_point(
+                self.tenors[0].0,
+                self.tenors[0].1,
+                t,
+                self.interpolation.extrapolation,
+            )
+            .ln()
+                / t);
+        };
+
+        match state.quantity {
+            InterpolatedQuantity::ZeroRate => state.interpolator.value(t),
+            InterpolatedQuantity::DiscountFactor => {
+                let df = state.interpolator.value(t)?;
+                Ok(-df.max(1.0e-14).ln() / t)
+            }
+        }
     }
 
     /// Returns continuously-compounded forward rate between `t1` and `t2`.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use openferric::rates::YieldCurve;
-    ///
-    /// let yc = YieldCurve::new(vec![(1.0, 0.95), (2.0, 0.90)]);
-    /// let fwd = yc.forward_rate(1.0, 2.0);
-    /// assert!(fwd > 0.0);
-    /// ```
     pub fn forward_rate(&self, t1: f64, t2: f64) -> f64 {
+        self.try_forward_rate(t1, t2).unwrap_or(f64::NAN)
+    }
+
+    /// Returns continuously-compounded forward rate between `t1` and `t2`
+    /// with explicit interpolation errors.
+    pub fn try_forward_rate(&self, t1: f64, t2: f64) -> Result<f64, InterpolationError> {
         assert!(t2 > t1, "t2 must be greater than t1");
-        (self.discount_factor(t1) / self.discount_factor(t2)).ln() / (t2 - t1)
+        let df1 = self.try_discount_factor(t1)?;
+        let df2 = self.try_discount_factor(t2)?;
+        Ok((df1 / df2).ln() / (t2 - t1))
+    }
+
+    /// Instantaneous forward rate `f(t) = -d/dt ln(P(t))`.
+    pub fn instantaneous_forward_rate(&self, t: f64) -> f64 {
+        self.try_instantaneous_forward_rate(t).unwrap_or(f64::NAN)
+    }
+
+    /// Instantaneous forward rate with explicit interpolation errors.
+    pub fn try_instantaneous_forward_rate(&self, t: f64) -> Result<f64, InterpolationError> {
+        if t <= 0.0 {
+            return Ok(self.try_zero_rate(1.0e-8)?);
+        }
+
+        let Some(state) = &self.interpolation_state else {
+            return Ok(self.try_zero_rate(t)?);
+        };
+
+        match state.quantity {
+            InterpolatedQuantity::DiscountFactor => {
+                let p = state.interpolator.value(t)?;
+                let dp = state.interpolator.derivative(t)?;
+                Ok(-(dp / p.max(1.0e-14)))
+            }
+            InterpolatedQuantity::ZeroRate => {
+                let z = state.interpolator.value(t)?;
+                let dz = state.interpolator.derivative(t)?;
+                Ok(z + t * dz)
+            }
+        }
+    }
+
+    /// Jacobian of discount factor wrt input pillar discount factors.
+    pub fn discount_factor_jacobian(&self, t: f64) -> Result<Vec<f64>, InterpolationError> {
+        if self.tenors.is_empty() {
+            return Ok(Vec::new());
+        }
+        if t <= 0.0 {
+            return Ok(vec![0.0; self.tenors.len()]);
+        }
+
+        let Some(state) = &self.interpolation_state else {
+            return Ok(vec![0.0; self.tenors.len()]);
+        };
+
+        let raw_j = state.interpolator.jacobian(t)?;
+        let j_no_origin = map_jacobian_from_interpolator(raw_j, state, self.tenors.len());
+
+        match state.quantity {
+            InterpolatedQuantity::DiscountFactor => Ok(j_no_origin),
+            InterpolatedQuantity::ZeroRate => {
+                let z = state.interpolator.value(t)?;
+                let df = (-z * t).exp();
+                let mut out = vec![0.0; self.tenors.len()];
+                for i in 0..self.tenors.len() {
+                    let ti = self.tenors[i].0;
+                    let dzi_ddfi = -1.0 / (ti * self.tenors[i].1.max(1.0e-14));
+                    out[i] = -t * df * j_no_origin[i] * dzi_ddfi;
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    /// Jacobian of zero rate wrt input pillar discount factors.
+    pub fn zero_rate_jacobian(&self, t: f64) -> Result<Vec<f64>, InterpolationError> {
+        if self.tenors.is_empty() {
+            return Ok(Vec::new());
+        }
+        if t <= 0.0 {
+            return Ok(vec![0.0; self.tenors.len()]);
+        }
+
+        let Some(state) = &self.interpolation_state else {
+            return Ok(vec![0.0; self.tenors.len()]);
+        };
+
+        let raw_j = state.interpolator.jacobian(t)?;
+        let j_no_origin = map_jacobian_from_interpolator(raw_j, state, self.tenors.len());
+
+        match state.quantity {
+            InterpolatedQuantity::DiscountFactor => {
+                let p = state.interpolator.value(t)?.max(1.0e-14);
+                Ok(j_no_origin
+                    .iter()
+                    .map(|dpi| -(dpi / (t * p)))
+                    .collect::<Vec<_>>())
+            }
+            InterpolatedQuantity::ZeroRate => {
+                let mut out = vec![0.0; self.tenors.len()];
+                for i in 0..self.tenors.len() {
+                    let ti = self.tenors[i].0;
+                    let dzi_ddfi = -1.0 / (ti * self.tenors[i].1.max(1.0e-14));
+                    out[i] = j_no_origin[i] * dzi_ddfi;
+                }
+                Ok(out)
+            }
+        }
     }
 }
 
@@ -67,16 +312,39 @@ pub struct YieldCurveBuilder;
 impl YieldCurveBuilder {
     /// Builds a curve from simple deposit rates `(tenor, rate)`.
     pub fn from_deposits(deposits: &[(f64, f64)]) -> YieldCurve {
+        Self::from_deposits_with_settings(deposits, YieldCurveInterpolationSettings::default())
+            .unwrap_or_else(|_| YieldCurve::empty())
+    }
+
+    /// Builds a curve from simple deposit rates with explicit interpolation.
+    pub fn from_deposits_with_settings(
+        deposits: &[(f64, f64)],
+        settings: YieldCurveInterpolationSettings,
+    ) -> Result<YieldCurve, InterpolationError> {
         let points = deposits
             .iter()
             .filter(|(tenor, _)| *tenor > 0.0)
             .map(|(tenor, rate)| (*tenor, 1.0 / (1.0 + rate * tenor)))
             .collect();
-        YieldCurve::new(points)
+        YieldCurve::new_with_settings(points, settings)
     }
 
     /// Bootstraps discount factors from par swap rates `(tenor, fixed_rate)`.
     pub fn from_swap_rates(swap_rates: &[(f64, f64)], frequency: usize) -> YieldCurve {
+        Self::from_swap_rates_with_settings(
+            swap_rates,
+            frequency,
+            YieldCurveInterpolationSettings::default(),
+        )
+        .unwrap_or_else(|_| YieldCurve::empty())
+    }
+
+    /// Bootstraps discount factors from par swap rates with explicit interpolation.
+    pub fn from_swap_rates_with_settings(
+        swap_rates: &[(f64, f64)],
+        frequency: usize,
+        settings: YieldCurveInterpolationSettings,
+    ) -> Result<YieldCurve, InterpolationError> {
         assert!(frequency > 0, "frequency must be > 0");
 
         let mut sorted = swap_rates.to_vec();
@@ -100,7 +368,7 @@ impl YieldCurveBuilder {
             let mut pv_coupons = 0.0;
             for i in 1..periods {
                 let ti = i as f64 * dt;
-                pv_coupons += coupon * discount_factor_from_points(&points, ti);
+                pv_coupons += coupon * discount_factor_from_points(&points, ti, settings)?;
             }
 
             let mut df = (1.0 - pv_coupons) / (1.0 + coupon);
@@ -111,46 +379,390 @@ impl YieldCurveBuilder {
             points.sort_by(|a, b| a.0.total_cmp(&b.0));
         }
 
-        YieldCurve::new(points)
+        YieldCurve::new_with_settings(points, settings)
     }
 }
 
-fn discount_factor_from_points(points: &[(f64, f64)], t: f64) -> f64 {
+fn sanitize_curve_nodes(mut tenors: Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    tenors.retain(|(t, df)| *t > 0.0 && *df > 0.0 && t.is_finite() && df.is_finite());
+    tenors.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut out: Vec<(f64, f64)> = Vec::with_capacity(tenors.len());
+    for (t, df) in tenors {
+        if let Some(last) = out.last_mut()
+            && (last.0 - t).abs() <= 1.0e-12
+        {
+            last.1 = df.max(1.0e-14);
+            continue;
+        }
+        out.push((t, df.max(1.0e-14)));
+    }
+    out
+}
+
+fn build_interpolation_state(
+    tenors: &[(f64, f64)],
+    settings: YieldCurveInterpolationSettings,
+) -> Result<Option<InterpolationState>, InterpolationError> {
+    if tenors.is_empty() {
+        return Ok(None);
+    }
+
+    let base_x_df: Vec<f64> = tenors.iter().map(|(t, _)| *t).collect();
+    let base_y_df: Vec<f64> = tenors.iter().map(|(_, df)| *df).collect();
+    let base_x_zero = base_x_df.clone();
+    let base_y_zero: Vec<f64> = tenors
+        .iter()
+        .map(|(t, df)| -df.ln() / *t)
+        .collect::<Vec<_>>();
+
+    let needs_origin = base_x_df[0] > 0.0;
+
+    let with_df_origin = || {
+        if !needs_origin {
+            return (base_x_df.clone(), base_y_df.clone(), false, false);
+        }
+        let mut x = base_x_df.clone();
+        let mut y = base_y_df.clone();
+        x.insert(0, 0.0);
+        y.insert(0, 1.0);
+        (x, y, true, false)
+    };
+
+    let with_zero_origin = || {
+        if !needs_origin {
+            return (base_x_zero.clone(), base_y_zero.clone(), false, false);
+        }
+        let mut x = base_x_zero.clone();
+        let mut y = base_y_zero.clone();
+        x.insert(0, 0.0);
+        y.insert(0, base_y_zero[0]);
+        (x, y, true, true)
+    };
+
+    let (interpolator, quantity, has_origin_node, origin_linked_to_first_input) = match settings
+        .method
+    {
+        YieldCurveInterpolationMethod::LogLinearDiscount => {
+            let (x, y, has_origin, origin_link) = with_df_origin();
+            (
+                AnyInterpolator::LogLinear(LogLinearInterpolator::new(
+                    x,
+                    y,
+                    settings.extrapolation,
+                )?),
+                InterpolatedQuantity::DiscountFactor,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::LinearZeroRate => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            (
+                AnyInterpolator::Linear(LinearInterpolator::new(x, y, settings.extrapolation)?),
+                InterpolatedQuantity::ZeroRate,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::MonotoneConvex => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            (
+                AnyInterpolator::MonotoneConvex(MonotoneConvexInterpolator::new(
+                    x,
+                    y,
+                    settings.extrapolation,
+                )?),
+                InterpolatedQuantity::ZeroRate,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::TensionSpline { tension } => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            (
+                AnyInterpolator::TensionSpline(TensionSplineInterpolator::new(
+                    x,
+                    y,
+                    tension,
+                    settings.extrapolation,
+                )?),
+                InterpolatedQuantity::ZeroRate,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::HermiteMonotone => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            (
+                AnyInterpolator::HermiteMonotone(HermiteMonotoneInterpolator::new(
+                    x,
+                    y,
+                    settings.extrapolation,
+                )?),
+                InterpolatedQuantity::ZeroRate,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::LogCubicMonotone => {
+            let (x, y, has_origin, origin_link) = with_df_origin();
+            (
+                AnyInterpolator::LogCubicMonotone(LogCubicMonotoneInterpolator::new(
+                    x,
+                    y,
+                    settings.extrapolation,
+                )?),
+                InterpolatedQuantity::DiscountFactor,
+                has_origin,
+                origin_link,
+            )
+        }
+        YieldCurveInterpolationMethod::NelsonSiegel => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            if x.len() < 3 {
+                (
+                    AnyInterpolator::Linear(LinearInterpolator::new(x, y, settings.extrapolation)?),
+                    InterpolatedQuantity::ZeroRate,
+                    has_origin,
+                    origin_link,
+                )
+            } else {
+                (
+                    AnyInterpolator::NelsonSiegel(NelsonSiegelInterpolator::fit(
+                        x,
+                        y,
+                        settings.extrapolation,
+                    )?),
+                    InterpolatedQuantity::ZeroRate,
+                    has_origin,
+                    origin_link,
+                )
+            }
+        }
+        YieldCurveInterpolationMethod::NelsonSiegelSvensson => {
+            let (x, y, has_origin, origin_link) = with_zero_origin();
+            if x.len() < 4 {
+                (
+                    AnyInterpolator::NelsonSiegel(NelsonSiegelInterpolator::fit(
+                        x,
+                        y,
+                        settings.extrapolation,
+                    )?),
+                    InterpolatedQuantity::ZeroRate,
+                    has_origin,
+                    origin_link,
+                )
+            } else {
+                (
+                    AnyInterpolator::NelsonSiegelSvensson(NelsonSiegelSvenssonInterpolator::fit(
+                        x,
+                        y,
+                        settings.extrapolation,
+                    )?),
+                    InterpolatedQuantity::ZeroRate,
+                    has_origin,
+                    origin_link,
+                )
+            }
+        }
+        YieldCurveInterpolationMethod::SmithWilson { ufr, alpha } => {
+            if base_x_df.len() < 2 {
+                (
+                    AnyInterpolator::LogLinear(LogLinearInterpolator::new(
+                        base_x_df.clone(),
+                        base_y_df.clone(),
+                        settings.extrapolation,
+                    )?),
+                    InterpolatedQuantity::DiscountFactor,
+                    false,
+                    false,
+                )
+            } else {
+                (
+                    AnyInterpolator::SmithWilson(SmithWilsonInterpolator::new(
+                        base_x_df.clone(),
+                        base_y_df.clone(),
+                        ufr,
+                        alpha,
+                        settings.extrapolation,
+                    )?),
+                    InterpolatedQuantity::DiscountFactor,
+                    false,
+                    false,
+                )
+            }
+        }
+    };
+
+    Ok(Some(InterpolationState {
+        interpolator,
+        quantity,
+        has_origin_node,
+        origin_linked_to_first_input,
+    }))
+}
+
+fn map_jacobian_from_interpolator(
+    jacobian: Vec<f64>,
+    state: &InterpolationState,
+    n_inputs: usize,
+) -> Vec<f64> {
+    if !state.has_origin_node {
+        return jacobian;
+    }
+
+    if state.origin_linked_to_first_input {
+        let mut out = vec![0.0; n_inputs];
+        if !jacobian.is_empty() {
+            out[0] += jacobian[0];
+        }
+        for i in 0..n_inputs {
+            if i + 1 < jacobian.len() {
+                out[i] += jacobian[i + 1];
+            }
+        }
+        out
+    } else {
+        jacobian.into_iter().skip(1).take(n_inputs).collect()
+    }
+}
+
+fn discount_factor_one_point(t1: f64, df1: f64, t: f64, extrapolation: ExtrapolationMode) -> f64 {
     if t <= 0.0 {
         return 1.0;
     }
-    if points.is_empty() {
-        return 1.0;
+    let z1 = -df1.ln() / t1;
+    match extrapolation {
+        ExtrapolationMode::Flat => {
+            if t <= t1 {
+                (-z1 * t).exp()
+            } else {
+                df1
+            }
+        }
+        ExtrapolationMode::Linear | ExtrapolationMode::Error => (-z1 * t).exp(),
     }
+}
 
-    let first = points[0];
-    if t <= first.0 {
-        return log_linear_df(0.0, 1.0, first.0, first.1, t);
+fn discount_factor_from_points(
+    points: &[(f64, f64)],
+    t: f64,
+    settings: YieldCurveInterpolationSettings,
+) -> Result<f64, InterpolationError> {
+    if t <= 0.0 || points.is_empty() {
+        return Ok(1.0);
     }
+    let curve = YieldCurve::new_with_settings(points.to_vec(), settings)?;
+    curve.try_discount_factor(t)
+}
 
-    for window in points.windows(2) {
-        let left = window[0];
-        let right = window[1];
-        if t <= right.0 {
-            return log_linear_df(left.0, left.1, right.0, right.1, t);
+#[cfg(test)]
+mod tests {
+    use approx::assert_relative_eq;
+
+    use super::*;
+
+    fn settings(method: YieldCurveInterpolationMethod) -> YieldCurveInterpolationSettings {
+        YieldCurveInterpolationSettings {
+            method,
+            extrapolation: ExtrapolationMode::Linear,
         }
     }
 
-    if points.len() == 1 {
-        let (t1, df1) = points[0];
-        let z = -df1.ln() / t1;
-        return (-z * t).exp();
+    #[test]
+    fn default_curve_keeps_log_linear_discount_behavior() {
+        let yc = YieldCurve::new(vec![(1.0, 0.95), (2.0, 0.90)]);
+        let mid = yc.discount_factor(1.5);
+        let expected = (0.5 * 0.95_f64.ln() + 0.5 * 0.90_f64.ln()).exp();
+        assert_relative_eq!(mid, expected, epsilon = 1e-12);
     }
 
-    let left = points[points.len() - 2];
-    let right = points[points.len() - 1];
-    log_linear_df(left.0, left.1, right.0, right.1, t)
-}
+    #[test]
+    fn linear_zero_rate_curve_is_flat_for_flat_inputs() {
+        let r = 0.03_f64;
+        let yc = YieldCurve::new_with_settings(
+            vec![
+                (1.0, (-r).exp()),
+                (5.0, (-r * 5.0).exp()),
+                (10.0, (-r * 10.0).exp()),
+            ],
+            settings(YieldCurveInterpolationMethod::LinearZeroRate),
+        )
+        .unwrap();
 
-fn log_linear_df(t1: f64, df1: f64, t2: f64, df2: f64, t: f64) -> f64 {
-    if (t2 - t1).abs() <= f64::EPSILON {
-        return df2;
+        for t in [0.5, 2.0, 7.0, 10.0] {
+            assert_relative_eq!(yc.zero_rate(t), r, epsilon = 1e-10);
+        }
     }
-    let w = (t - t1) / (t2 - t1);
-    (df1.ln() + w * (df2.ln() - df1.ln())).exp()
+
+    #[test]
+    fn curve_methods_produce_positive_discount_factors() {
+        let points = vec![
+            (0.5, 0.99),
+            (1.0, 0.975),
+            (2.0, 0.945),
+            (5.0, 0.86),
+            (10.0, 0.72),
+        ];
+
+        let methods = [
+            YieldCurveInterpolationMethod::LogLinearDiscount,
+            YieldCurveInterpolationMethod::LinearZeroRate,
+            YieldCurveInterpolationMethod::MonotoneConvex,
+            YieldCurveInterpolationMethod::TensionSpline { tension: 0.25 },
+            YieldCurveInterpolationMethod::HermiteMonotone,
+            YieldCurveInterpolationMethod::LogCubicMonotone,
+            YieldCurveInterpolationMethod::NelsonSiegel,
+            YieldCurveInterpolationMethod::NelsonSiegelSvensson,
+            YieldCurveInterpolationMethod::SmithWilson {
+                ufr: 0.032,
+                alpha: 0.12,
+            },
+        ];
+
+        for method in methods {
+            let yc = YieldCurve::new_with_settings(points.clone(), settings(method)).unwrap();
+            for t in [0.25, 0.75, 1.5, 3.0, 8.0, 15.0] {
+                let df = yc.discount_factor(t);
+                assert!(df > 0.0 && df <= 1.5, "method={method:?}, t={t}, df={df}");
+            }
+        }
+    }
+
+    #[test]
+    fn zero_rate_jacobian_matches_finite_difference() {
+        let points = vec![(1.0, 0.98), (2.0, 0.95), (5.0, 0.87), (10.0, 0.74)];
+        let s = settings(YieldCurveInterpolationMethod::HermiteMonotone);
+        let yc = YieldCurve::new_with_settings(points.clone(), s).unwrap();
+
+        let t = 3.5;
+        let j = yc.zero_rate_jacobian(t).unwrap();
+        let eps = 1.0e-6;
+
+        for i in 0..points.len() {
+            let mut up = points.clone();
+            up[i].1 += eps;
+            let r_up = YieldCurve::new_with_settings(up, s).unwrap().zero_rate(t);
+
+            let mut dn = points.clone();
+            dn[i].1 -= eps;
+            let r_dn = YieldCurve::new_with_settings(dn, s).unwrap().zero_rate(t);
+
+            let fd = (r_up - r_dn) / (2.0 * eps);
+            assert_relative_eq!(j[i], fd, epsilon = 2.0e-4);
+        }
+    }
+
+    #[test]
+    fn extrapolation_error_mode_surfaces_error_in_try_methods() {
+        let settings = YieldCurveInterpolationSettings {
+            method: YieldCurveInterpolationMethod::LinearZeroRate,
+            extrapolation: ExtrapolationMode::Error,
+        };
+        let yc = YieldCurve::new_with_settings(vec![(1.0, 0.98), (2.0, 0.95)], settings).unwrap();
+
+        assert!(yc.try_discount_factor(3.0).is_err());
+        assert!(yc.discount_factor(3.0).is_nan());
+    }
 }


### PR DESCRIPTION
97 files, 6367 lines. Interpolator trait + log-linear, monotone convex, tension splines, Hermite, Nelson-Siegel/Svensson, Smith-Wilson. ~10ns/point. 357 tests.