### PR TITLE
feat(instruments): general Bermudan options via LSM/PDE (closes #56)

### DIFF
--- a/src/engines/lsm/longstaff_schwartz.rs
+++ b/src/engines/lsm/longstaff_schwartz.rs
@@ -15,10 +15,52 @@ use crate::core::{
     BarrierDirection, BarrierStyle, ExerciseStyle, OptionType, PricingEngine, PricingError,
     PricingResult,
 };
-use crate::instruments::{BarrierOption, VanillaOption};
+use crate::instruments::{BarrierOption, BermudanOption, VanillaOption};
 use crate::market::Market;
 use crate::math::fast_norm::beasley_springer_moro_inv_cdf;
 use crate::math::fast_rng::{Xoshiro256PlusPlus, uniform_open01};
+use crate::models::Heston;
+
+/// Dynamics used by the Bermudan LSM path simulation.
+#[derive(Debug, Clone, Copy)]
+pub enum LsmDynamics {
+    /// Geometric Brownian motion with a single implied volatility.
+    Gbm,
+    /// Log-Euler simulation with state/time-dependent volatility from `market.vol_for(S, t)`.
+    LocalVolEuler,
+    /// Heston stochastic-volatility Euler scheme (full truncation on variance).
+    HestonEuler {
+        kappa: f64,
+        theta: f64,
+        xi: f64,
+        rho: f64,
+        v0: f64,
+    },
+}
+
+/// Exercise-boundary point at one Bermudan decision time.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ExerciseBoundaryPoint {
+    /// Exercise date in year fractions.
+    pub time: f64,
+    /// Strike used at this exercise date.
+    pub strike: f64,
+    /// Estimated optimal boundary (`S*`); `None` when no path exercised.
+    pub boundary_spot: Option<f64>,
+    /// Number of in-the-money paths used for regression.
+    pub itm_paths: usize,
+    /// Number of paths that exercised under the policy.
+    pub exercised_paths: usize,
+}
+
+/// Bermudan LSM output including price and exercise-boundary diagnostics.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BermudanLsmOutput {
+    /// Standard engine result payload.
+    pub result: PricingResult,
+    /// Exercise boundary across all decision dates in chronological order.
+    pub exercise_boundary: Vec<ExerciseBoundaryPoint>,
+}
 
 /// Longstaff-Schwartz least-squares Monte Carlo engine.
 #[derive(Debug, Clone)]
@@ -29,6 +71,8 @@ pub struct LongstaffSchwartzEngine {
     pub num_steps: usize,
     /// RNG seed.
     pub seed: u64,
+    /// Dynamics used for Bermudan path simulation.
+    pub dynamics: LsmDynamics,
 }
 
 impl LongstaffSchwartzEngine {
@@ -38,7 +82,29 @@ impl LongstaffSchwartzEngine {
             num_paths,
             num_steps,
             seed,
+            dynamics: LsmDynamics::Gbm,
         }
+    }
+
+    /// Uses local-vol Euler dynamics for Bermudan pricing.
+    pub fn with_local_vol_dynamics(mut self) -> Self {
+        self.dynamics = LsmDynamics::LocalVolEuler;
+        self
+    }
+
+    /// Uses Heston Euler dynamics for Bermudan pricing.
+    ///
+    /// The spot drift is set to risk-neutral drift `r-q` from `Market`; the
+    /// `mu` field of `model` is ignored.
+    pub fn with_heston_dynamics(mut self, model: Heston) -> Self {
+        self.dynamics = LsmDynamics::HestonEuler {
+            kappa: model.kappa,
+            theta: model.theta,
+            xi: model.xi,
+            rho: model.rho,
+            v0: model.v0,
+        };
+        self
     }
 }
 
@@ -71,6 +137,283 @@ fn mean_and_stderr(values: &[f64]) -> (f64, f64) {
         0.0
     };
     (mean, (var / n).sqrt())
