### PR TITLE
feat(market): dividend modelling with curve bootstrap (closes #58)

### DIFF
--- a/src/engines/analytic/asian_geometric.rs
+++ b/src/engines/analytic/asian_geometric.rs
@@ -57,7 +57,7 @@ impl PricingEngine<AsianOption> for GeometricAsianEngine {
             market.spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            market.effective_dividend_yield(instrument.expiry),
             vol,
             &instrument.asian.observation_times,
         );

--- a/src/engines/analytic/barrier_analytic.rs
+++ b/src/engines/analytic/barrier_analytic.rs
@@ -39,6 +39,7 @@ impl PricingEngine<BarrierOption> for BarrierAnalyticEngine {
                 "market volatility must be > 0".to_string(),
             ));
         }
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
 
         let price = barrier_price_closed_form_with_carry_and_rebate(
             instrument.option_type,
@@ -48,7 +49,7 @@ impl PricingEngine<BarrierOption> for BarrierAnalyticEngine {
             instrument.strike,
             instrument.barrier.level,
             market.rate,
-            market.dividend_yield,
+            effective_dividend_yield,
             vol,
             instrument.expiry,
             instrument.barrier.rebate,

--- a/src/engines/analytic/black_scholes.rs
+++ b/src/engines/analytic/black_scholes.rs
@@ -324,12 +324,18 @@ impl PricingEngine<VanillaOption> for BlackScholesEngine {
             });
         }
 
+        let (spot, dividend_yield) = if market.has_discrete_dividends() {
+            (market.prepaid_forward_spot(instrument.expiry), 0.0)
+        } else {
+            (market.spot, market.dividend_yield)
+        };
+
         let (price, greeks, d1, d2) = bs_price_greeks_with_dividend(
             instrument.option_type,
-            market.spot,
+            spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            dividend_yield,
             vol,
             instrument.expiry,
         );
@@ -366,21 +372,27 @@ impl PricingEngine<VanillaOption> for BlackScholesEngine {
             ));
         }
 
+        let (spot, dividend_yield) = if market.has_discrete_dividends() {
+            (market.prepaid_forward_spot(instrument.expiry), 0.0)
+        } else {
+            (market.spot, market.dividend_yield)
+        };
+
         let (price, greeks) = black_scholes_price_greeks_aad(
             instrument.option_type,
-            market.spot,
+            spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            dividend_yield,
             vol,
             instrument.expiry,
         );
         let (d1, d2) = if instrument.expiry > 0.0 && vol > 0.0 {
             d1_d2(
-                market.spot,
+                spot,
                 instrument.strike,
                 market.rate,
-                market.dividend_yield,
+                dividend_yield,
                 vol,
                 instrument.expiry,
             )

--- a/src/engines/analytic/digital.rs
+++ b/src/engines/analytic/digital.rs
@@ -97,12 +97,13 @@ impl PricingEngine<CashOrNothingOption> for DigitalAnalyticEngine {
                 "market volatility must be > 0".to_string(),
             ));
         }
+        let q = market.effective_dividend_yield(instrument.expiry);
 
         let (_, d2) = d1_d2(
             market.spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            q,
             vol,
             instrument.expiry,
         );
@@ -155,16 +156,17 @@ impl PricingEngine<AssetOrNothingOption> for DigitalAnalyticEngine {
                 "market volatility must be > 0".to_string(),
             ));
         }
+        let q = market.effective_dividend_yield(instrument.expiry);
 
         let (d1, _) = d1_d2(
             market.spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            q,
             vol,
             instrument.expiry,
         );
-        let df_q = (-market.dividend_yield * instrument.expiry).exp();
+        let df_q = (-q * instrument.expiry).exp();
 
         // Compute N(d1) once; derive put price via N(-d1) = 1 - N(d1).
         let nd1 = normal_cdf(d1);
@@ -214,17 +216,18 @@ impl PricingEngine<GapOption> for DigitalAnalyticEngine {
                 "market volatility must be > 0".to_string(),
             ));
         }
+        let q = market.effective_dividend_yield(instrument.expiry);
 
         let (d1, d2) = d1_d2(
             market.spot,
             instrument.trigger_strike,
             market.rate,
-            market.dividend_yield,
+            q,
             vol,
             instrument.expiry,
         );
         let df_r = (-market.rate * instrument.expiry).exp();
-        let df_q = (-market.dividend_yield * instrument.expiry).exp();
+        let df_q = (-q * instrument.expiry).exp();
 
         // Compute N(d1), N(d2) once; derive put via N(-d) = 1 - N(d).
         let nd1 = normal_cdf(d1);

--- a/src/engines/analytic/double_barrier.rs
+++ b/src/engines/analytic/double_barrier.rs
@@ -254,6 +254,7 @@ impl PricingEngine<DoubleBarrierOption> for DoubleBarrierAnalyticEngine {
                 "market volatility must be > 0".to_string(),
             ));
         }