+}
+
+#[inline]
+fn regression_beta(
+    itm: &[usize],
+    paths: &[f64],
+    stride: usize,
+    step: usize,
+    values: &[f64],
+) -> Vector3<f64> {
+    let mut s1 = 0.0_f64;
+    let mut s_s = 0.0_f64;
+    let mut s_s2 = 0.0_f64;
+    let mut s_s3 = 0.0_f64;
+    let mut s_s4 = 0.0_f64;
+    let mut s_y = 0.0_f64;
+    let mut s_sy = 0.0_f64;
+    let mut s_s2y = 0.0_f64;
+
+    for &idx in itm {
+        let s = paths[idx * stride + step];
+        let s2 = s * s;
+        let y = values[idx];
+        s1 += 1.0;
+        s_s += s;
+        s_s2 += s2;
+        s_s3 += s2 * s;
+        s_s4 += s2 * s2;
+        s_y += y;
+        s_sy += s * y;
+        s_s2y += s2 * y;
+    }
+
+    let xtx = Matrix3::new(s1, s_s, s_s2, s_s, s_s2, s_s3, s_s2, s_s3, s_s4);
+    let xty = Vector3::new(s_y, s_sy, s_s2y);
+    xtx.lu().solve(&xty).unwrap_or(Vector3::zeros())
+}
+
+#[inline]
+fn boundary_from_exercised(option_type: OptionType, exercised_spots: &[f64]) -> Option<f64> {
+    if exercised_spots.is_empty() {
+        return None;
+    }
+    match option_type {
+        OptionType::Put => exercised_spots.iter().copied().reduce(f64::max),
+        OptionType::Call => exercised_spots.iter().copied().reduce(f64::min),
+    }
+}
+
+impl LongstaffSchwartzEngine {
+    fn simulate_bermudan_paths(
+        &self,
+        instrument: &BermudanOption,
+        market: &Market,
+        reference_strike: f64,
+    ) -> Result<(Vec<f64>, usize), PricingError> {
+        let dt = instrument.expiry / self.num_steps as f64;
+        let sqrt_dt = dt.sqrt();
+        let drift_rn = market.rate - market.dividend_yield;
+        let raw_stride = self.num_steps + 1;
+        let stride = (raw_stride + 7) & !7;
+        let mut paths = vec![0.0_f64; self.num_paths * stride];
+        let mut rng = Xoshiro256PlusPlus::seed_from_u64(self.seed);
+
+        match self.dynamics {
+            LsmDynamics::Gbm => {
+                let vol = market.vol_for(reference_strike, instrument.expiry);
+                if !vol.is_finite() || vol <= 0.0 {
+                    return Err(PricingError::InvalidInput(
+                        "market volatility must be finite and > 0".to_string(),
+                    ));
+                }
+                let drift = (drift_rn - 0.5 * vol * vol) * dt;
+                let step_vol = vol * sqrt_dt;
+                for pi in 0..self.num_paths {
+                    let base = pi * stride;
+                    paths[base] = market.spot;
+                    for ti in 1..=self.num_steps {
+                        let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
+                        paths[base + ti] = paths[base + ti - 1] * step_vol.mul_add(z, drift).exp();
+                    }
+                }
+            }
+            LsmDynamics::LocalVolEuler => {
+                for pi in 0..self.num_paths {
+                    let base = pi * stride;
+                    let mut s = market.spot;
+                    paths[base] = s;
+                    for ti in 1..=self.num_steps {
+                        let t = (ti as f64 * dt).max(1.0e-8);
+                        let sigma = market.vol_for(s.max(1.0e-8), t);
+                        if !sigma.is_finite() || sigma <= 0.0 {
+                            return Err(PricingError::InvalidInput(
+                                "local volatility surface returned non-positive value".to_string(),
+                            ));
+                        }
+                        let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
+                        let drift = (drift_rn - 0.5 * sigma * sigma) * dt;
+                        s *= (drift + sigma * sqrt_dt * z).exp();
+                        paths[base + ti] = s.max(1.0e-12);
+                        s = paths[base + ti];
+                    }
+                }
+            }
+            LsmDynamics::HestonEuler {
+                kappa,
+                theta,
+                xi,
+                rho,
+                v0,
+            } => {
+                let heston = Heston {
+                    mu: drift_rn,
+                    kappa,
+                    theta,
+                    xi,
+                    rho,
+                    v0,
+                };
+                if !heston.validate() {
+                    return Err(PricingError::InvalidInput(
+                        "invalid Heston parameters for Bermudan LSM dynamics".to_string(),
+                    ));
+                }
+                for pi in 0..self.num_paths {
+                    let base = pi * stride;
+                    let mut s = market.spot;
+                    let mut v = v0;
+                    paths[base] = s;
+                    for ti in 1..=self.num_steps {
+                        let z1 = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
+                        let z2 = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
+                        let (s_next, v_next) = heston.step_euler(s, v, dt, z1, z2);
+                        s = s_next.max(1.0e-12);
+                        v = v_next.max(0.0);
+                        paths[base + ti] = s;
+                    }
+                }
+            }
+        }
+
+        Ok((paths, stride))
+    }
+
+    /// Prices a Bermudan option and returns the estimated optimal exercise boundary.
+    ///
+    /// Boundary extraction is pathwise:
+    /// - put: largest exercised spot at each decision date,
+    /// - call: smallest exercised spot at each decision date.
+    ///
+    /// References:
+    /// - Longstaff and Schwartz (2001), least-squares continuation regression.
+    /// - Glasserman (2004), Monte Carlo implementation details.
+    pub fn price_bermudan_with_boundary(
+        &self,
+        instrument: &BermudanOption,
+        market: &Market,
+    ) -> Result<BermudanLsmOutput, PricingError> {
+        instrument.validate()?;
+        if self.num_steps < 2 {
+            return Err(PricingError::InvalidInput(
+                "num_steps must be >= 2 for Longstaff-Schwartz".to_string(),
+            ));
+        }
+        if self.num_paths < 3 {
+            return Err(PricingError::InvalidInput(
+                "num_paths must be >= 3 for Longstaff-Schwartz".to_string(),
+            ));
+        }
+
+        let schedule = instrument.effective_schedule()?;
+        let terminal_strike = schedule.last().map(|(_, k)| *k).ok_or_else(|| {
+            PricingError::InvalidInput("bermudan schedule cannot be empty".to_string())
+        })?;
+        let (paths, stride) = self.simulate_bermudan_paths(instrument, market, terminal_strike)?;
+
+        let dt = instrument.expiry / self.num_steps as f64;
+        let disc = (-market.rate * dt).exp();
+        let mut step_schedule = vec![None::<(f64, f64)>; self.num_steps + 1];
+        for &(t, k) in &schedule {
+            let idx = (((t / instrument.expiry) * self.num_steps as f64).round() as usize)
+                .clamp(1, self.num_steps);
+            step_schedule[idx] = Some((t, k));
+        }
+
+        let mut values: Vec<f64> = (0..self.num_paths)
+            .map(|pi| {
+                intrinsic(
+                    instrument.option_type,
+                    paths[pi * stride + self.num_steps],
+                    terminal_strike,
+                )
+            })
+            .collect();
+
+        let terminal_itm = values.iter().filter(|v| **v > 0.0).count();
+        let mut boundary_rev = vec![ExerciseBoundaryPoint {
+            time: instrument.expiry,
+            strike: terminal_strike,
+            boundary_spot: Some(terminal_strike),
+            itm_paths: terminal_itm,
+            exercised_paths: terminal_itm,
+        }];
+
+        for ti in (1..self.num_steps).rev() {
+            for value in &mut values {
+                *value *= disc;
+            }
+
+            let Some((time, strike)) = step_schedule[ti] else {
+                continue;
+            };
+
+            let itm: Vec<usize> = (0..self.num_paths)
+                .filter(|&idx| {
+                    intrinsic(instrument.option_type, paths[idx * stride + ti], strike) > 0.0
+                })
+                .collect();
+
+            if itm.len() < 3 {
+                boundary_rev.push(ExerciseBoundaryPoint {
+                    time,
+                    strike,
+                    boundary_spot: None,
+                    itm_paths: itm.len(),
+                    exercised_paths: 0,
+                });
+                continue;
+            }
+
+            let beta = regression_beta(&itm, &paths, stride, ti, &values);
+            let mut exercised_spots = Vec::with_capacity(itm.len());
+            for idx in itm.iter().copied() {
+                let s = paths[idx * stride + ti];
+                let continuation = beta[0] + beta[1] * s + beta[2] * s * s;
+                let exercise = intrinsic(instrument.option_type, s, strike);
+                if exercise > continuation {
+                    values[idx] = exercise;
+                    exercised_spots.push(s);
+                }
+            }
+
+            boundary_rev.push(ExerciseBoundaryPoint {
+                time,
+                strike,
+                boundary_spot: boundary_from_exercised(instrument.option_type, &exercised_spots),
+                itm_paths: itm.len(),
+                exercised_paths: exercised_spots.len(),
+            });
+        }
+
+        let discounted: Vec<f64> = values.into_iter().map(|v| v * disc).collect();
+        let (price, stderr) = mean_and_stderr(&discounted);
+
+        let mut diagnostics = crate::core::Diagnostics::new();
+        diagnostics.insert_key(crate::core::DiagKey::NumPaths, self.num_paths as f64);
+        diagnostics.insert_key(crate::core::DiagKey::NumSteps, self.num_steps as f64);
+        diagnostics.insert_key(crate::core::DiagKey::ExerciseDates, schedule.len() as f64);
+
+        if let LsmDynamics::Gbm = self.dynamics {
+            diagnostics.insert_key(
+                crate::core::DiagKey::Vol,
+                market.vol_for(terminal_strike, instrument.expiry),
+            );
+        }
+
+        boundary_rev.reverse();
+        Ok(BermudanLsmOutput {
+            result: PricingResult {
+                price,
+                stderr: Some(stderr),
+                greeks: None,
+                diagnostics,
+            },
+            exercise_boundary: boundary_rev,
+        })
+    }
 }
 
 impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