+        let q = market.effective_dividend_yield(instrument.expiry);
 
         let df_r = (-market.rate * instrument.expiry).exp();
         let vanilla = bs_price_with_dividend(
@@ -261,7 +262,7 @@ impl PricingEngine<DoubleBarrierOption> for DoubleBarrierAnalyticEngine {
             market.spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            q,
             vol,
             instrument.expiry,
         );
@@ -275,7 +276,7 @@ impl PricingEngine<DoubleBarrierOption> for DoubleBarrierAnalyticEngine {
                     instrument.lower_barrier,
                     instrument.upper_barrier,
                     market.rate,
-                    market.dividend_yield,
+                    q,
                     vol,
                     instrument.expiry,
                     self.series_terms,
@@ -285,7 +286,7 @@ impl PricingEngine<DoubleBarrierOption> for DoubleBarrierAnalyticEngine {
                     instrument.lower_barrier,
                     instrument.upper_barrier,
                     market.rate,
-                    market.dividend_yield,
+                    q,
                     vol,
                     instrument.expiry,
                     self.series_terms,

--- a/src/engines/analytic/power.rs
+++ b/src/engines/analytic/power.rs
@@ -129,13 +129,14 @@ impl PricingEngine<PowerOption> for PowerOptionEngine {
                 "market volatility must be >= 0".to_string(),
             ));
         }
+        let q = market.effective_dividend_yield(instrument.expiry.max(1.0e-12));
 
         let price = power_option_price(
             instrument.option_type,
             market.spot,
             instrument.strike,
             market.rate,
-            market.dividend_yield,
+            q,
             vol,
             instrument.alpha,
             instrument.expiry,
@@ -144,7 +145,7 @@ impl PricingEngine<PowerOption> for PowerOptionEngine {
         let pv_forward = market.spot.powf(instrument.alpha)
             * (((instrument.alpha - 1.0)
                 * (0.5 * instrument.alpha * vol).mul_add(vol, market.rate)
-                - instrument.alpha * market.dividend_yield)
+                - instrument.alpha * q)
                 * instrument.expiry)
                 .exp();
 

--- a/src/engines/analytic/variance_swap.rs
+++ b/src/engines/analytic/variance_swap.rs
@@ -211,7 +211,7 @@ impl PricingEngine<VarianceSwap> for VarianceSwapEngine {
             instrument.expiry,
             market.rate,
             market.spot,
-            market.dividend_yield,
+            market.effective_dividend_yield(instrument.expiry),
             &instrument.option_quotes,
         )?;
         let fair_volatility = fair_variance.sqrt();
@@ -242,7 +242,7 @@ impl PricingEngine<VolatilitySwap> for VarianceSwapEngine {
             instrument.expiry,
             market.rate,
             market.spot,
-            market.dividend_yield,
+            market.effective_dividend_yield(instrument.expiry),
             &instrument.option_quotes,
         )?;
         let fair_volatility =

--- a/src/engines/lsm/longstaff_schwartz.rs
+++ b/src/engines/lsm/longstaff_schwartz.rs
@@ -195,7 +195,8 @@ impl LongstaffSchwartzEngine {
     ) -> Result<(Vec<f64>, usize), PricingError> {
         let dt = instrument.expiry / self.num_steps as f64;
         let sqrt_dt = dt.sqrt();
-        let drift_rn = market.rate - market.dividend_yield;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let drift_rn = market.rate - effective_dividend_yield;
         let raw_stride = self.num_steps + 1;
         let stride = (raw_stride + 7) & !7;
         let mut paths = vec![0.0_f64; self.num_paths * stride];
@@ -452,7 +453,8 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
         }
 
         let dt = instrument.expiry / self.num_steps as f64;
-        let drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * dt;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * dt;
         let step_vol = vol * dt.sqrt();
         let disc = (-market.rate * dt).exp();
 
@@ -654,7 +656,8 @@ impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
         }
 
         let dt = instrument.expiry / self.num_steps as f64;
-        let drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * dt;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * dt;
         let step_vol = vol * dt.sqrt();
         let discount = (-market.rate * instrument.expiry).exp();
 

--- a/src/engines/monte_carlo/mc_aad.rs
+++ b/src/engines/monte_carlo/mc_aad.rs
@@ -135,6 +135,7 @@ pub fn mc_european_pathwise_aad(
     let mut sum = 0.0_f64;
     let mut sum_sq = 0.0_f64;
     let mut grad_sum = [0.0_f64; 4];
+    let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
 
     for i in 0..samples {
         let seed = resolve_stream_seed(engine.seed, i, engine.reproducible);
@@ -150,7 +151,7 @@ pub fn mc_european_pathwise_aad(
             instrument.strike,
             market.spot,
             market.rate,
-            market.dividend_yield,
+            effective_dividend_yield,
             vol,
             instrument.expiry,
             &normals,
@@ -167,7 +168,7 @@ pub fn mc_european_pathwise_aad(
                 instrument.strike,
                 market.spot,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 vol,
                 instrument.expiry,
                 &normals,

--- a/src/engines/monte_carlo/mc_greeks.rs
+++ b/src/engines/monte_carlo/mc_greeks.rs
@@ -169,7 +169,7 @@ impl MonteCarloGreeksEngine {
         }
 
         let rate = market.rate;
-        let dividend = market.dividend_yield;
+        let dividend = market.effective_dividend_yield(maturity);
         let drift = (rate - dividend - 0.5 * vol * vol) * maturity;
         let sig_sqrt_t = vol * maturity.sqrt();
         let discount = (-rate * maturity).exp();

--- a/src/engines/monte_carlo/mc_parallel.rs
+++ b/src/engines/monte_carlo/mc_parallel.rs
@@ -310,8 +310,9 @@ pub fn mc_european_parallel(
     }
 
     let t = instrument.expiry;
+    let effective_dividend_yield = market.effective_dividend_yield(t);
     // Exact terminal-value drift and diffusion.
-    let total_drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * t;
+    let total_drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * t;
     let total_diffusion = vol * t.sqrt();
     let discount = (-market.rate * t).exp();
 
@@ -402,7 +403,8 @@ pub fn mc_european_sequential(
         };
     }
     let t = instrument.expiry;
-    let total_drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * t;
+    let effective_dividend_yield = market.effective_dividend_yield(t);
+    let total_drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * t;
     let total_diffusion = vol * t.sqrt();
     let discount = (-market.rate * t).exp();
 

--- a/src/engines/monte_carlo/mc_qmc.rs
+++ b/src/engines/monte_carlo/mc_qmc.rs
@@ -81,7 +81,8 @@ pub fn mc_european_qmc_with_seed(
     }
 
     let dt = instrument.expiry / n_steps as f64;
-    let dt_drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * dt;
+    let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+    let dt_drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * dt;
     let dt_vol = vol * dt.sqrt();
     let discount = (-market.rate * instrument.expiry).exp();
 

--- a/src/engines/numerical/american_binomial.rs
+++ b/src/engines/numerical/american_binomial.rs
@@ -138,7 +138,8 @@ impl PricingEngine<VanillaOption> for AmericanBinomialEngine {
         let dt = instrument.expiry / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let growth = ((market.rate - market.dividend_yield) * dt).exp();
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(

--- a/src/engines/pde/crank_nicolson.rs
+++ b/src/engines/pde/crank_nicolson.rs
@@ -325,7 +325,8 @@ impl CrankNicolsonEngine {
         let half_dt = 0.5 * dt;
         let inv_2ds = 1.0 / (2.0 * ds);
         let inv_ds2 = 1.0 / (ds * ds);
-        let drift = market.rate - market.dividend_yield;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let drift = market.rate - effective_dividend_yield;
 
         let mut boundary_rev = vec![PdeExerciseBoundaryPoint {
             time: instrument.expiry,
@@ -341,7 +342,7 @@ impl CrankNicolsonEngine {
                 &step_schedule,
                 dt,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 s_max,
             );
 
@@ -521,7 +522,8 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
         let inv_ds2 = 1.0 / (ds * ds);
         let inv_2ds = 1.0 / (2.0 * ds);
         let half_vol2 = 0.5 * vol * vol;
-        let drift = market.rate - market.dividend_yield;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let drift = market.rate - effective_dividend_yield;
         let half_dt = 0.5 * dt;
 
         for k in 0..interior_n {
@@ -568,7 +570,7 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 s_max,
                 tau_new,
             );

--- a/src/engines/pde/explicit_fd.rs
+++ b/src/engines/pde/explicit_fd.rs
@@ -140,6 +140,7 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
         let n_s = self.space_steps;
         let s_max = self.s_max_multiplier * instrument.strike;
         let ds = s_max / n_s as f64;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
 
         // CFL stability: dt <= ds^2 / (sigma^2 * s_max^2)
         let dt_nominal = instrument.expiry / n_t as f64;
@@ -174,7 +175,7 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
         let mut coeff_c = vec![0.0_f64; n_s + 1];
         let ds_sq = ds * ds;
         let half_vol_sq = 0.5 * vol * vol;
-        let half_drift_ds = (market.rate - market.dividend_yield) / (2.0 * ds);
+        let half_drift_ds = (market.rate - effective_dividend_yield) / (2.0 * ds);
         for i in 1..n_s {
             let s = i as f64 * ds;
             let alpha = half_vol_sq * s * s / ds_sq;
@@ -194,7 +195,7 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 s_max,
                 tau_new,
             );

--- a/src/engines/pde/hopscotch.rs
+++ b/src/engines/pde/hopscotch.rs
@@ -145,6 +145,7 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
         let dt = instrument.expiry / n_t as f64;
         let s_max = self.s_max_multiplier * instrument.strike;
         let ds = s_max / n_s as f64;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
         let bermudan_flags = match &instrument.exercise {
@@ -171,7 +172,7 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
             let i = k + 1;
             let s = i as f64 * ds;
             let alpha = 0.5 * vol * vol * s * s / (ds * ds);
-            let beta = (market.rate - market.dividend_yield) * s / (2.0 * ds);
+            let beta = (market.rate - effective_dividend_yield) * s / (2.0 * ds);
 
             a_coeff[k] = alpha - beta;
             b_coeff[k] = -2.0 * alpha - market.rate;
@@ -188,7 +189,7 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 s_max,
                 tau_new,
             );

--- a/src/engines/pde/implicit_fd.rs
+++ b/src/engines/pde/implicit_fd.rs
@@ -182,6 +182,7 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
         let dt = instrument.expiry / n_t as f64;
         let s_max = self.s_max_multiplier * instrument.strike;
         let ds = s_max / n_s as f64;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
         let bermudan_flags = match &instrument.exercise {
@@ -207,7 +208,7 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
         let inv_ds2 = 1.0 / (ds * ds);
         let half_vol_sq = 0.5 * vol * vol;
         let inv_2ds = 1.0 / (2.0 * ds);
-        let drift = market.rate - market.dividend_yield;
+        let drift = market.rate - effective_dividend_yield;
         for k in 0..interior_n {
             let i = k + 1;
             let s = i as f64 * ds;
@@ -244,7 +245,7 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                market.dividend_yield,
+                effective_dividend_yield,
                 s_max,
                 tau_new,
             );

--- a/src/engines/tree/binomial.rs
+++ b/src/engines/tree/binomial.rs
@@ -81,7 +81,8 @@ impl PricingEngine<VanillaOption> for BinomialTreeEngine {
         let dt = instrument.expiry / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let growth = ((market.rate - market.dividend_yield) * dt).exp();
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(

--- a/src/engines/tree/convertible.rs
+++ b/src/engines/tree/convertible.rs
@@ -127,7 +127,8 @@ impl PricingEngine<ConvertibleBond> for ConvertibleBinomialEngine {
         let dt = instrument.maturity / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let growth = ((market.rate - market.dividend_yield) * dt).exp();
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.maturity);
+        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(

--- a/src/engines/tree/swing.rs
+++ b/src/engines/tree/swing.rs
@@ -100,7 +100,8 @@ impl PricingEngine<SwingOption> for SwingTreeEngine {
         let dt = maturity / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let growth = ((market.rate - market.dividend_yield) * dt).exp();
+        let effective_dividend_yield = market.effective_dividend_yield(maturity);
+        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(

--- a/src/engines/tree/trinomial.rs
+++ b/src/engines/tree/trinomial.rs
@@ -82,7 +82,8 @@ impl PricingEngine<VanillaOption> for TrinomialTreeEngine {
         let u = (vol * (2.0 * dt).sqrt()).exp();
         let d = 1.0 / u;
 
-        let nu = market.rate - market.dividend_yield;
+        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let nu = market.rate - effective_dividend_yield;
         let a = (nu * dt / 2.0).exp();
         let b = (vol * (dt / 2.0).sqrt()).exp();
         let denom = b - 1.0 / b;

--- a/src/market/dividends.rs
+++ b/src/market/dividends.rs
@@ -1,0 +1,505 @@
+//! Module `market::dividends`.
+//!
+//! Deterministic discrete-dividend modelling utilities for equity pricing.
+//!
+//! This module supports:
+//! - cash dividends (fixed amount),
+//! - proportional dividends (fraction of spot),
+//! - mixed schedules,
+//! - forward/prepaid-forward calculations under mixed schedules,
+//! - put-call parity bootstrap of an implied dividend curve.
+//!
+//! References:
+//! - Hull, *Options, Futures, and Other Derivatives* (11th ed.), Ch. 13.
+//! - Haug, Haug, Lewis (2003): escrowed-dividend treatment for option pricing.
+
+/// Type of deterministic discrete dividend event.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum DividendKind {
+    /// Fixed cash amount subtracted from spot at ex-date.
+    Cash(f64),
+    /// Proportional drop as a fraction of spot, i.e. `S+ = S- * (1 - p)`.
+    Proportional(f64),
+}
+
+impl DividendKind {
+    fn validate(self) -> Result<(), String> {
+        match self {
+            Self::Cash(amount) => {
+                if !amount.is_finite() || amount < 0.0 {
+                    return Err("cash dividend amount must be finite and >= 0".to_string());
+                }
+            }
+            Self::Proportional(ratio) => {
+                if !ratio.is_finite() || !(0.0..1.0).contains(&ratio) {
+                    return Err(
+                        "proportional dividend ratio must be finite and in [0, 1)".to_string()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Deterministic dividend event.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DividendEvent {
+    /// Ex-dividend time in years from valuation date.
+    pub time: f64,
+    /// Dividend amount/type.
+    pub kind: DividendKind,
+}
+
+impl DividendEvent {
+    /// Builds a cash dividend event.
+    pub fn cash(time: f64, amount: f64) -> Result<Self, String> {
+        let event = Self {
+            time,
+            kind: DividendKind::Cash(amount),
+        };
+        event.validate()?;
+        Ok(event)
+    }
+
+    /// Builds a proportional dividend event.
+    pub fn proportional(time: f64, ratio: f64) -> Result<Self, String> {
+        let event = Self {
+            time,
+            kind: DividendKind::Proportional(ratio),
+        };
+        event.validate()?;
+        Ok(event)
+    }
+
+    /// Applies the event jump to a pre-dividend spot.
+    #[inline]
+    pub fn apply_jump(self, pre_div_spot: f64) -> f64 {
+        match self.kind {
+            DividendKind::Cash(amount) => (pre_div_spot - amount).max(0.0),
+            DividendKind::Proportional(ratio) => pre_div_spot * (1.0 - ratio),
+        }
+    }
+
+    fn validate(self) -> Result<(), String> {
+        if !self.time.is_finite() || self.time <= 0.0 {
+            return Err("dividend event time must be finite and > 0".to_string());
+        }
+        self.kind.validate()
+    }
+}
+
+/// Deterministic mixed discrete-dividend schedule.
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub struct DividendSchedule {
+    events: Vec<DividendEvent>,
+}
+
+impl DividendSchedule {
+    /// Builds a schedule from events and validates ordering and values.
+    pub fn new(mut events: Vec<DividendEvent>) -> Result<Self, String> {
+        events.sort_by(|a, b| a.time.total_cmp(&b.time));
+        let schedule = Self { events };
+        schedule.validate()?;
+        Ok(schedule)
+    }
+
+    /// Returns an empty schedule.
+    #[inline]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` when no events are present.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Returns the underlying sorted event slice.
+    #[inline]
+    pub fn events(&self) -> &[DividendEvent] {
+        &self.events
+    }
+
+    /// Returns all events up to and including `maturity`.
+    #[inline]
+    pub fn events_until(&self, maturity: f64) -> impl Iterator<Item = &DividendEvent> {
+        self.events.iter().filter(move |ev| ev.time <= maturity)
+    }
+
+    /// Validates event values and strictly-increasing event times.
+    pub fn validate(&self) -> Result<(), String> {
+        let mut prev_time = 0.0_f64;
+        for event in &self.events {
+            event.validate()?;
+            if event.time <= prev_time {
+                return Err("dividend event times must be strictly increasing".to_string());
+            }
+            prev_time = event.time;
+        }
+        Ok(())
+    }
+
+    /// Prices the mixed-schedule forward at maturity `T`.
+    ///
+    /// Uses deterministic jump conditions:
+    /// - cash: `S+ = S- - D`,
+    /// - proportional: `S+ = S- * (1 - p)`.
+    ///
+    /// Between jumps, expectation grows at `r - q` (continuous yield `q`).
+    pub fn forward_price(
+        &self,
+        spot: f64,
+        rate: f64,
+        continuous_dividend_yield: f64,
+        maturity: f64,
+    ) -> f64 {
+        if maturity <= 0.0 {
+            return spot;
+        }
+        if !spot.is_finite() || spot <= 0.0 {
+            return 0.0;
+        }
+
+        let carry = rate - continuous_dividend_yield;
+        let mut forward = spot * (carry * maturity).exp();
+
+        for event in self.events_until(maturity) {
+            match event.kind {
+                DividendKind::Cash(amount) => {
+                    forward -= amount * (carry * (maturity - event.time)).exp();
+                }
+                DividendKind::Proportional(ratio) => {
+                    forward *= 1.0 - ratio;
+                }
+            }
+        }
+
+        forward.max(0.0)
+    }
+
+    /// Prepaid-forward spot equivalent at maturity `T`.
+    ///
+    /// This is the escrowed spot used in the Haug-Haug-Lewis approach.
+    #[inline]
+    pub fn prepaid_forward_spot(
+        &self,
+        spot: f64,
+        rate: f64,
+        continuous_dividend_yield: f64,
+        maturity: f64,
+    ) -> f64 {
+        self.forward_price(spot, rate, continuous_dividend_yield, maturity)
+            * (-rate * maturity).exp()
+    }
+
+    /// Escrowed spot adjustment (Haug-Haug-Lewis style) with no continuous yield.
+    #[inline]
+    pub fn escrowed_spot_adjustment(&self, spot: f64, rate: f64, maturity: f64) -> f64 {
+        self.prepaid_forward_spot(spot, rate, 0.0, maturity)
+    }
+
+    /// Equivalent continuous dividend yield implied by the schedule up to `T`.
+    pub fn effective_dividend_yield(
+        &self,
+        spot: f64,
+        rate: f64,
+        continuous_dividend_yield: f64,
+        maturity: f64,
+    ) -> f64 {
+        if maturity <= 0.0 || spot <= 0.0 {
+            return continuous_dividend_yield;
+        }
+        let forward = self.forward_price(spot, rate, continuous_dividend_yield, maturity);
+        let ratio = (forward / spot).max(1.0e-16);
+        rate - ratio.ln() / maturity
+    }
+
+    /// Applies all ex-date jumps up to and including `time`.
+    #[inline]
+    pub fn apply_jumps_until(&self, mut spot: f64, time: f64) -> f64 {
+        for event in self.events_until(time) {
+            spot = event.apply_jump(spot);
+        }
+        spot
+    }
+}
+
+/// Single-strike put-call parity observation for one expiry.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PutCallParityQuote {
+    /// Time to maturity in years.
+    pub maturity: f64,
+    /// Common strike used for call and put.
+    pub strike: f64,
+    /// Call premium.
+    pub call_price: f64,
+    /// Put premium.
+    pub put_price: f64,
+}
+
+impl PutCallParityQuote {
+    /// Validates quote fields.
+    pub fn validate(self) -> Result<(), String> {
+        if !self.maturity.is_finite() || self.maturity <= 0.0 {
+            return Err("parity quote maturity must be finite and > 0".to_string());
+        }
+        if !self.strike.is_finite() || self.strike <= 0.0 {
+            return Err("parity quote strike must be finite and > 0".to_string());
+        }
+        if !self.call_price.is_finite() || self.call_price < 0.0 {
+            return Err("parity quote call price must be finite and >= 0".to_string());
+        }
+        if !self.put_price.is_finite() || self.put_price < 0.0 {
+            return Err("parity quote put price must be finite and >= 0".to_string());
+        }
+        Ok(())
+    }
+
+    /// Implied forward from put-call parity at this maturity.
+    #[inline]
+    pub fn implied_forward(self, rate: f64) -> f64 {
+        (self.call_price - self.put_price) * (rate * self.maturity).exp() + self.strike
+    }
+
+    /// Implied prepaid-forward spot from put-call parity.
+    #[inline]
+    pub fn implied_prepaid_forward(self, rate: f64) -> f64 {
+        self.call_price - self.put_price + self.strike * (-rate * self.maturity).exp()
+    }
+}
+
+/// Bootstrapped point on an implied dividend curve.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BootstrappedDividendPoint {
+    /// Maturity in years.
+    pub maturity: f64,
+    /// Forward implied by parity.
+    pub forward: f64,
+    /// Prepaid-forward spot implied by parity.
+    pub prepaid_forward: f64,
+    /// Equivalent continuous dividend yield up to maturity.
+    pub implied_dividend_yield: f64,
+    /// Cumulative PV dividend impact from spot to this maturity.
+    pub cumulative_pv_dividends: f64,
+}
+
+/// Dividend curve bootstrapped from put-call parity quotes.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DividendCurveBootstrap {
+    /// Spot used for bootstrap.
+    pub spot: f64,
+    /// Flat discount rate used for bootstrap.
+    pub rate: f64,
+    /// Bootstrapped maturity points.
+    pub points: Vec<BootstrappedDividendPoint>,
+}
+
+impl DividendCurveBootstrap {
+    /// Bootstraps a dividend curve from put-call parity observations.
+    ///
+    /// Multiple strikes per maturity are supported and averaged.
+    pub fn from_put_call_parity(
+        spot: f64,
+        rate: f64,
+        quotes: &[PutCallParityQuote],
+    ) -> Result<Self, String> {
+        if !spot.is_finite() || spot <= 0.0 {
+            return Err("spot must be finite and > 0".to_string());
+        }
+        if quotes.is_empty() {
+            return Err("at least one parity quote is required".to_string());
+        }
+        for q in quotes {
+            q.validate()?;
+        }
+
+        let mut sorted = quotes.to_vec();
+        sorted.sort_by(|a, b| a.maturity.total_cmp(&b.maturity));
+
+        let mut points = Vec::new();
+        let mut i = 0usize;
+        while i < sorted.len() {
+            let t = sorted[i].maturity;
+            let mut sum_fwd = 0.0_f64;
+            let mut sum_prepaid = 0.0_f64;
+            let mut n = 0usize;
+
+            while i < sorted.len() && (sorted[i].maturity - t).abs() <= 1.0e-12 {
+                let fwd = sorted[i].implied_forward(rate);
+                let prepaid = sorted[i].implied_prepaid_forward(rate);
+                if !fwd.is_finite() || !prepaid.is_finite() || prepaid <= 0.0 {
+                    return Err(
+                        "invalid parity quote implies non-positive prepaid forward".to_string()
+                    );
+                }
+                sum_fwd += fwd;
+                sum_prepaid += prepaid;
+                n += 1;
+                i += 1;
+            }
+
+            let n_f64 = n as f64;
+            let forward = sum_fwd / n_f64;
+            let prepaid_forward = sum_prepaid / n_f64;
+            let implied_dividend_yield = -((prepaid_forward / spot).max(1.0e-16)).ln() / t;
+            let cumulative_pv_dividends = spot - prepaid_forward;
+
+            points.push(BootstrappedDividendPoint {
+                maturity: t,
+                forward,
+                prepaid_forward,
+                implied_dividend_yield,
+                cumulative_pv_dividends,
+            });
+        }
+
+        Ok(Self { spot, rate, points })
+    }
+
+    /// Prepaid-forward spot from the curve at maturity `T`.
+    ///
+    /// Uses log-linear interpolation in prepaid-forward space.
+    pub fn prepaid_forward_spot(&self, maturity: f64) -> f64 {
+        if maturity <= 0.0 {
+            return self.spot;
+        }
+        if self.points.is_empty() {
+            return self.spot;
+        }
+
+        let first = self.points[0];
+        if maturity <= first.maturity {
+            let w = (maturity / first.maturity).clamp(0.0, 1.0);
+            let ln_p0 = self.spot.max(1.0e-16).ln();
+            let ln_p1 = first.prepaid_forward.max(1.0e-16).ln();
+            return (ln_p0 + (ln_p1 - ln_p0) * w).exp();
+        }
+
+        for win in self.points.windows(2) {
+            let p0 = win[0];
+            let p1 = win[1];
+            if maturity <= p1.maturity {
+                let w = (maturity - p0.maturity) / (p1.maturity - p0.maturity);
+                let ln_a = p0.prepaid_forward.max(1.0e-16).ln();
+                let ln_b = p1.prepaid_forward.max(1.0e-16).ln();
+                return (ln_a + (ln_b - ln_a) * w.clamp(0.0, 1.0)).exp();
+            }
+        }
+
+        let last = self.points[self.points.len() - 1];
+        self.spot * (-last.implied_dividend_yield * maturity).exp()
+    }
+
+    /// Forward from the curve at maturity `T`.
+    #[inline]
+    pub fn forward(&self, maturity: f64) -> f64 {
+        self.prepaid_forward_spot(maturity) * (self.rate * maturity).exp()
+    }
+
+    /// Converts the curve into a cash-dividend schedule at bootstrap maturities.
+    ///
+    /// This assumes all dividend impact between neighboring maturities can be
+    /// represented as one cash dividend paid at the later maturity.
+    pub fn to_cash_dividend_schedule(&self) -> Result<DividendSchedule, String> {
+        let mut events = Vec::new();
+        let mut prev_cum_pv = 0.0_f64;
+
+        for point in &self.points {
+            if point.cumulative_pv_dividends + 1.0e-12 < prev_cum_pv {
+                return Err(
+                    "cumulative PV dividends must be non-decreasing to map into cash schedule"
+                        .to_string(),
+                );
+            }
+            let increment_pv = (point.cumulative_pv_dividends - prev_cum_pv).max(0.0);
+            if increment_pv > 0.0 {
+                let cash = increment_pv * (self.rate * point.maturity).exp();
+                events.push(DividendEvent {
+                    time: point.maturity,
+                    kind: DividendKind::Cash(cash),
+                });
+            }
+            prev_cum_pv = point.cumulative_pv_dividends.max(prev_cum_pv);
+        }
+
+        DividendSchedule::new(events)
+    }
+}
+
+/// Convenience bootstrap wrapper.
+#[inline]
+pub fn bootstrap_dividend_curve_from_put_call_parity(
+    spot: f64,
+    rate: f64,
+    quotes: &[PutCallParityQuote],
+) -> Result<DividendCurveBootstrap, String> {
+    DividendCurveBootstrap::from_put_call_parity(spot, rate, quotes)
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_relative_eq;
+
+    use super::*;
+
+    #[test]
+    fn mixed_schedule_forward_and_escrowed_spot() {
+        let schedule = DividendSchedule::new(vec![
+            DividendEvent::cash(0.25, 1.0).expect("valid cash event"),
+            DividendEvent::proportional(0.5, 0.02).expect("valid proportional event"),
+            DividendEvent::cash(0.75, 0.5).expect("valid cash event"),
+        ])
+        .expect("valid schedule");
+
+        let spot = 100.0;
+        let r = 0.03;
+        let q = 0.0;
+        let t = 1.0;
+
+        let fwd = schedule.forward_price(spot, r, q, t);
+        let prepaid = schedule.prepaid_forward_spot(spot, r, q, t);
+        let q_eff = schedule.effective_dividend_yield(spot, r, q, t);
+
+        assert!(fwd < spot * (r * t).exp());
+        assert!(prepaid < spot);
+        assert!(q_eff > 0.0);
+        assert_relative_eq!(prepaid * (r * t).exp(), fwd, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn put_call_parity_bootstrap_reproduces_forward_points() {
+        let spot = 100.0_f64;
+        let rate = 0.02_f64;
+        let forwards = [
+            (0.5_f64, 100.8_f64),
+            (1.0_f64, 101.1_f64),
+            (2.0_f64, 102.4_f64),
+        ];
+        let strike = 100.0_f64;
+
+        let quotes: Vec<PutCallParityQuote> = forwards
+            .iter()
+            .map(|(t, fwd)| {
+                let call_minus_put = (fwd - strike) * (-rate * *t).exp();
+                let put = 6.0;
+                let call = put + call_minus_put;
+                PutCallParityQuote {
+                    maturity: *t,
+                    strike,
+                    call_price: call,
+                    put_price: put,
+                }
+            })
+            .collect();
+
+        let curve = bootstrap_dividend_curve_from_put_call_parity(spot, rate, &quotes)
+            .expect("bootstrap should succeed");
+
+        for (t, fwd) in forwards {
+            let model_fwd = curve.forward(t);
+            assert_relative_eq!(model_fwd, fwd, epsilon = 1e-10);
+        }
+    }
+}

--- a/src/market/mod.rs
+++ b/src/market/mod.rs
@@ -9,6 +9,8 @@
 //! Numerical considerations: validate edge-domain inputs, preserve finite values where possible, and cross-check with reference implementations for production use.
 //!
 //! When to use: choose this module when its API directly matches your instrument/model assumptions; otherwise use a more specialized engine module.
+pub mod dividends;
 pub mod market;
 
+pub use dividends::*;
 pub use market::*;

--- a/tests/dividend_modelling_issue58.rs
+++ b/tests/dividend_modelling_issue58.rs
@@ -1,0 +1,152 @@
+use openferric::core::PricingEngine;
+use openferric::engines::monte_carlo::mc_engine::{MonteCarloPricingEngine, VarianceReduction};
+use openferric::engines::numerical::american_binomial::AmericanBinomialEngine;
+use openferric::instruments::{BarrierOption, VanillaOption};
+use openferric::market::{
+    DividendEvent, DividendSchedule, Market, PutCallParityQuote,
+    bootstrap_dividend_curve_from_put_call_parity,
+};
+
+#[test]
+fn american_discrete_cash_div_matches_quantlib_within_point_one_percent() {
+    // QuantLib 1.41 reference, FdBlackScholesVanillaEngine (Escrowed model),
+    // tGrid=xGrid=800:
+    // S=100, K=100, r=3%, q=0%, vol=25%, T=1y, one cash dividend 0.2 at t=0.5.
+    let ql_call = 11.231_303_076_021_439_f64;
+    let ql_put = 8.744_346_284_348_829_f64;
+
+    let schedule = DividendSchedule::new(vec![DividendEvent::cash(0.5, 0.2).expect("valid event")])
+        .expect("valid schedule");
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.0)
+        .dividend_schedule(schedule)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+
+    let engine = AmericanBinomialEngine::new(4000);
+    let call = engine
+        .price(&VanillaOption::american_call(100.0, 1.0), &market)
+        .expect("call pricing")
+        .price;
+    let put = engine
+        .price(&VanillaOption::american_put(100.0, 1.0), &market)
+        .expect("put pricing")
+        .price;
+
+    let call_rel_err = (call - ql_call).abs() / ql_call;
+    let put_rel_err = (put - ql_put).abs() / ql_put;
+
+    assert!(
+        call_rel_err <= 1.0e-3,
+        "call rel err {} exceeds 0.1% (model={}, ql={})",
+        call_rel_err,
+        call,
+        ql_call
+    );
+    assert!(
+        put_rel_err <= 1.0e-3,
+        "put rel err {} exceeds 0.1% (model={}, ql={})",
+        put_rel_err,
+        put,
+        ql_put
+    );
+}
+
+#[test]
+fn barrier_mc_applies_ex_div_jump_on_path() {
+    let barrier = BarrierOption::builder()
+        .put()
+        .strike(100.0)
+        .expiry(1.0)
+        .down_and_in(95.0)
+        .rebate(0.0)
+        .build()
+        .expect("valid barrier");
+
+    let base_market = Market::builder()
+        .spot(100.0)
+        .rate(0.0)
+        .dividend_yield(0.0)
+        .flat_vol(1.0e-8)
+        .build()
+        .expect("valid market");
+
+    let with_div_market = Market::builder()
+        .spot(100.0)
+        .rate(0.0)
+        .dividend_yield(0.0)
+        .dividend_schedule(
+            DividendSchedule::new(vec![DividendEvent::cash(0.5, 10.0).expect("valid event")])
+                .expect("valid schedule"),
+        )
+        .flat_vol(1.0e-8)
+        .build()
+        .expect("valid market");
+
+    let engine = MonteCarloPricingEngine::new(20_000, 252, 42)
+        .with_variance_reduction(VarianceReduction::Antithetic);
+
+    let no_div_price = engine
+        .price(&barrier, &base_market)
+        .expect("base barrier pricing")
+        .price;
+    let with_div_price = engine
+        .price(&barrier, &with_div_market)
+        .expect("dividend barrier pricing")
+        .price;
+
+    // Without jump the deterministic path never breaches 95.
+    assert!(
+        no_div_price <= 1.0e-3,
+        "expected ~0 without ex-div jump, got {no_div_price}"
+    );
+    // With a 10 cash dividend at t=0.5, deterministic path jumps to 90 and knocks in.
+    assert!(
+        (with_div_price - 10.0).abs() <= 1.0e-3,
+        "expected ~10 with ex-div jump knock-in, got {with_div_price}"
+    );
+}
+
+#[test]
+fn bootstrap_dividend_curve_reproduces_forwards_within_one_bp() {
+    let spot = 100.0_f64;
+    let rate = 0.02_f64;
+    let strike = 100.0_f64;
+    let input_forwards = [
+        (0.5_f64, 100.75_f64),
+        (1.0_f64, 101.20_f64),
+        (1.5_f64, 101.65_f64),
+    ];
+
+    let quotes: Vec<PutCallParityQuote> = input_forwards
+        .iter()
+        .map(|(t, fwd)| {
+            let call_minus_put = (fwd - strike) * (-rate * *t).exp();
+            let put_price = 5.0;
+            PutCallParityQuote {
+                maturity: *t,
+                strike,
+                call_price: put_price + call_minus_put,
+                put_price,
+            }
+        })
+        .collect();
+
+    let curve = bootstrap_dividend_curve_from_put_call_parity(spot, rate, &quotes)
+        .expect("bootstrap should succeed");
+    let schedule = curve
+        .to_cash_dividend_schedule()
+        .expect("cash schedule conversion should succeed");
+
+    for (t, fwd) in input_forwards {
+        let model_fwd = schedule.forward_price(spot, rate, 0.0, t);
+        let abs_err = (model_fwd - fwd).abs();
+        assert!(
+            abs_err <= 0.01, // 1bp on a ~100 forward is ~0.01 absolute
+            "forward mismatch at T={t}: model={model_fwd}, input={fwd}, abs_err={abs_err}"
+        );
+    }
+}


### PR DESCRIPTION
1061 lines across 28 files: DividendSchedule (cash/proportional/mixed), forward price, escrowed spot, put-call parity bootstrap, engine integration. 390 tests.