@@ -273,6 +616,17 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
     }
 }
 
+impl PricingEngine<BermudanOption> for LongstaffSchwartzEngine {
+    fn price(
+        &self,
+        instrument: &BermudanOption,
+        market: &Market,
+    ) -> Result<PricingResult, PricingError> {
+        self.price_bermudan_with_boundary(instrument, market)
+            .map(|out| out.result)
+    }
+}
+
 impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
     fn price(
         &self,
@@ -317,6 +671,7 @@ impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
         let use_simd = false;
 
         let buf_size = (self.num_steps + 3) & !3;
+        #[allow(unused_mut)]
         let mut normal_buf = vec![0.0_f64; buf_size];
 
         for _ in 0..self.num_paths {

--- a/src/engines/lsm/mod.rs
+++ b/src/engines/lsm/mod.rs
@@ -12,4 +12,6 @@
 
 pub mod longstaff_schwartz;
 
-pub use longstaff_schwartz::LongstaffSchwartzEngine;
+pub use longstaff_schwartz::{
+    BermudanLsmOutput, ExerciseBoundaryPoint, LongstaffSchwartzEngine, LsmDynamics,
+};

--- a/src/engines/pde/mod.rs
+++ b/src/engines/pde/mod.rs
@@ -15,7 +15,7 @@ pub mod explicit_fd;
 pub mod hopscotch;
 pub mod implicit_fd;
 
-pub use crank_nicolson::CrankNicolsonEngine;
+pub use crank_nicolson::{BermudanPdeOutput, CrankNicolsonEngine, PdeExerciseBoundaryPoint};
 pub use explicit_fd::ExplicitFdEngine;
 pub use hopscotch::HopscotchEngine;
 pub use implicit_fd::ImplicitFdEngine;

--- a/src/instruments/bermudan.rs
+++ b/src/instruments/bermudan.rs
@@ -1,0 +1,186 @@
+//! Module `instruments::bermudan`.
+//!
+//! Bermudan vanilla option with an explicit exercise-date schedule and
+//! per-date strike schedule (supports step-down / step-up structures).
+//!
+//! References:
+//! - Longstaff and Schwartz (2001), *Valuing American Options by Simulation*.
+//! - Tavella and Randall (2000), finite-difference methods for free-boundary
+//!   option problems.
+
+use crate::core::{Instrument, OptionType, PricingError};
+
+/// Bermudan option with discrete exercise rights and strike schedule.
+///
+/// `exercise_dates[i]` pairs with `strike_schedule[i]`.
+/// If the final exercise date is strictly below expiry, engines append an
+/// implicit final exercise right at expiry with the last scheduled strike.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BermudanOption {
+    /// Call or put.
+    pub option_type: OptionType,
+    /// Expiry in years.
+    pub expiry: f64,
+    /// Exercise dates in year fractions.
+    pub exercise_dates: Vec<f64>,
+    /// Strike corresponding to each exercise date.
+    pub strike_schedule: Vec<f64>,
+}
+
+impl BermudanOption {
+    /// Creates a Bermudan option with explicit per-date strikes.
+    pub fn new(
+        option_type: OptionType,
+        expiry: f64,
+        exercise_dates: Vec<f64>,
+        strike_schedule: Vec<f64>,
+    ) -> Self {
+        Self {
+            option_type,
+            expiry,
+            exercise_dates,
+            strike_schedule,
+        }
+    }
+
+    /// Creates a Bermudan option with constant strike across all exercise dates.
+    pub fn with_constant_strike(
+        option_type: OptionType,
+        strike: f64,
+        expiry: f64,
+        exercise_dates: Vec<f64>,
+    ) -> Self {
+        let strike_schedule = vec![strike; exercise_dates.len()];
+        Self::new(option_type, expiry, exercise_dates, strike_schedule)
+    }
+
+    /// Number of scheduled exercise rights.
+    #[inline]
+    pub fn num_exercise_dates(&self) -> usize {
+        self.exercise_dates.len()
+    }
+
+    /// Returns the strike applied at a specific exercise date.
+    #[inline]
+    pub fn strike_at_exercise_index(&self, index: usize) -> Option<f64> {
+        self.strike_schedule.get(index).copied()
+    }
+
+    /// Returns the strike active at `time` using a right-continuous step
+    /// schedule induced by `exercise_dates`.
+    pub fn strike_at_time(&self, time: f64) -> Result<f64, PricingError> {
+        self.validate()?;
+        let idx = self.exercise_dates.partition_point(|&d| d <= time);
+        if idx == 0 {
+            Ok(self.strike_schedule[0])
+        } else {
+            Ok(self.strike_schedule[idx - 1])
+        }
+    }
+
+    /// Returns effective `(exercise_time, strike)` pairs.
+    ///
+    /// If the last exercise date is `< expiry`, an extra pair `(expiry, last_strike)`
+    /// is appended so payoff-at-expiry is always well-defined.
+    pub fn effective_schedule(&self) -> Result<Vec<(f64, f64)>, PricingError> {
+        self.validate()?;
+
+        let mut out = self
+            .exercise_dates
+            .iter()
+            .copied()
+            .zip(self.strike_schedule.iter().copied())
+            .collect::<Vec<_>>();
+
+        let last = *out.last().ok_or_else(|| {
+            PricingError::InvalidInput("bermudan schedule cannot be empty".to_string())
+        })?;
+        if self.expiry - last.0 > 1.0e-12 {
+            out.push((self.expiry, last.1));
+        }
+
+        Ok(out)
+    }
+
+    /// Validates schedule and strike inputs.
+    pub fn validate(&self) -> Result<(), PricingError> {
+        if self.expiry <= 0.0 || !self.expiry.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "bermudan expiry must be finite and > 0".to_string(),
+            ));
+        }
+        if self.exercise_dates.is_empty() {
+            return Err(PricingError::InvalidInput(
+                "bermudan exercise_dates cannot be empty".to_string(),
+            ));
+        }
+        if self.exercise_dates.len() != self.strike_schedule.len() {
+            return Err(PricingError::InvalidInput(
+                "bermudan strike_schedule must match exercise_dates length".to_string(),
+            ));
+        }
+        if self
+            .exercise_dates
+            .iter()
+            .any(|&t| !t.is_finite() || t <= 0.0 || t > self.expiry)
+        {
+            return Err(PricingError::InvalidInput(
+                "bermudan exercise_dates must be finite and in (0, expiry]".to_string(),
+            ));
+        }
+        if self.exercise_dates.windows(2).any(|w| w[1] <= w[0]) {
+            return Err(PricingError::InvalidInput(
+                "bermudan exercise_dates must be strictly increasing".to_string(),
+            ));
+        }
+        if self
+            .strike_schedule
+            .iter()
+            .any(|&k| !k.is_finite() || k <= 0.0)
+        {
+            return Err(PricingError::InvalidInput(
+                "bermudan strike_schedule entries must be finite and > 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Instrument for BermudanOption {
+    fn instrument_type(&self) -> &str {
+        "BermudanOption"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn appends_expiry_with_last_strike_when_missing() {
+        let b = BermudanOption::new(
+            OptionType::Put,
+            1.0,
+            vec![0.25, 0.5, 0.75],
+            vec![100.0, 98.0, 96.0],
+        );
+        let sch = b.effective_schedule().unwrap();
+        assert_eq!(sch.len(), 4);
+        assert!((sch[3].0 - 1.0).abs() < 1.0e-12);
+        assert!((sch[3].1 - 96.0).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn strike_at_time_is_stepwise() {
+        let b = BermudanOption::new(
+            OptionType::Put,
+            1.0,
+            vec![0.25, 0.5, 1.0],
+            vec![100.0, 95.0, 90.0],
+        );
+        assert_eq!(b.strike_at_time(0.10).unwrap(), 100.0);
+        assert_eq!(b.strike_at_time(0.40).unwrap(), 100.0);
+        assert_eq!(b.strike_at_time(0.75).unwrap(), 95.0);
+        assert_eq!(b.strike_at_time(1.00).unwrap(), 90.0);
+    }
+}

--- a/src/instruments/mod.rs
+++ b/src/instruments/mod.rs
@@ -14,6 +14,7 @@ pub mod asian;
 pub mod autocallable;
 pub mod barrier;
 pub mod basket;
+pub mod bermudan;
 pub mod black76;
 pub mod cliquet;
 pub mod commodity;
@@ -39,6 +40,7 @@ pub use asian::AsianOption;
 pub use autocallable::{Autocallable, PhoenixAutocallable};
 pub use barrier::{BarrierOption, BarrierOptionBuilder};
 pub use basket::{BasketOption, BasketType};
+pub use bermudan::BermudanOption;
 pub use black76::FuturesOption;
 pub use cliquet::{CliquetOption, ForwardStartOption};
 pub use commodity::{CommodityForward, CommodityFutures, CommodityOption, CommoditySpreadOption};
@@ -86,6 +88,7 @@ pub enum TradeInstrument {
     PhoenixAutocallable(PhoenixAutocallable),
     BarrierOption(BarrierOption),
     BasketOption(BasketOption),
+    BermudanOption(BermudanOption),
     FuturesOption(FuturesOption),
     CliquetOption(CliquetOption),
     ForwardStartOption(ForwardStartOption),

--- a/tests/bermudan_quantlib.rs
+++ b/tests/bermudan_quantlib.rs
@@ -1,0 +1,389 @@
+//! Bermudan option reference and regression tests.
+//!
+//! QuantLib references were generated with QuantLib 1.41 using
+//! `FdBlackScholesVanillaEngine(process, 2000, 400)` and
+//! `BermudanExercise` schedules under ACT/365 year fractions.
+//! Tolerance target from issue #56: 0.5%.
+
+use openferric::core::{OptionType, PricingEngine};
+use openferric::engines::lsm::LongstaffSchwartzEngine;
+use openferric::engines::numerical::AmericanBinomialEngine;
+use openferric::engines::pde::CrankNicolsonEngine;
+use openferric::instruments::{BermudanOption, VanillaOption};
+use openferric::market::{Market, VolSurface};
+use openferric::models::Heston;
+
+#[derive(Clone, Copy)]
+struct QlBermudanCase {
+    option_type: OptionType,
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend: f64,
+    vol: f64,
+    expiry: f64,
+    dates: &'static [f64],
+    quantlib_fd_price: f64,
+}
+
+const D4_1Y: &[f64] = &[0.249_315_068_5, 0.498_630_137_0, 0.750_684_931_5, 1.0];
+const D6_15Y: &[f64] = &[
+    0.249_315_068_5,
+    0.501_369_863_0,
+    0.750_684_931_5,
+    1.0,
+    1.252_054_794_5,
+    1.501_369_863_0,
+];
+const D8_2Y: &[f64] = &[
+    0.249_315_068_5,
+    0.498_630_137_0,
+    0.750_684_931_5,
+    1.0,
+    1.249_315_068_5,
+    1.501_369_863_0,
+    1.750_684_931_5,
+    2.0,
+];
+const D6_2Y: &[f64] = &[
+    0.334_246_575_3,
+    0.665_753_424_7,
+    1.0,
+    1.334_246_575_3,
+    1.665_753_424_7,
+    2.0,
+];
+const D3_075Y: &[f64] = &[0.249_315_068_5, 0.501_369_863_0, 0.750_684_931_5];
+const D5_05Y: &[f64] = &[0.098_630_137_0, 0.2, 0.298_630_137_0, 0.4, 0.498_630_137_0];
+const D12_3Y: &[f64] = &[
+    0.249_315_068_5,
+    0.498_630_137_0,
+    0.750_684_931_5,
+    1.0,
+    1.249_315_068_5,
+    1.501_369_863_0,
+    1.750_684_931_5,
+    2.0,
+    2.249_315_068_5,
+    2.498_630_137_0,
+    2.750_684_931_5,
+    3.0,
+];
+
+fn quantlib_reference_cases() -> Vec<QlBermudanCase> {
+    vec![
+        QlBermudanCase {
+            option_type: OptionType::Put,
+            spot: 100.0,
+            strike: 100.0,
+            rate: 0.03,
+            dividend: 0.00,
+            vol: 0.20,
+            expiry: 1.0,
+            dates: D4_1Y,
+            quantlib_fd_price: 6.658_125_199_2,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Put,
+            spot: 95.0,
+            strike: 100.0,
+            rate: 0.05,
+            dividend: 0.01,
+            vol: 0.25,
+            expiry: 1.501_369_863_0,
+            dates: D6_15Y,
+            quantlib_fd_price: 11.718_175_402_9,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Put,
+            spot: 110.0,
+            strike: 100.0,
+            rate: 0.02,
+            dividend: 0.00,
+            vol: 0.30,
+            expiry: 2.0,
+            dates: D8_2Y,
+            quantlib_fd_price: 11.428_287_704_3,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Call,
+            spot: 100.0,
+            strike: 95.0,
+            rate: 0.04,
+            dividend: 0.02,
+            vol: 0.18,
+            expiry: 1.0,
+            dates: D4_1Y,
+            quantlib_fd_price: 10.684_103_943_7,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Call,
+            spot: 105.0,
+            strike: 100.0,
+            rate: 0.01,
+            dividend: 0.03,
+            vol: 0.22,
+            expiry: 2.0,
+            dates: D6_2Y,
+            quantlib_fd_price: 13.138_338_528_3,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Put,
+            spot: 80.0,
+            strike: 90.0,
+            rate: 0.06,
+            dividend: 0.00,
+            vol: 0.35,
+            expiry: 0.750_684_931_5,
+            dates: D3_075Y,
+            quantlib_fd_price: 13.859_666_158_9,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Call,
+            spot: 120.0,
+            strike: 110.0,
+            rate: 0.03,
+            dividend: 0.00,
+            vol: 0.15,
+            expiry: 0.498_630_137_0,
+            dates: D5_05Y,
+            quantlib_fd_price: 12.712_610_941_6,
+        },
+        QlBermudanCase {
+            option_type: OptionType::Put,
+            spot: 150.0,
+            strike: 140.0,
+            rate: 0.025,
+            dividend: 0.005,
+            vol: 0.28,
+            expiry: 3.0,
+            dates: D12_3Y,
+            quantlib_fd_price: 19.297_566_667_3,
+        },
+    ]
+}
+
+fn market(case_: &QlBermudanCase) -> Market {
+    Market::builder()
+        .spot(case_.spot)
+        .rate(case_.rate)
+        .dividend_yield(case_.dividend)
+        .flat_vol(case_.vol)
+        .build()
+        .unwrap()
+}
+
+fn rel_err(got: f64, expected: f64) -> f64 {
+    (got - expected).abs() / expected.abs().max(1.0e-12)
+}
+
+#[test]
+fn bermudan_cn_matches_quantlib_fd_within_half_percent() {
+    let engine = CrankNicolsonEngine::new(450, 450).with_s_max_multiplier(5.0);
+    for (idx, case_) in quantlib_reference_cases().iter().enumerate() {
+        let inst = BermudanOption::with_constant_strike(
+            case_.option_type,
+            case_.strike,
+            case_.expiry,
+            case_.dates.to_vec(),
+        );
+        let out = engine
+            .price_bermudan_with_boundary(&inst, &market(case_))
+            .unwrap();
+        let err = rel_err(out.result.price, case_.quantlib_fd_price);
+        assert!(
+            err <= 0.005,
+            "CN Bermudan case {idx} rel_err={err:.6} got={} ref={}",
+            out.result.price,
+            case_.quantlib_fd_price
+        );
+        assert!(
+            !out.exercise_boundary.is_empty(),
+            "boundary output missing for case {idx}"
+        );
+    }
+}
+
+#[test]
+fn bermudan_lsm_matches_quantlib_fd_within_half_percent_on_reference_puts() {
+    let engine = LongstaffSchwartzEngine::new(450_000, 120, 7);
+    let put_cases = quantlib_reference_cases()
+        .into_iter()
+        .filter(|c| c.option_type == OptionType::Put)
+        .collect::<Vec<_>>();
+    for (idx, case_) in put_cases.iter().enumerate() {
+        let inst = BermudanOption::with_constant_strike(
+            case_.option_type,
+            case_.strike,
+            case_.expiry,
+            case_.dates.to_vec(),
+        );
+        let out = engine
+            .price_bermudan_with_boundary(&inst, &market(case_))
+            .unwrap();
+        let err = rel_err(out.result.price, case_.quantlib_fd_price);
+        assert!(
+            err <= 0.005,
+            "LSM Bermudan put case {idx} rel_err={err:.6} got={} ref={} stderr={:?}",
+            out.result.price,
+            case_.quantlib_fd_price,
+            out.result.stderr
+        );
+        assert!(
+            out.exercise_boundary
+                .iter()
+                .any(|b| b.boundary_spot.is_some()),
+            "boundary output has no populated points for put case {idx}"
+        );
+    }
+}
+
+#[test]
+fn bermudan_time_varying_strike_step_down_put_prices_lower_than_constant_strike() {
+    let dates = vec![0.25, 0.5, 0.75, 1.0];
+    let step_down = BermudanOption::new(
+        OptionType::Put,
+        1.0,
+        dates.clone(),
+        vec![100.0, 97.5, 95.0, 92.5],
+    );
+    let constant = BermudanOption::with_constant_strike(OptionType::Put, 100.0, 1.0, dates);
+
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.0)
+        .flat_vol(0.25)
+        .build()
+        .unwrap();
+
+    let lsm = LongstaffSchwartzEngine::new(250_000, 100, 42);
+    let pde = CrankNicolsonEngine::new(300, 300).with_s_max_multiplier(5.0);
+
+    let px_step_lsm = lsm.price(&step_down, &market).unwrap().price;
+    let px_const_lsm = lsm.price(&constant, &market).unwrap().price;
+    assert!(px_step_lsm < px_const_lsm);
+
+    let px_step_pde = pde.price(&step_down, &market).unwrap().price;
+    let px_const_pde = pde.price(&constant, &market).unwrap().price;
+    assert!(px_step_pde < px_const_pde);
+}
+
+#[test]
+fn bermudan_lsm_supports_local_vol_and_heston_dynamics() {
+    let dates = vec![0.2, 0.4, 0.6, 0.8, 1.0];
+    let inst = BermudanOption::with_constant_strike(OptionType::Put, 100.0, 1.0, dates);
+
+    #[derive(Debug, Clone)]
+    struct LocalSmile;
+    impl VolSurface for LocalSmile {
+        fn vol(&self, strike: f64, expiry: f64) -> f64 {
+            let m = (strike / 100.0 - 1.0).abs();
+            let term = (expiry.max(1.0e-6)).sqrt();
+            (0.18 + 0.08 * m + 0.03 * term).max(0.05)
+        }
+    }
+
+    let local_vol_market = Market::builder()
+        .spot(100.0)
+        .rate(0.02)
+        .dividend_yield(0.01)
+        .vol_surface(Box::new(LocalSmile))
+        .build()
+        .unwrap();
+
+    let local_engine = LongstaffSchwartzEngine::new(200_000, 90, 123).with_local_vol_dynamics();
+    let local_out = local_engine
+        .price_bermudan_with_boundary(&inst, &local_vol_market)
+        .unwrap();
+    assert!(local_out.result.price.is_finite() && local_out.result.price > 0.0);
+    assert!(
+        local_out
+            .exercise_boundary
+            .iter()
+            .any(|pt| pt.boundary_spot.is_some())
+    );
+
+    let heston = Heston {
+        mu: 0.0,
+        kappa: 2.0,
+        theta: 0.04,
+        xi: 0.6,
+        rho: -0.5,
+        v0: 0.04,
+    };
+    let flat_market = Market::builder()
+        .spot(100.0)
+        .rate(0.02)
+        .dividend_yield(0.01)
+        .flat_vol(0.20)
+        .build()
+        .unwrap();
+    let heston_engine =
+        LongstaffSchwartzEngine::new(220_000, 100, 321).with_heston_dynamics(heston);
+    let heston_out = heston_engine
+        .price_bermudan_with_boundary(&inst, &flat_market)
+        .unwrap();
+    assert!(heston_out.result.price.is_finite() && heston_out.result.price > 0.0);
+    assert!(
+        heston_out
+            .exercise_boundary
+            .iter()
+            .any(|pt| pt.boundary_spot.is_some())
+    );
+}
+
+#[test]
+fn bermudan_converges_toward_american_as_exercise_dates_increase() {
+    let maturity = 1.0;
+    let strike = 100.0;
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.05)
+        .dividend_yield(0.0)
+        .flat_vol(0.20)
+        .build()
+        .unwrap();
+    let american = VanillaOption::american_put(strike, maturity);
+    let american_ref = AmericanBinomialEngine::new(2500)
+        .price(&american, &market)
+        .unwrap()
+        .price;
+
+    let date_grid = |n: usize| -> Vec<f64> {
+        (1..=n)
+            .map(|i| maturity * i as f64 / n as f64)
+            .collect::<Vec<_>>()
+    };
+
+    let pde = CrankNicolsonEngine::new(400, 400).with_s_max_multiplier(5.0);
+    let berm_4 =
+        BermudanOption::with_constant_strike(OptionType::Put, strike, maturity, date_grid(4));
+    let berm_12 =
+        BermudanOption::with_constant_strike(OptionType::Put, strike, maturity, date_grid(12));
+    let berm_52 =
+        BermudanOption::with_constant_strike(OptionType::Put, strike, maturity, date_grid(52));
+
+    let p4 = pde.price(&berm_4, &market).unwrap().price;
+    let p12 = pde.price(&berm_12, &market).unwrap().price;
+    let p52 = pde.price(&berm_52, &market).unwrap().price;
+
+    assert!(p12 >= p4 - 1.0e-8);
+    assert!(p52 >= p12 - 1.0e-8);
+    assert!(p52 <= american_ref + 0.05);
+    assert!(
+        rel_err(p52, american_ref) <= 0.01,
+        "dense Bermudan should approach American: berm={p52} am={american_ref}"
+    );
+
+    let lsm = LongstaffSchwartzEngine::new(350_000, 120, 11);
+    let l52 = lsm.price(&berm_52, &market).unwrap();
+    assert!(l52.price <= american_ref + 0.20);
+    assert!(
+        rel_err(l52.price, american_ref) <= 0.03,
+        "LSM dense Bermudan should be close to American: berm={} am={} stderr={:?}",
+        l52.price,
+        american_ref,
+        l52.stderr
+    );
+}

--- a/tests/serialization_roundtrip.rs
+++ b/tests/serialization_roundtrip.rs
@@ -7,16 +7,16 @@ use openferric::core::{
 use openferric::credit::SurvivalCurve;
 use openferric::instruments::{
     AbandonmentOption, AsianOption, AssetOrNothingOption, Autocallable, BarrierOption,
-    BasketOption, BasketType, BestOfTwoCallOption, CashOrNothingOption, CatastropheBond,
-    ChooserOption, CliquetOption, CommodityForward, CommodityFutures, CommodityOption,
-    CommoditySpreadOption, CompoundOption, ConstantCpr, ConvertibleBond, DeferInvestmentOption,
-    DegreeDayType, DiscreteCashFlow, DoubleBarrierOption, DoubleBarrierType, DualRangeAccrual,
-    EmployeeStockOption, ExoticOption, ExpandOption, ForwardStartOption, FuturesOption, FxOption,
-    GapOption, LookbackFixedOption, LookbackFloatingOption, MbsCashflow, MbsPassThrough,
-    PhoenixAutocallable, Portfolio, PowerOption, PrepaymentModel, PsaModel, QuantoOption,
-    RangeAccrual, RealOptionBinomialSpec, RealOptionInstrument, SpreadOption, SwingOption, Tarf,
-    TarfType, Trade, TradeInstrument, TradeMetadata, TwoAssetCorrelationOption, VanillaOption,
-    VarianceOptionQuote, VarianceSwap, VolatilitySwap, WeatherOption, WeatherSwap,
+    BasketOption, BasketType, BermudanOption, BestOfTwoCallOption, CashOrNothingOption,
+    CatastropheBond, ChooserOption, CliquetOption, CommodityForward, CommodityFutures,
+    CommodityOption, CommoditySpreadOption, CompoundOption, ConstantCpr, ConvertibleBond,
+    DeferInvestmentOption, DegreeDayType, DiscreteCashFlow, DoubleBarrierOption, DoubleBarrierType,
+    DualRangeAccrual, EmployeeStockOption, ExoticOption, ExpandOption, ForwardStartOption,
+    FuturesOption, FxOption, GapOption, LookbackFixedOption, LookbackFloatingOption, MbsCashflow,
+    MbsPassThrough, PhoenixAutocallable, Portfolio, PowerOption, PrepaymentModel, PsaModel,
+    QuantoOption, RangeAccrual, RealOptionBinomialSpec, RealOptionInstrument, SpreadOption,
+    SwingOption, Tarf, TarfType, Trade, TradeInstrument, TradeMetadata, TwoAssetCorrelationOption,
+    VanillaOption, VarianceOptionQuote, VarianceSwap, VolatilitySwap, WeatherOption, WeatherSwap,
     WorstOfTwoCallOption,
 };
 use openferric::market::{
@@ -409,6 +409,12 @@ fn sample_trade_instruments() -> Vec<TradeInstrument> {
                 dates: vec![0.5, 0.75, 1.0],
             },
         }),
+        TradeInstrument::BermudanOption(BermudanOption::new(
+            OptionType::Put,
+            1.0,
+            vec![0.25, 0.5, 0.75, 1.0],
+            vec![105.0, 102.5, 100.0, 97.5],
+        )),
         TradeInstrument::VarianceSwap(VarianceSwap::new(
             100_000.0,
             0.20,


### PR DESCRIPTION
1265 lines: Bermudan instrument + LSM/PDE pricing + exercise boundary output. Step-down strikes, Heston/local vol support. Convergence to American verified. 376 tests.