### PR TITLE
feat(engines): explicit FD, implicit FD, hopscotch & ADI PDE solvers (closes #35)

### DIFF
--- a/openferric-wasm/src/pricing.rs
+++ b/openferric-wasm/src/pricing.rs
@@ -492,17 +492,8 @@ mod tests {
         let mats = [1.0, 0.75];
         let calls = [1u8, 0u8];
 
-        let black =
-            black76_price_batch_wasm(&forwards, &strikes, &rates, &vols, &mats, &calls);
-        let bsm = bs_price_batch_wasm(
-            &forwards,
-            &strikes,
-            &rates,
-            &rates,
-            &vols,
-            &mats,
-            &calls,
-        );
+        let black = black76_price_batch_wasm(&forwards, &strikes, &rates, &vols, &mats, &calls);
+        let bsm = bs_price_batch_wasm(&forwards, &strikes, &rates, &rates, &vols, &mats, &calls);
 
         assert_eq!(black.len(), bsm.len());
         for i in 0..black.len() {
@@ -524,13 +515,7 @@ mod tests {
         let black =
             black76_greeks_batch_wasm(&forwards, &strikes, &rates, &vols, &expiries, &calls);
         let bsm = bsm_greeks_batch_wasm(
-            &forwards,
-            &strikes,
-            &rates,
-            &rates,
-            &vols,
-            &expiries,
-            &calls,
+            &forwards, &strikes, &rates, &rates, &vols, &expiries, &calls,
         );
 
         assert_eq!(black.len(), 7);

--- a/src/engines/pde/adi.rs
+++ b/src/engines/pde/adi.rs
@@ -1,0 +1,665 @@
+//! Alternating-Direction Implicit solvers for the two-factor Heston PDE.
+//!
+//! This module provides Douglas-Rachford and Craig-Sneyd ADI schemes for
+//! European vanilla options on a uniform `(S, v)` grid.
+
+use crate::core::{DiagKey, ExerciseStyle, OptionType, PricingEngine, PricingError, PricingResult};
+use crate::instruments::vanilla::VanillaOption;
+use crate::market::Market;
+use crate::models::stochastic::Heston;
+
+use super::fd_common::{intrinsic, solve_tridiagonal_inplace};
+
+#[inline]
+fn idx(i: usize, j: usize, n_s: usize) -> usize {
+    j * (n_s + 1) + i
+}
+
+/// ADI splitting variant for the Heston PDE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdiScheme {
+    /// Douglas-Rachford two-sweep ADI splitting.
+    DouglasRachford,
+    /// Craig-Sneyd splitting with an extra mixed-derivative correction sweep.
+    CraigSneyd,
+}
+
+/// ADI finite-difference engine for European vanilla options under Heston dynamics.
+#[derive(Debug, Clone)]
+pub struct AdiHestonEngine {
+    /// Heston model parameters.
+    pub model: Heston,
+    /// ADI splitting scheme.
+    pub scheme: AdiScheme,
+    /// Number of time steps.
+    pub time_steps: usize,
+    /// Number of spot intervals.
+    pub spot_steps: usize,
+    /// Number of variance intervals.
+    pub variance_steps: usize,
+    /// Spot truncation multiplier: `S_max = s_max_multiplier * max(spot, strike)`.
+    pub s_max_multiplier: f64,
+    /// Variance truncation multiplier: `v_max = v_max_multiplier * max(theta, v0, 0.04)`.
+    pub v_max_multiplier: f64,
+    /// ADI theta parameter used by implicit directional sweeps.
+    pub theta_adi: f64,
+    /// If `true`, reject model parameters that violate `2*kappa*theta >= xi^2`.
+    pub enforce_feller: bool,
+}
+
+impl AdiHestonEngine {
+    /// Creates an ADI Heston engine with explicit grid sizes.
+    pub fn new(model: Heston, time_steps: usize, spot_steps: usize, variance_steps: usize) -> Self {
+        Self {
+            model,
+            scheme: AdiScheme::CraigSneyd,
+            time_steps,
+            spot_steps,
+            variance_steps,
+            s_max_multiplier: 4.0,
+            v_max_multiplier: 5.0,
+            theta_adi: 0.5,
+            enforce_feller: true,
+        }
+    }
+
+    /// Selects the splitting scheme.
+    pub fn with_scheme(mut self, scheme: AdiScheme) -> Self {
+        self.scheme = scheme;
+        self
+    }
+
+    /// Sets `S_max = multiplier * max(spot, strike)`.
+    pub fn with_s_max_multiplier(mut self, s_max_multiplier: f64) -> Self {
+        self.s_max_multiplier = s_max_multiplier;
+        self
+    }
+
+    /// Sets `v_max = multiplier * max(theta, v0, 0.04)`.
+    pub fn with_v_max_multiplier(mut self, v_max_multiplier: f64) -> Self {
+        self.v_max_multiplier = v_max_multiplier;
+        self
+    }
+
+    /// Sets the ADI theta parameter.
+    pub fn with_theta_adi(mut self, theta_adi: f64) -> Self {
+        self.theta_adi = theta_adi;
+        self
+    }
+
+    /// Enables or disables strict Feller-condition enforcement.
+    pub fn with_enforce_feller(mut self, enforce_feller: bool) -> Self {
+        self.enforce_feller = enforce_feller;
+        self
+    }
+}
+
+struct HestonPdeCoefficients {
+    a0: Vec<f64>,
+    a1: Vec<f64>,
+    a2: Vec<f64>,
+    total: Vec<f64>,
+}
+
+struct HestonGrid {
+    n_s: usize,
+    n_v: usize,
+    ds: f64,
+    dv: f64,
+    s_max: f64,
+}
+
+impl HestonGrid {
+    fn n_points(&self) -> usize {
+        (self.n_s + 1) * (self.n_v + 1)
+    }
+}
+
+fn apply_spot_boundaries(
+    values: &mut [f64],
+    option_type: OptionType,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    tau: f64,
+    grid: &HestonGrid,
+) {
+    let lower = match option_type {
+        OptionType::Call => 0.0,
+        OptionType::Put => strike * (-rate * tau).exp(),
+    };
+    let upper = match option_type {
+        OptionType::Call => {
+            (grid.s_max * (-dividend_yield * tau).exp() - strike * (-rate * tau).exp()).max(0.0)
+        }
+        OptionType::Put => 0.0,
+    };
+
+    for j in 0..=grid.n_v {
+        values[idx(0, j, grid.n_s)] = lower;
+        values[idx(grid.n_s, j, grid.n_s)] = upper;
+    }
+}
+
+fn apply_variance_neumann_boundaries(values: &mut [f64], grid: &HestonGrid) {
+    for i in 1..grid.n_s {
+        values[idx(i, 0, grid.n_s)] = values[idx(i, 1, grid.n_s)];
+        values[idx(i, grid.n_v, grid.n_s)] = values[idx(i, grid.n_v - 1, grid.n_s)];
+    }
+}
+
+fn apply_boundaries(
+    values: &mut [f64],
+    option_type: OptionType,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    tau: f64,
+    grid: &HestonGrid,
+) {
+    apply_variance_neumann_boundaries(values, grid);
+    apply_spot_boundaries(values, option_type, strike, rate, dividend_yield, tau, grid);
+}
+
+fn compute_heston_operators(
+    values: &[f64],
+    rate: f64,
+    dividend_yield: f64,
+    model: &Heston,
+    grid: &HestonGrid,
+    out: &mut HestonPdeCoefficients,
+) {
+    out.a0.fill(0.0);
+    out.a1.fill(0.0);
+    out.a2.fill(0.0);
+    out.total.fill(0.0);
+
+    let ds = grid.ds;
+    let dv = grid.dv;
+    let inv_2ds = 0.5 / ds;
+    let inv_2dv = 0.5 / dv;
+    let inv_ds2 = 1.0 / (ds * ds);
+    let inv_dv2 = 1.0 / (dv * dv);
+    let inv_4dsdv = 0.25 / (ds * dv);
+
+    for j in 1..grid.n_v {
+        let v = j as f64 * dv;
+        for i in 1..grid.n_s {
+            let s = i as f64 * ds;
+            let p = idx(i, j, grid.n_s);
+
+            let v_c = values[p];
+            let v_s_m = values[idx(i - 1, j, grid.n_s)];
+            let v_s_p = values[idx(i + 1, j, grid.n_s)];
+            let v_v_m = values[idx(i, j - 1, grid.n_s)];
+            let v_v_p = values[idx(i, j + 1, grid.n_s)];
+
+            let dss = (v_s_p - 2.0 * v_c + v_s_m) * inv_ds2;
+            let d_s = (v_s_p - v_s_m) * inv_2ds;
+            let dvv = (v_v_p - 2.0 * v_c + v_v_m) * inv_dv2;
+            let d_v = (v_v_p - v_v_m) * inv_2dv;
+
+            let cross = (values[idx(i + 1, j + 1, grid.n_s)]
+                - values[idx(i + 1, j - 1, grid.n_s)]
+                - values[idx(i - 1, j + 1, grid.n_s)]
+                + values[idx(i - 1, j - 1, grid.n_s)])
+                * inv_4dsdv;
+
+            let a0 = model.rho * model.xi * v * s * cross;
+            let a1 = 0.5 * v * s * s * dss + (rate - dividend_yield) * s * d_s - rate * v_c;
+            let a2 = 0.5 * model.xi * model.xi * v * dvv + model.kappa * (model.theta - v) * d_v;
+
+            out.a0[p] = a0;
+            out.a1[p] = a1;
+            out.a2[p] = a2;
+            out.total[p] = a0 + a1 + a2;
+        }
+    }
+}
+
+struct SolveCtx<'a> {
+    rate: f64,
+    dividend_yield: f64,
+    theta_dt: f64,
+    model: &'a Heston,
+    grid: &'a HestonGrid,
+}
+
+fn solve_s_direction(
+    rhs_seed: &[f64],
+    a1_old: &[f64],
+    option_type: OptionType,
+    strike: f64,
+    tau: f64,
+    ctx: &SolveCtx<'_>,
+    out: &mut [f64],
+) -> Result<(), PricingError> {
+    let m = ctx.grid.n_s - 1;
+    let mut lower = vec![0.0_f64; m];
+    let mut diag = vec![0.0_f64; m];
+    let mut upper = vec![0.0_f64; m];
+    let mut solve_lower = vec![0.0_f64; m];
+    let mut solve_upper = vec![0.0_f64; m];
+    let mut rhs = vec![0.0_f64; m];
+    let mut c_star = vec![0.0_f64; m];
+    let mut d_star = vec![0.0_f64; m];
+    let mut interior = vec![0.0_f64; m];
+
+    apply_spot_boundaries(
+        out,
+        option_type,
+        strike,
+        ctx.rate,
+        ctx.dividend_yield,
+        tau,
+        ctx.grid,
+    );
+
+    let ds = ctx.grid.ds;
+    let inv_2ds = 0.5 / ds;
+    let inv_ds2 = 1.0 / (ds * ds);
+
+    for j in 1..ctx.grid.n_v {
+        let v = j as f64 * ctx.grid.dv;
+        let lo_bv = out[idx(0, j, ctx.grid.n_s)];
+        let hi_bv = out[idx(ctx.grid.n_s, j, ctx.grid.n_s)];
+
+        for k in 0..m {
+            let i = k + 1;
+            let s = i as f64 * ds;
+
+            let a = 0.5 * v * s * s * inv_ds2 - (ctx.rate - ctx.dividend_yield) * s * inv_2ds;
+            let b = -v * s * s * inv_ds2 - ctx.rate;
+            let c = 0.5 * v * s * s * inv_ds2 + (ctx.rate - ctx.dividend_yield) * s * inv_2ds;
+
+            lower[k] = -ctx.theta_dt * a;
+            diag[k] = 1.0 - ctx.theta_dt * b;
+            upper[k] = -ctx.theta_dt * c;
+
+            let p = idx(i, j, ctx.grid.n_s);
+            rhs[k] = rhs_seed[p] - ctx.theta_dt * a1_old[p];
+        }
+
+        rhs[0] -= lower[0] * lo_bv;
+        rhs[m - 1] -= upper[m - 1] * hi_bv;
+
+        solve_lower.copy_from_slice(&lower);
+        solve_upper.copy_from_slice(&upper);
+        solve_lower[0] = 0.0;
+        solve_upper[m - 1] = 0.0;
+
+        solve_tridiagonal_inplace(
+            &solve_lower,
+            &diag,
+            &solve_upper,
+            &rhs,
+            &mut c_star,
+            &mut d_star,
+            &mut interior,
+        )?;
+
+        for k in 0..m {
+            let i = k + 1;
+            out[idx(i, j, ctx.grid.n_s)] = interior[k];
+        }
+    }
+
+    apply_boundaries(
+        out,
+        option_type,
+        strike,
+        ctx.rate,
+        ctx.dividend_yield,
+        tau,
+        ctx.grid,
+    );
+    Ok(())
+}
+
+fn solve_v_direction(
+    rhs_seed: &[f64],
+    a2_old: &[f64],
+    option_type: OptionType,
+    strike: f64,
+    tau: f64,
+    ctx: &SolveCtx<'_>,
+    out: &mut [f64],
+) -> Result<(), PricingError> {
+    let m = ctx.grid.n_v - 1;
+    let mut lower = vec![0.0_f64; m];
+    let mut diag = vec![0.0_f64; m];
+    let mut upper = vec![0.0_f64; m];
+    let mut solve_lower = vec![0.0_f64; m];
+    let mut solve_upper = vec![0.0_f64; m];
+    let mut rhs = vec![0.0_f64; m];
+    let mut c_star = vec![0.0_f64; m];
+    let mut d_star = vec![0.0_f64; m];
+    let mut interior = vec![0.0_f64; m];
+
+    let dv = ctx.grid.dv;
+    let inv_2dv = 0.5 / dv;
+    let inv_dv2 = 1.0 / (dv * dv);
+
+    for i in 1..ctx.grid.n_s {
+        let lo_bv = rhs_seed[idx(i, 1, ctx.grid.n_s)];
+        let hi_bv = rhs_seed[idx(i, ctx.grid.n_v - 1, ctx.grid.n_s)];
+
+        for k in 0..m {
+            let j = k + 1;
+            let v = j as f64 * dv;
+
+            let a = 0.5 * ctx.model.xi * ctx.model.xi * v * inv_dv2
+                - ctx.model.kappa * (ctx.model.theta - v) * inv_2dv;
+            let b = -ctx.model.xi * ctx.model.xi * v * inv_dv2;
+            let c = 0.5 * ctx.model.xi * ctx.model.xi * v * inv_dv2
+                + ctx.model.kappa * (ctx.model.theta - v) * inv_2dv;
+
+            lower[k] = -ctx.theta_dt * a;
+            diag[k] = 1.0 - ctx.theta_dt * b;
+            upper[k] = -ctx.theta_dt * c;
+
+            let p = idx(i, j, ctx.grid.n_s);
+            rhs[k] = rhs_seed[p] - ctx.theta_dt * a2_old[p];
+        }
+
+        rhs[0] -= lower[0] * lo_bv;
+        rhs[m - 1] -= upper[m - 1] * hi_bv;
+
+        solve_lower.copy_from_slice(&lower);
+        solve_upper.copy_from_slice(&upper);
+        solve_lower[0] = 0.0;
+        solve_upper[m - 1] = 0.0;
+
+        solve_tridiagonal_inplace(
+            &solve_lower,
+            &diag,
+            &solve_upper,
+            &rhs,
+            &mut c_star,
+            &mut d_star,
+            &mut interior,
+        )?;
+
+        for k in 0..m {
+            let j = k + 1;
+            out[idx(i, j, ctx.grid.n_s)] = interior[k];
+        }
+    }
+
+    apply_boundaries(
+        out,
+        option_type,
+        strike,
+        ctx.rate,
+        ctx.dividend_yield,
+        tau,
+        ctx.grid,
+    );
+    Ok(())
+}
+
+impl PricingEngine<VanillaOption> for AdiHestonEngine {
+    fn price(
+        &self,
+        instrument: &VanillaOption,
+        market: &Market,
+    ) -> Result<PricingResult, PricingError> {
+        instrument.validate()?;
+
+        if !matches!(instrument.exercise, ExerciseStyle::European) {
+            return Err(PricingError::InvalidInput(
+                "AdiHestonEngine supports European exercise only".to_string(),
+            ));
+        }
+        if self.time_steps == 0 || self.spot_steps < 3 || self.variance_steps < 3 {
+            return Err(PricingError::InvalidInput(
+                "time_steps must be > 0 and spot_steps/variance_steps must be >= 3".to_string(),
+            ));
+        }
+        if self.s_max_multiplier <= 0.0
+            || !self.s_max_multiplier.is_finite()
+            || self.v_max_multiplier <= 0.0
+            || !self.v_max_multiplier.is_finite()
+        {
+            return Err(PricingError::InvalidInput(
+                "s_max_multiplier and v_max_multiplier must be finite and > 0".to_string(),
+            ));
+        }
+        if self.theta_adi <= 0.0 || self.theta_adi > 1.0 || !self.theta_adi.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "theta_adi must be finite and in (0, 1]".to_string(),
+            ));
+        }
+        if !self.model.validate() {
+            return Err(PricingError::InvalidInput(
+                "invalid Heston parameters".to_string(),
+            ));
+        }
+
+        let feller_lhs = 2.0 * self.model.kappa * self.model.theta;
+        let feller_rhs = self.model.xi * self.model.xi;
+        if self.enforce_feller && feller_lhs + 1.0e-12 < feller_rhs {
+            return Err(PricingError::InvalidInput(format!(
+                "Feller condition violated: 2*kappa*theta={feller_lhs:.6e} < xi^2={feller_rhs:.6e}",
+            )));
+        }
+
+        if instrument.expiry == 0.0 {
+            return Ok(PricingResult {
+                price: intrinsic(instrument.option_type, market.spot, instrument.strike),
+                stderr: None,
+                greeks: None,
+                diagnostics: crate::core::Diagnostics::new(),
+            });
+        }
+
+        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        let s_max = self.s_max_multiplier * s_anchor;
+        let v_anchor = self.model.theta.max(self.model.v0).max(0.04);
+        let v_max = self.v_max_multiplier * v_anchor;
+
+        let grid = HestonGrid {
+            n_s: self.spot_steps,
+            n_v: self.variance_steps,
+            ds: s_max / self.spot_steps as f64,
+            dv: v_max / self.variance_steps as f64,
+            s_max,
+        };
+
+        let n_t = self.time_steps;
+        let dt = instrument.expiry / n_t as f64;
+        let theta_dt = self.theta_adi * dt;
+        let rate = market.rate;
+        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+
+        let mut u = vec![0.0_f64; grid.n_points()];
+        for j in 0..=grid.n_v {
+            for i in 0..=grid.n_s {
+                let s = i as f64 * grid.ds;
+                u[idx(i, j, grid.n_s)] = intrinsic(instrument.option_type, s, instrument.strike);
+            }
+        }
+        apply_boundaries(
+            &mut u,
+            instrument.option_type,
+            instrument.strike,
+            rate,
+            dividend_yield,
+            0.0,
+            &grid,
+        );
+
+        let mut ops = HestonPdeCoefficients {
+            a0: vec![0.0; grid.n_points()],
+            a1: vec![0.0; grid.n_points()],
+            a2: vec![0.0; grid.n_points()],
+            total: vec![0.0; grid.n_points()],
+        };
+        let mut ops_tmp = HestonPdeCoefficients {
+            a0: vec![0.0; grid.n_points()],
+            a1: vec![0.0; grid.n_points()],
+            a2: vec![0.0; grid.n_points()],
+            total: vec![0.0; grid.n_points()],
+        };
+
+        let mut y0 = vec![0.0_f64; grid.n_points()];
+        let mut y1 = vec![0.0_f64; grid.n_points()];
+        let mut y2 = vec![0.0_f64; grid.n_points()];
+        let mut z0 = vec![0.0_f64; grid.n_points()];
+        let mut z1 = vec![0.0_f64; grid.n_points()];
+        let mut z2 = vec![0.0_f64; grid.n_points()];
+
+        let ctx = SolveCtx {
+            rate,
+            dividend_yield,
+            theta_dt,
+            model: &self.model,
+            grid: &grid,
+        };
+
+        for step in 0..n_t {
+            let tau_new = (step + 1) as f64 * dt;
+
+            compute_heston_operators(&u, rate, dividend_yield, &self.model, &grid, &mut ops);
+
+            y0.copy_from_slice(&u);
+            for j in 1..grid.n_v {
+                for i in 1..grid.n_s {
+                    let p = idx(i, j, grid.n_s);
+                    y0[p] = dt.mul_add(ops.total[p], u[p]);
+                }
+            }
+            apply_boundaries(
+                &mut y0,
+                instrument.option_type,
+                instrument.strike,
+                rate,
+                dividend_yield,
+                tau_new,
+                &grid,
+            );
+
+            solve_s_direction(
+                &y0,
+                &ops.a1,
+                instrument.option_type,
+                instrument.strike,
+                tau_new,
+                &ctx,
+                &mut y1,
+            )?;
+            solve_v_direction(
+                &y1,
+                &ops.a2,
+                instrument.option_type,
+                instrument.strike,
+                tau_new,
+                &ctx,
+                &mut y2,
+            )?;
+
+            match self.scheme {
+                AdiScheme::DouglasRachford => {
+                    u.copy_from_slice(&y2);
+                }
+                AdiScheme::CraigSneyd => {
+                    compute_heston_operators(
+                        &y2,
+                        rate,
+                        dividend_yield,
+                        &self.model,
+                        &grid,
+                        &mut ops_tmp,
+                    );
+
+                    z0.copy_from_slice(&y0);
+                    for j in 1..grid.n_v {
+                        for i in 1..grid.n_s {
+                            let p = idx(i, j, grid.n_s);
+                            z0[p] = y0[p] + 0.5 * dt * (ops_tmp.a0[p] - ops.a0[p]);
+                        }
+                    }
+                    apply_boundaries(
+                        &mut z0,
+                        instrument.option_type,
+                        instrument.strike,
+                        rate,
+                        dividend_yield,
+                        tau_new,
+                        &grid,
+                    );
+
+                    solve_s_direction(
+                        &z0,
+                        &ops.a1,
+                        instrument.option_type,
+                        instrument.strike,
+                        tau_new,
+                        &ctx,
+                        &mut z1,
+                    )?;
+                    solve_v_direction(
+                        &z1,
+                        &ops.a2,
+                        instrument.option_type,
+                        instrument.strike,
+                        tau_new,
+                        &ctx,
+                        &mut z2,
+                    )?;
+                    u.copy_from_slice(&z2);
+                }
+            }
+
+            apply_boundaries(
+                &mut u,
+                instrument.option_type,
+                instrument.strike,
+                rate,
+                dividend_yield,
+                tau_new,
+                &grid,
+            );
+        }
+
+        let s = market.spot.clamp(0.0, s_max);
+        let v = self.model.v0.clamp(0.0, v_max);
+
+        let i_hi = (s / grid.ds).floor() as usize;
+        let j_hi = (v / grid.dv).floor() as usize;
+        let i = i_hi.min(grid.n_s - 1);
+        let j = j_hi.min(grid.n_v - 1);
+
+        let s0 = i as f64 * grid.ds;
+        let s1 = (i + 1) as f64 * grid.ds;
+        let v0 = j as f64 * grid.dv;
+        let v1 = (j + 1) as f64 * grid.dv;
+
+        let ws = if s1 > s0 { (s - s0) / (s1 - s0) } else { 0.0 };
+        let wv = if v1 > v0 { (v - v0) / (v1 - v0) } else { 0.0 };
+
+        let p00 = u[idx(i, j, grid.n_s)];
+        let p10 = u[idx(i + 1, j, grid.n_s)];
+        let p01 = u[idx(i, j + 1, grid.n_s)];
+        let p11 = u[idx(i + 1, j + 1, grid.n_s)];
+
+        let price = (1.0 - ws) * (1.0 - wv) * p00
+            + ws * (1.0 - wv) * p10
+            + (1.0 - ws) * wv * p01
+            + ws * wv * p11;
+
+        let mut diagnostics = crate::core::Diagnostics::new();
+        diagnostics.insert_key(DiagKey::NumTimeSteps, self.time_steps as f64);
+        diagnostics.insert_key(DiagKey::NumSpaceSteps, self.spot_steps as f64);
+        diagnostics.insert_key(DiagKey::NumSteps, self.variance_steps as f64);
+        diagnostics.insert_key(DiagKey::SMax, s_max);
+        diagnostics.insert_key(DiagKey::VarOfVar, self.model.xi * self.model.xi);
+
+        Ok(PricingResult {
+            price,
+            stderr: None,
+            greeks: None,
+            diagnostics,
+        })
+    }
+}

--- a/src/engines/pde/explicit_fd.rs
+++ b/src/engines/pde/explicit_fd.rs
@@ -1,37 +1,53 @@
-//! Module `engines::pde::explicit_fd`.
+//! Forward-Euler finite-difference solver for Black-Scholes vanilla options.
 //!
-//! Implements explicit fd abstractions and re-exports used by adjacent pricing/model modules.
-//!
-//! References: Hull (11th ed.) Ch. 20, Tavella and Randall (2000), finite-difference stencils around Eq. (20.11)-(20.13).
-//!
-//! Key types and purpose: `ExplicitFdEngine` define the core data contracts for this module.
-//!
-//! Numerical considerations: grid spacing, time-step size, and boundary handling dominate stability/consistency; check monotonicity and CFL-style limits where explicit terms appear.
-//!
-//! When to use: use PDE engines for early-exercise and barrier-style boundary problems in low dimensions; switch to Monte Carlo or trees for high-dimensional state spaces.
-use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, PricingResult};
+//! This module implements an explicit-in-time discretization of the Black-Scholes PDE,
+//! including a CFL stability check and early-exercise projection for American/Bermudan styles.
+
+use crate::core::{DiagKey, ExerciseStyle, PricingEngine, PricingError, PricingResult};
 use crate::instruments::vanilla::VanillaOption;
 use crate::market::Market;
 
-/// Explicit (Forward Euler) finite-difference engine for Black-Scholes PDE.
+use super::fd_common::{
+    bermudan_exercise_steps, boundary_values, build_operator_coefficients,
+    build_stretched_spot_grid, explicit_cfl_dt_max, interpolate_on_grid, intrinsic,
+};
+
+/// Forward-Euler explicit finite-difference engine for the Black-Scholes PDE.
+///
+/// The solver is conditionally stable and checks a CFL-like bound before time marching.
 #[derive(Debug, Clone)]
 pub struct ExplicitFdEngine {
+    /// Number of time steps.
     pub time_steps: usize,
+    /// Number of spot intervals; the grid has `space_steps + 1` nodes.
     pub space_steps: usize,
+    /// Spot truncation multiplier: `S_max = s_max_multiplier * max(spot, strike)`.
     pub s_max_multiplier: f64,
+    /// Stretching parameter for the non-uniform spot grid.
+    ///
+    /// Smaller values concentrate more points around strike.
+    pub grid_stretch: f64,
+    /// Safety factor applied to the computed CFL time-step limit.
+    pub cfl_safety_factor: f64,
+    /// If `true`, pricing fails when `dt` violates the CFL bound.
+    pub enforce_cfl: bool,
 }
 
 impl Default for ExplicitFdEngine {
     fn default() -> Self {
         Self {
-            time_steps: 200,
-            space_steps: 200,
+            time_steps: 2_000,
+            space_steps: 180,
             s_max_multiplier: 4.0,
+            grid_stretch: 0.15,
+            cfl_safety_factor: 0.95,
+            enforce_cfl: true,
         }
     }
 }
 
 impl ExplicitFdEngine {
+    /// Creates an explicit-FD engine with custom time/space resolution.
     pub fn new(time_steps: usize, space_steps: usize) -> Self {
         Self {
             time_steps,
@@ -40,64 +56,28 @@ impl ExplicitFdEngine {
         }
     }
 
+    /// Sets `S_max = multiplier * max(spot, strike)`.
     pub fn with_s_max_multiplier(mut self, s_max_multiplier: f64) -> Self {
-        self.s_max_multiplier = s_max_multiplier.max(1.0);
+        self.s_max_multiplier = s_max_multiplier;
         self
     }
-}
 
-#[inline(always)]
-fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
-    match option_type {
-        OptionType::Call => (spot - strike).max(0.0),
-        OptionType::Put => (strike - spot).max(0.0),
+    /// Sets the non-uniform grid stretching parameter.
+    pub fn with_grid_stretch(mut self, grid_stretch: f64) -> Self {
+        self.grid_stretch = grid_stretch;
+        self
     }
-}
 
-fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool> {
-    let mut flags = vec![false; steps + 1];
-    for &t in dates {
-        if expiry <= 0.0 {
-            continue;
-        }
-        let idx = ((t / expiry) * steps as f64).round() as usize;
-        flags[idx.min(steps)] = true;
+    /// Sets the CFL safety factor.
+    pub fn with_cfl_safety_factor(mut self, cfl_safety_factor: f64) -> Self {
+        self.cfl_safety_factor = cfl_safety_factor;
+        self
     }
-    flags[steps] = true;
-    flags
-}
 
-fn boundary_values(
-    option_type: OptionType,
-    is_american: bool,
-    strike: f64,
-    rate: f64,
-    dividend_yield: f64,
-    s_max: f64,
-    tau: f64,
-) -> (f64, f64) {
-    match (option_type, is_american) {
-        (OptionType::Call, false) => {
-            let lower = 0.0;
-            let upper =
-                (s_max * (-dividend_yield * tau).exp() - strike * (-rate * tau).exp()).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, false) => {
-            let lower = strike * (-rate * tau).exp();
-            let upper = 0.0;
-            (lower, upper)
-        }
-        (OptionType::Call, true) => {
-            let lower = 0.0;
-            let upper = (s_max - strike).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, true) => {
-            let lower = strike;
-            let upper = 0.0;
-            (lower, upper)
-        }
+    /// Enables or disables strict CFL enforcement.
+    pub fn with_enforce_cfl(mut self, enforce_cfl: bool) -> Self {
+        self.enforce_cfl = enforce_cfl;
+        self
     }
 }
 
@@ -119,6 +99,11 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
                 "s_max_multiplier must be finite and > 0".to_string(),
             ));
         }
+        if self.grid_stretch <= 0.0 || !self.grid_stretch.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "grid_stretch must be finite and > 0".to_string(),
+            ));
+        }
 
         if instrument.expiry == 0.0 {
             return Ok(PricingResult {
@@ -138,64 +123,45 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
 
         let n_t = self.time_steps;
         let n_s = self.space_steps;
-        let s_max = self.s_max_multiplier * instrument.strike;
-        let ds = s_max / n_s as f64;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let dt = instrument.expiry / n_t as f64;
 
-        // CFL stability: dt <= ds^2 / (sigma^2 * s_max^2)
-        let dt_nominal = instrument.expiry / n_t as f64;
-        let dt_max = ds * ds / (vol * vol * s_max * s_max);
-        let (dt, actual_steps) = if dt_nominal <= dt_max {
-            (dt_nominal, n_t)
-        } else {
-            let steps = (instrument.expiry / dt_max).ceil() as usize;
-            (instrument.expiry / steps as f64, steps)
-        };
+        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        let s_max = self.s_max_multiplier * s_anchor;
+        let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
+
+        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
+
+        let dt_max = explicit_cfl_dt_max(&b, self.cfl_safety_factor)?;
+        if self.enforce_cfl && dt > dt_max {
+            let min_steps = (instrument.expiry / dt_max).ceil() as usize;
+            return Err(PricingError::ConvergenceFailure(format!(
+                "explicit FD CFL violated: dt={dt:.6e} > dt_max={dt_max:.6e}; increase time_steps to at least {min_steps}",
+            )));
+        }
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
         let bermudan_flags = match &instrument.exercise {
-            ExerciseStyle::Bermudan { dates } => Some(bermudan_exercise_steps(
-                dates,
-                instrument.expiry,
-                actual_steps,
-            )),
+            ExerciseStyle::Bermudan { dates } => {
+                Some(bermudan_exercise_steps(dates, instrument.expiry, n_t))
+            }
             _ => None,
         };
 
-        let mut values = vec![0.0_f64; n_s + 1];
-        for (i, v) in values.iter_mut().enumerate() {
-            let s = i as f64 * ds;
-            *v = intrinsic(instrument.option_type, s, instrument.strike);
-        }
-
-        // Pre-compute spatial coefficients once (they are constant across timesteps).
-        // Previous code recomputed alpha, beta, a, b, c per space point per timestep.
-        let mut coeff_a = vec![0.0_f64; n_s + 1];
-        let mut coeff_b = vec![0.0_f64; n_s + 1];
-        let mut coeff_c = vec![0.0_f64; n_s + 1];
-        let ds_sq = ds * ds;
-        let half_vol_sq = 0.5 * vol * vol;
-        let half_drift_ds = (market.rate - effective_dividend_yield) / (2.0 * ds);
-        for i in 1..n_s {
-            let s = i as f64 * ds;
-            let alpha = half_vol_sq * s * s / ds_sq;
-            let beta = half_drift_ds * s;
-            coeff_a[i] = alpha - beta;
-            coeff_b[i] = -2.0 * alpha - market.rate;
-            coeff_c[i] = alpha + beta;
-        }
-
-        // Double-buffer to eliminate per-timestep allocation.
+        let mut values = grid
+            .iter()
+            .map(|&s| intrinsic(instrument.option_type, s, instrument.strike))
+            .collect::<Vec<_>>();
         let mut next_values = vec![0.0_f64; n_s + 1];
 
-        for n in (0..actual_steps).rev() {
+        for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
             let (lower_bv, upper_bv) = boundary_values(
                 instrument.option_type,
                 is_american,
                 instrument.strike,
                 market.rate,
-                effective_dividend_yield,
+                dividend_yield,
                 s_max,
                 tau_new,
             );
@@ -203,13 +169,9 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
             next_values[0] = lower_bv;
             next_values[n_s] = upper_bv;
 
-            // FMA chain for the explicit timestep update:
-            // next[i] = values[i] + dt * (a[i]*v[i-1] + b[i]*v[i] + c[i]*v[i+1])
             for i in 1..n_s {
-                let rhs = coeff_a[i].mul_add(
-                    values[i - 1],
-                    coeff_b[i].mul_add(values[i], coeff_c[i] * values[i + 1]),
-                );
+                let rhs =
+                    a[i].mul_add(values[i - 1], b[i].mul_add(values[i], c[i] * values[i + 1]));
                 next_values[i] = dt.mul_add(rhs, values[i]);
             }
 
@@ -222,31 +184,24 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
             };
             if can_exercise {
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    let s = i as f64 * ds;
-                    *v = v.max(intrinsic(instrument.option_type, s, instrument.strike));
+                    *v = v.max(intrinsic(
+                        instrument.option_type,
+                        grid[i],
+                        instrument.strike,
+                    ));
                 }
             }
 
-            // Swap instead of copy — eliminates full memcpy per timestep.
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = if market.spot <= 0.0 {
-            values[0]
-        } else if market.spot >= s_max {
-            values[n_s]
-        } else {
-            let x = market.spot / ds;
-            let i = x.floor() as usize;
-            let w = x - i as f64;
-            (1.0 - w) * values[i] + w * values[i + 1]
-        };
+        let price = interpolate_on_grid(market.spot, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
-        diagnostics.insert("num_time_steps", actual_steps as f64);
-        diagnostics.insert("num_space_steps", n_s as f64);
-        diagnostics.insert("s_max", s_max);
-        diagnostics.insert("vol", vol);
+        diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);
+        diagnostics.insert_key(DiagKey::NumSpaceSteps, n_s as f64);
+        diagnostics.insert_key(DiagKey::SMax, s_max);
+        diagnostics.insert_key(DiagKey::Vol, vol);
 
         Ok(PricingResult {
             price,
@@ -254,91 +209,5 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
             greeks: None,
             diagnostics,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::PricingEngine;
-    use crate::engines::pde::crank_nicolson::CrankNicolsonEngine;
-    use crate::pricing::european::black_scholes_price;
-
-    #[test]
-    fn european_call_matches_black_scholes() {
-        let option = VanillaOption::european_call(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = ExplicitFdEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Call, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn european_put_matches_black_scholes() {
-        let option = VanillaOption::european_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = ExplicitFdEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Put, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn american_put_matches_crank_nicolson() {
-        let option = VanillaOption::american_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.02)
-            .flat_vol(0.30)
-            .build()
-            .unwrap();
-
-        let pde = ExplicitFdEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let cn = CrankNicolsonEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-
-        assert!(
-            (pde.price - cn.price).abs() <= 0.05,
-            "Explicit/CN mismatch: explicit={} cn={}",
-            pde.price,
-            cn.price
-        );
     }
 }

--- a/src/engines/pde/fd_common.rs
+++ b/src/engines/pde/fd_common.rs
@@ -1,0 +1,227 @@
+use crate::core::{OptionType, PricingError};
+
+#[inline]
+pub(super) fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
+    match option_type {
+        OptionType::Call => (spot - strike).max(0.0),
+        OptionType::Put => (strike - spot).max(0.0),
+    }
+}
+
+pub(super) fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool> {
+    let mut flags = vec![false; steps + 1];
+    for &t in dates {
+        if expiry <= 0.0 {
+            continue;
+        }
+        let idx = ((t / expiry) * steps as f64).round() as usize;
+        flags[idx.min(steps)] = true;
+    }
+    flags[steps] = true;
+    flags
+}
+
+pub(super) fn boundary_values(
+    option_type: OptionType,
+    is_american: bool,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    s_max: f64,
+    tau: f64,
+) -> (f64, f64) {
+    match (option_type, is_american) {
+        (OptionType::Call, false) => {
+            let lower = 0.0;
+            let upper =
+                (s_max * (-dividend_yield * tau).exp() - strike * (-rate * tau).exp()).max(0.0);
+            (lower, upper)
+        }
+        (OptionType::Put, false) => {
+            let lower = strike * (-rate * tau).exp();
+            (lower, 0.0)
+        }
+        (OptionType::Call, true) => (0.0, (s_max - strike).max(0.0)),
+        (OptionType::Put, true) => (strike, 0.0),
+    }
+}
+
+pub(super) fn build_stretched_spot_grid(
+    space_steps: usize,
+    s_max: f64,
+    strike: f64,
+    stretch: f64,
+) -> Result<Vec<f64>, PricingError> {
+    if space_steps < 2 {
+        return Err(PricingError::InvalidInput(
+            "space_steps must be >= 2".to_string(),
+        ));
+    }
+    if s_max <= 0.0 || !s_max.is_finite() {
+        return Err(PricingError::InvalidInput(
+            "s_max must be finite and > 0".to_string(),
+        ));
+    }
+    if !strike.is_finite() || strike <= 0.0 {
+        return Err(PricingError::InvalidInput(
+            "strike must be finite and > 0".to_string(),
+        ));
+    }
+    if !stretch.is_finite() || stretch <= 0.0 {
+        return Err(PricingError::InvalidInput(
+            "grid_stretch must be finite and > 0".to_string(),
+        ));
+    }
+
+    let anchor = (strike / s_max).clamp(1.0e-8, 1.0 - 1.0e-8);
+    let alpha = stretch.max(1.0e-6);
+    let y_lo = (-anchor / alpha).asinh();
+    let y_hi = ((1.0 - anchor) / alpha).asinh();
+    let y_span = y_hi - y_lo;
+
+    let mut grid = vec![0.0_f64; space_steps + 1];
+    for (i, s) in grid.iter_mut().enumerate() {
+        let x = i as f64 / space_steps as f64;
+        let y = y_lo + y_span * x;
+        let z = anchor + alpha * y.sinh();
+        *s = (s_max * z).clamp(0.0, s_max);
+    }
+    grid[0] = 0.0;
+    grid[space_steps] = s_max;
+
+    if grid
+        .windows(2)
+        .any(|w| !w[0].is_finite() || !w[1].is_finite() || w[1] <= w[0])
+    {
+        return Err(PricingError::NumericalError(
+            "failed to build a strictly increasing stretched grid".to_string(),
+        ));
+    }
+
+    Ok(grid)
+}
+
+pub(super) fn build_operator_coefficients(
+    grid: &[f64],
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    let n_s = grid.len() - 1;
+    let mut a = vec![0.0_f64; n_s + 1];
+    let mut b = vec![0.0_f64; n_s + 1];
+    let mut c = vec![0.0_f64; n_s + 1];
+
+    for i in 1..n_s {
+        let s = grid[i];
+        let h_m = grid[i] - grid[i - 1];
+        let h_p = grid[i + 1] - grid[i];
+
+        let d1_m = -h_p / (h_m * (h_m + h_p));
+        let d1_0 = (h_p - h_m) / (h_m * h_p);
+        let d1_p = h_m / (h_p * (h_m + h_p));
+
+        let d2_m = 2.0 / (h_m * (h_m + h_p));
+        let d2_0 = -2.0 / (h_m * h_p);
+        let d2_p = 2.0 / (h_p * (h_m + h_p));
+
+        let diffusion = 0.5 * vol * vol * s * s;
+        let drift = (rate - dividend_yield) * s;
+
+        a[i] = diffusion * d2_m + drift * d1_m;
+        b[i] = diffusion * d2_0 + drift * d1_0 - rate;
+        c[i] = diffusion * d2_p + drift * d1_p;
+    }
+
+    (a, b, c)
+}
+
+pub(super) fn explicit_cfl_dt_max(b: &[f64], cfl_safety_factor: f64) -> Result<f64, PricingError> {
+    if !cfl_safety_factor.is_finite() || cfl_safety_factor <= 0.0 {
+        return Err(PricingError::InvalidInput(
+            "cfl_safety_factor must be finite and > 0".to_string(),
+        ));
+    }
+
+    let mut dt_max = f64::INFINITY;
+    for &bi in b.iter().skip(1).take(b.len().saturating_sub(2)) {
+        if bi < -1.0e-14 {
+            dt_max = dt_max.min((-1.0 / bi) * cfl_safety_factor);
+        }
+    }
+    if !dt_max.is_finite() || dt_max <= 0.0 {
+        return Err(PricingError::NumericalError(
+            "unable to compute a positive CFL bound".to_string(),
+        ));
+    }
+    Ok(dt_max)
+}
+
+pub(super) fn interpolate_on_grid(spot: f64, grid: &[f64], values: &[f64]) -> f64 {
+    debug_assert_eq!(grid.len(), values.len());
+
+    if spot <= grid[0] {
+        return values[0];
+    }
+    let n = grid.len() - 1;
+    if spot >= grid[n] {
+        return values[n];
+    }
+
+    let hi = grid.partition_point(|&x| x < spot).clamp(1, n);
+    let lo = hi - 1;
+    let w = (spot - grid[lo]) / (grid[hi] - grid[lo]);
+    (1.0 - w) * values[lo] + w * values[hi]
+}
+
+pub(super) fn solve_tridiagonal_inplace(
+    lower: &[f64],
+    diag: &[f64],
+    upper: &[f64],
+    rhs: &[f64],
+    c_star: &mut [f64],
+    d_star: &mut [f64],
+    out: &mut [f64],
+) -> Result<(), PricingError> {
+    let n = diag.len();
+    if n == 0 {
+        return Ok(());
+    }
+    if lower.len() != n
+        || upper.len() != n
+        || rhs.len() != n
+        || c_star.len() != n
+        || d_star.len() != n
+        || out.len() != n
+    {
+        return Err(PricingError::InvalidInput(
+            "tridiagonal input lengths must match".to_string(),
+        ));
+    }
+
+    if diag[0].abs() <= 1.0e-14 {
+        return Err(PricingError::NumericalError(
+            "tridiagonal solver singular matrix".to_string(),
+        ));
+    }
+
+    c_star[0] = if n > 1 { upper[0] / diag[0] } else { 0.0 };
+    d_star[0] = rhs[0] / diag[0];
+
+    for i in 1..n {
+        let denom = diag[i] - lower[i] * c_star[i - 1];
+        if denom.abs() <= 1.0e-14 {
+            return Err(PricingError::NumericalError(
+                "tridiagonal solver singular matrix".to_string(),
+            ));
+        }
+        c_star[i] = if i < n - 1 { upper[i] / denom } else { 0.0 };
+        d_star[i] = (rhs[i] - lower[i] * d_star[i - 1]) / denom;
+    }
+
+    out[n - 1] = d_star[n - 1];
+    for i in (0..n - 1).rev() {
+        out[i] = d_star[i] - c_star[i] * out[i + 1];
+    }
+    Ok(())
+}

--- a/src/engines/pde/hopscotch.rs
+++ b/src/engines/pde/hopscotch.rs
@@ -1,42 +1,45 @@
-//! Module `engines::pde::hopscotch`.
+//! Gourlay-McKee hopscotch finite-difference solver for Black-Scholes vanillas.
 //!
-//! Implements hopscotch abstractions and re-exports used by adjacent pricing/model modules.
-//!
-//! References: Hull (11th ed.) Ch. 20, Tavella and Randall (2000), finite-difference stencils around Eq. (20.11)-(20.13).
-//!
-//! Key types and purpose: `HopscotchEngine` define the core data contracts for this module.
-//!
-//! Numerical considerations: grid spacing, time-step size, and boundary handling dominate stability/consistency; check monotonicity and CFL-style limits where explicit terms appear.
-//!
-//! When to use: use PDE engines for early-exercise and barrier-style boundary problems in low dimensions; switch to Monte Carlo or trees for high-dimensional state spaces.
-use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, PricingResult};
+//! The scheme alternates explicit and implicit updates on a checkerboard pattern,
+//! delivering good stability without solving a full tridiagonal system each step.
+
+use crate::core::{DiagKey, ExerciseStyle, PricingEngine, PricingError, PricingResult};
 use crate::instruments::vanilla::VanillaOption;
 use crate::market::Market;
 
-/// Hopscotch finite-difference engine for Black-Scholes PDE.
-///
-/// Alternates explicit and implicit updates in a checkerboard pattern.
-/// At points where (i + n) is even: explicit update.
-/// At points where (i + n) is odd: implicit (local 1-point solve).
-/// Unconditionally stable, no tridiagonal solve needed.
+use super::fd_common::{
+    bermudan_exercise_steps, boundary_values, build_operator_coefficients,
+    build_stretched_spot_grid, interpolate_on_grid, intrinsic,
+};
+
+/// Gourlay-McKee hopscotch finite-difference engine for Black-Scholes PDE pricing.
 #[derive(Debug, Clone)]
 pub struct HopscotchEngine {
+    /// Number of time steps.
     pub time_steps: usize,
+    /// Number of spot intervals; the grid has `space_steps + 1` nodes.
     pub space_steps: usize,
+    /// Spot truncation multiplier: `S_max = s_max_multiplier * max(spot, strike)`.
     pub s_max_multiplier: f64,
+    /// Stretching parameter for the non-uniform spot grid.
+    ///
+    /// Smaller values concentrate more points around strike.
+    pub grid_stretch: f64,
 }
 
 impl Default for HopscotchEngine {
     fn default() -> Self {
         Self {
-            time_steps: 200,
-            space_steps: 200,
+            time_steps: 320,
+            space_steps: 180,
             s_max_multiplier: 4.0,
+            grid_stretch: 0.15,
         }
     }
 }
 
 impl HopscotchEngine {
+    /// Creates a hopscotch engine with custom time/space resolution.
     pub fn new(time_steps: usize, space_steps: usize) -> Self {
         Self {
             time_steps,
@@ -45,63 +48,16 @@ impl HopscotchEngine {
         }
     }
 
+    /// Sets `S_max = multiplier * max(spot, strike)`.
     pub fn with_s_max_multiplier(mut self, s_max_multiplier: f64) -> Self {
-        self.s_max_multiplier = s_max_multiplier.max(1.0);
+        self.s_max_multiplier = s_max_multiplier;
         self
     }
-}
 
-fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
-    match option_type {
-        OptionType::Call => (spot - strike).max(0.0),
-        OptionType::Put => (strike - spot).max(0.0),
-    }
-}
-
-fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool> {
-    let mut flags = vec![false; steps + 1];
-    for &t in dates {
-        if expiry <= 0.0 {
-            continue;
-        }
-        let idx = ((t / expiry) * steps as f64).round() as usize;
-        flags[idx.min(steps)] = true;
-    }
-    flags[steps] = true;
-    flags
-}
-
-fn boundary_values(
-    option_type: OptionType,
-    is_american: bool,
-    strike: f64,
-    rate: f64,
-    dividend_yield: f64,
-    s_max: f64,
-    tau: f64,
-) -> (f64, f64) {
-    match (option_type, is_american) {
-        (OptionType::Call, false) => {
-            let lower = 0.0;
-            let upper =
-                (s_max * (-dividend_yield * tau).exp() - strike * (-rate * tau).exp()).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, false) => {
-            let lower = strike * (-rate * tau).exp();
-            let upper = 0.0;
-            (lower, upper)
-        }
-        (OptionType::Call, true) => {
-            let lower = 0.0;
-            let upper = (s_max - strike).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, true) => {
-            let lower = strike;
-            let upper = 0.0;
-            (lower, upper)
-        }
+    /// Sets the non-uniform grid stretching parameter.
+    pub fn with_grid_stretch(mut self, grid_stretch: f64) -> Self {
+        self.grid_stretch = grid_stretch;
+        self
     }
 }
 
@@ -121,6 +77,11 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
         if self.s_max_multiplier <= 0.0 || !self.s_max_multiplier.is_finite() {
             return Err(PricingError::InvalidInput(
                 "s_max_multiplier must be finite and > 0".to_string(),
+            ));
+        }
+        if self.grid_stretch <= 0.0 || !self.grid_stretch.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "grid_stretch must be finite and > 0".to_string(),
             ));
         }
 
@@ -143,9 +104,13 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
         let n_t = self.time_steps;
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
-        let s_max = self.s_max_multiplier * instrument.strike;
-        let ds = s_max / n_s as f64;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+
+        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        let s_max = self.s_max_multiplier * s_anchor;
+        let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
+
+        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
         let bermudan_flags = match &instrument.exercise {
@@ -155,31 +120,10 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
             _ => None,
         };
 
-        let mut values = vec![0.0_f64; n_s + 1];
-        for (i, v) in values.iter_mut().enumerate() {
-            let s = i as f64 * ds;
-            *v = intrinsic(instrument.option_type, s, instrument.strike);
-        }
-
-        // Precompute coefficients for each interior point
-        // L V_i = a_i V_{i-1} + b_i V_i + c_i V_{i+1}
-        let interior_n = n_s - 1;
-        let mut a_coeff = vec![0.0_f64; interior_n];
-        let mut b_coeff = vec![0.0_f64; interior_n];
-        let mut c_coeff = vec![0.0_f64; interior_n];
-
-        for k in 0..interior_n {
-            let i = k + 1;
-            let s = i as f64 * ds;
-            let alpha = 0.5 * vol * vol * s * s / (ds * ds);
-            let beta = (market.rate - effective_dividend_yield) * s / (2.0 * ds);
-
-            a_coeff[k] = alpha - beta;
-            b_coeff[k] = -2.0 * alpha - market.rate;
-            c_coeff[k] = alpha + beta;
-        }
-
-        // Pre-allocate double-buffer to eliminate per-timestep clone + allocation.
+        let mut values = grid
+            .iter()
+            .map(|&s| intrinsic(instrument.option_type, s, instrument.strike))
+            .collect::<Vec<_>>();
         let mut next_values = vec![0.0_f64; n_s + 1];
 
         for n in (0..n_t).rev() {
@@ -189,34 +133,34 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                effective_dividend_yield,
+                dividend_yield,
                 s_max,
                 tau_new,
             );
 
-            // Copy old values then apply boundary conditions.
             next_values.copy_from_slice(&values);
             next_values[0] = lower_bv;
             next_values[n_s] = upper_bv;
 
-            // First pass: explicit updates where (i + n) is even
-            for k in 0..interior_n {
-                let i = k + 1;
+            for i in 1..n_s {
                 if (i + n) % 2 == 0 {
-                    let l_v = a_coeff[k] * values[i - 1]
-                        + b_coeff[k] * values[i]
-                        + c_coeff[k] * values[i + 1];
+                    let l_v = a[i] * values[i - 1] + b[i] * values[i] + c[i] * values[i + 1];
                     next_values[i] = values[i] + dt * l_v;
                 }
             }
 
-            // Second pass: implicit updates where (i + n) is odd
-            for k in 0..interior_n {
-                let i = k + 1;
+            for i in 1..n_s {
                 if (i + n) % 2 != 0 {
-                    let rhs = values[i]
-                        + dt * (a_coeff[k] * next_values[i - 1] + c_coeff[k] * next_values[i + 1]);
-                    next_values[i] = rhs / (1.0 - dt * b_coeff[k]);
+                    let denom = 1.0 - dt * b[i];
+                    if denom.abs() <= 1.0e-14 {
+                        return Err(PricingError::NumericalError(
+                            "hopscotch implicit stage encountered near-zero denominator"
+                                .to_string(),
+                        ));
+                    }
+                    let rhs =
+                        values[i] + dt * (a[i] * next_values[i - 1] + c[i] * next_values[i + 1]);
+                    next_values[i] = rhs / denom;
                 }
             }
 
@@ -229,30 +173,24 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
             };
             if can_exercise {
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    let s = i as f64 * ds;
-                    *v = v.max(intrinsic(instrument.option_type, s, instrument.strike));
+                    *v = v.max(intrinsic(
+                        instrument.option_type,
+                        grid[i],
+                        instrument.strike,
+                    ));
                 }
             }
 
-            values.copy_from_slice(&next_values);
+            std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = if market.spot <= 0.0 {
-            values[0]
-        } else if market.spot >= s_max {
-            values[n_s]
-        } else {
-            let x = market.spot / ds;
-            let i = x.floor() as usize;
-            let w = x - i as f64;
-            (1.0 - w) * values[i] + w * values[i + 1]
-        };
+        let price = interpolate_on_grid(market.spot, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
-        diagnostics.insert("num_time_steps", n_t as f64);
-        diagnostics.insert("num_space_steps", n_s as f64);
-        diagnostics.insert("s_max", s_max);
-        diagnostics.insert("vol", vol);
+        diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);
+        diagnostics.insert_key(DiagKey::NumSpaceSteps, n_s as f64);
+        diagnostics.insert_key(DiagKey::SMax, s_max);
+        diagnostics.insert_key(DiagKey::Vol, vol);
 
         Ok(PricingResult {
             price,
@@ -260,91 +198,5 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
             greeks: None,
             diagnostics,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::PricingEngine;
-    use crate::engines::pde::crank_nicolson::CrankNicolsonEngine;
-    use crate::pricing::european::black_scholes_price;
-
-    #[test]
-    fn european_call_matches_black_scholes() {
-        let option = VanillaOption::european_call(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = HopscotchEngine::new(400, 400)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Call, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn european_put_matches_black_scholes() {
-        let option = VanillaOption::european_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = HopscotchEngine::new(400, 400)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Put, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn american_put_matches_crank_nicolson() {
-        let option = VanillaOption::american_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.02)
-            .flat_vol(0.30)
-            .build()
-            .unwrap();
-
-        let pde = HopscotchEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let cn = CrankNicolsonEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-
-        assert!(
-            (pde.price - cn.price).abs() <= 0.05,
-            "Hopscotch/CN mismatch: hopscotch={} cn={}",
-            pde.price,
-            cn.price
-        );
     }
 }

--- a/src/engines/pde/implicit_fd.rs
+++ b/src/engines/pde/implicit_fd.rs
@@ -1,37 +1,48 @@
-//! Module `engines::pde::implicit_fd`.
+//! Backward-Euler finite-difference solver for Black-Scholes vanilla options.
 //!
-//! Implements implicit fd abstractions and re-exports used by adjacent pricing/model modules.
-//!
-//! References: Hull (11th ed.) Ch. 20, Tavella and Randall (2000), finite-difference stencils around Eq. (20.11)-(20.13).
-//!
-//! Key types and purpose: `ImplicitFdEngine` define the core data contracts for this module.
-//!
-//! Numerical considerations: grid spacing, time-step size, and boundary handling dominate stability/consistency; check monotonicity and CFL-style limits where explicit terms appear.
-//!
-//! When to use: use PDE engines for early-exercise and barrier-style boundary problems in low dimensions; switch to Monte Carlo or trees for high-dimensional state spaces.
-use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, PricingResult};
+//! This module implements a fully implicit time discretization and solves the
+//! tridiagonal linear system at each step with the Thomas algorithm.
+
+use crate::core::{DiagKey, ExerciseStyle, PricingEngine, PricingError, PricingResult};
 use crate::instruments::vanilla::VanillaOption;
 use crate::market::Market;
 
-/// Implicit (Backward Euler) finite-difference engine for Black-Scholes PDE.
+use super::fd_common::{
+    bermudan_exercise_steps, boundary_values, build_operator_coefficients,
+    build_stretched_spot_grid, interpolate_on_grid, intrinsic, solve_tridiagonal_inplace,
+};
+
+/// Backward-Euler implicit finite-difference engine for the Black-Scholes PDE.
+///
+/// The scheme is unconditionally stable in time and supports European,
+/// American, and Bermudan exercise through projection onto intrinsic value.
 #[derive(Debug, Clone)]
 pub struct ImplicitFdEngine {
+    /// Number of time steps.
     pub time_steps: usize,
+    /// Number of spot intervals; the grid has `space_steps + 1` nodes.
     pub space_steps: usize,
+    /// Spot truncation multiplier: `S_max = s_max_multiplier * max(spot, strike)`.
     pub s_max_multiplier: f64,
+    /// Stretching parameter for the non-uniform spot grid.
+    ///
+    /// Smaller values concentrate more points around strike.
+    pub grid_stretch: f64,
 }
 
 impl Default for ImplicitFdEngine {
     fn default() -> Self {
         Self {
-            time_steps: 200,
-            space_steps: 200,
+            time_steps: 320,
+            space_steps: 180,
             s_max_multiplier: 4.0,
+            grid_stretch: 0.15,
         }
     }
 }
 
 impl ImplicitFdEngine {
+    /// Creates an implicit-FD engine with custom time/space resolution.
     pub fn new(time_steps: usize, space_steps: usize) -> Self {
         Self {
             time_steps,
@@ -40,106 +51,17 @@ impl ImplicitFdEngine {
         }
     }
 
+    /// Sets `S_max = multiplier * max(spot, strike)`.
     pub fn with_s_max_multiplier(mut self, s_max_multiplier: f64) -> Self {
-        self.s_max_multiplier = s_max_multiplier.max(1.0);
+        self.s_max_multiplier = s_max_multiplier;
         self
     }
-}
 
-#[inline(always)]
-fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
-    match option_type {
-        OptionType::Call => (spot - strike).max(0.0),
-        OptionType::Put => (strike - spot).max(0.0),
+    /// Sets the non-uniform grid stretching parameter.
+    pub fn with_grid_stretch(mut self, grid_stretch: f64) -> Self {
+        self.grid_stretch = grid_stretch;
+        self
     }
-}
-
-fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool> {
-    let mut flags = vec![false; steps + 1];
-    for &t in dates {
-        if expiry <= 0.0 {
-            continue;
-        }
-        let idx = ((t / expiry) * steps as f64).round() as usize;
-        flags[idx.min(steps)] = true;
-    }
-    flags[steps] = true;
-    flags
-}
-
-fn boundary_values(
-    option_type: OptionType,
-    is_american: bool,
-    strike: f64,
-    rate: f64,
-    dividend_yield: f64,
-    s_max: f64,
-    tau: f64,
-) -> (f64, f64) {
-    match (option_type, is_american) {
-        (OptionType::Call, false) => {
-            let lower = 0.0;
-            let upper =
-                (s_max * (-dividend_yield * tau).exp() - strike * (-rate * tau).exp()).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, false) => {
-            let lower = strike * (-rate * tau).exp();
-            let upper = 0.0;
-            (lower, upper)
-        }
-        (OptionType::Call, true) => {
-            let lower = 0.0;
-            let upper = (s_max - strike).max(0.0);
-            (lower, upper)
-        }
-        (OptionType::Put, true) => {
-            let lower = strike;
-            let upper = 0.0;
-            (lower, upper)
-        }
-    }
-}
-
-/// In-place tridiagonal solve using pre-allocated scratch buffers.
-#[inline(always)]
-fn solve_tridiagonal_inplace(
-    lower: &[f64],
-    diag: &[f64],
-    upper: &[f64],
-    rhs: &[f64],
-    c_star: &mut [f64],
-    d_star: &mut [f64],
-    x: &mut [f64],
-) -> Result<(), PricingError> {
-    let n = diag.len();
-
-    let inv_denom0 = 1.0 / diag[0];
-    if !inv_denom0.is_finite() {
-        return Err(PricingError::NumericalError(
-            "tridiagonal solver singular matrix".to_string(),
-        ));
-    }
-    c_star[0] = if n > 1 { upper[0] * inv_denom0 } else { 0.0 };
-    d_star[0] = rhs[0] * inv_denom0;
-
-    for i in 1..n {
-        let denom = (-lower[i]).mul_add(c_star[i - 1], diag[i]);
-        if denom.abs() <= 1.0e-14 {
-            return Err(PricingError::NumericalError(
-                "tridiagonal solver singular matrix".to_string(),
-            ));
-        }
-        let inv_denom = 1.0 / denom;
-        c_star[i] = if i < n - 1 { upper[i] * inv_denom } else { 0.0 };
-        d_star[i] = (-lower[i]).mul_add(d_star[i - 1], rhs[i]) * inv_denom;
-    }
-
-    x[n - 1] = d_star[n - 1];
-    for i in (0..(n - 1)).rev() {
-        x[i] = (-c_star[i]).mul_add(x[i + 1], d_star[i]);
-    }
-    Ok(())
 }
 
 impl PricingEngine<VanillaOption> for ImplicitFdEngine {
@@ -158,6 +80,11 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
         if self.s_max_multiplier <= 0.0 || !self.s_max_multiplier.is_finite() {
             return Err(PricingError::InvalidInput(
                 "s_max_multiplier must be finite and > 0".to_string(),
+            ));
+        }
+        if self.grid_stretch <= 0.0 || !self.grid_stretch.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "grid_stretch must be finite and > 0".to_string(),
             ));
         }
 
@@ -180,9 +107,13 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
         let n_t = self.time_steps;
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
-        let s_max = self.s_max_multiplier * instrument.strike;
-        let ds = s_max / n_s as f64;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
+
+        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        let s_max = self.s_max_multiplier * s_anchor;
+        let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
+
+        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
         let bermudan_flags = match &instrument.exercise {
@@ -192,51 +123,31 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
             _ => None,
         };
 
-        let mut values = vec![0.0_f64; n_s + 1];
-        for (i, v) in values.iter_mut().enumerate() {
-            let s = i as f64 * ds;
-            *v = intrinsic(instrument.option_type, s, instrument.strike);
-        }
-
-        // Fully implicit: θ=1, so LHS = I - dt*A, RHS = V^{n+1} (just the old values)
         let interior_n = n_s - 1;
         let mut lhs_lower = vec![0.0_f64; interior_n];
         let mut lhs_diag = vec![0.0_f64; interior_n];
         let mut lhs_upper = vec![0.0_f64; interior_n];
-
-        // Pre-compute reciprocals to avoid repeated divisions in coefficient loop.
-        let inv_ds2 = 1.0 / (ds * ds);
-        let half_vol_sq = 0.5 * vol * vol;
-        let inv_2ds = 1.0 / (2.0 * ds);
-        let drift = market.rate - effective_dividend_yield;
         for k in 0..interior_n {
             let i = k + 1;
-            let s = i as f64 * ds;
-            let alpha = half_vol_sq * s * s * inv_ds2;
-            let beta = drift * s * inv_2ds;
-
-            let a = alpha - beta;
-            let b = -2.0 * alpha - market.rate;
-            let c = alpha + beta;
-
-            lhs_lower[k] = -dt * a;
-            lhs_diag[k] = (-dt).mul_add(b, 1.0);
-            lhs_upper[k] = -dt * c;
+            lhs_lower[k] = -dt * a[i];
+            lhs_diag[k] = (-dt).mul_add(b[i], 1.0);
+            lhs_upper[k] = -dt * c[i];
         }
 
-        // Pre-allocate all scratch buffers once to eliminate per-timestep allocations.
-        let mut rhs_buf = vec![0.0_f64; interior_n];
-        let mut solve_lower = vec![0.0_f64; interior_n];
-        let mut solve_upper = vec![0.0_f64; interior_n];
+        let mut solve_lower = lhs_lower.clone();
+        let mut solve_upper = lhs_upper.clone();
+        solve_lower[0] = 0.0;
+        solve_upper[interior_n - 1] = 0.0;
+
+        let mut values = grid
+            .iter()
+            .map(|&s| intrinsic(instrument.option_type, s, instrument.strike))
+            .collect::<Vec<_>>();
+        let mut next_values = vec![0.0_f64; n_s + 1];
+        let mut rhs = vec![0.0_f64; interior_n];
         let mut c_star = vec![0.0_f64; interior_n];
         let mut d_star = vec![0.0_f64; interior_n];
         let mut interior = vec![0.0_f64; interior_n];
-        let mut next_values = vec![0.0_f64; n_s + 1];
-
-        solve_lower.copy_from_slice(&lhs_lower);
-        solve_lower[0] = 0.0;
-        solve_upper.copy_from_slice(&lhs_upper);
-        solve_upper[interior_n - 1] = 0.0;
 
         for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
@@ -245,20 +156,20 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
                 is_american,
                 instrument.strike,
                 market.rate,
-                effective_dividend_yield,
+                dividend_yield,
                 s_max,
                 tau_new,
             );
 
-            rhs_buf[..interior_n].copy_from_slice(&values[1..interior_n + 1]);
-            rhs_buf[0] -= lhs_lower[0] * lower_bv;
-            rhs_buf[interior_n - 1] -= lhs_upper[interior_n - 1] * upper_bv;
+            rhs.copy_from_slice(&values[1..n_s]);
+            rhs[0] -= lhs_lower[0] * lower_bv;
+            rhs[interior_n - 1] -= lhs_upper[interior_n - 1] * upper_bv;
 
             solve_tridiagonal_inplace(
                 &solve_lower,
                 &lhs_diag,
                 &solve_upper,
-                &rhs_buf,
+                &rhs,
                 &mut c_star,
                 &mut d_star,
                 &mut interior,
@@ -277,30 +188,24 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
             };
             if can_exercise {
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    let s = i as f64 * ds;
-                    *v = v.max(intrinsic(instrument.option_type, s, instrument.strike));
+                    *v = v.max(intrinsic(
+                        instrument.option_type,
+                        grid[i],
+                        instrument.strike,
+                    ));
                 }
             }
 
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = if market.spot <= 0.0 {
-            values[0]
-        } else if market.spot >= s_max {
-            values[n_s]
-        } else {
-            let x = market.spot / ds;
-            let i = x.floor() as usize;
-            let w = x - i as f64;
-            (1.0 - w) * values[i] + w * values[i + 1]
-        };
+        let price = interpolate_on_grid(market.spot, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
-        diagnostics.insert_key(crate::core::DiagKey::NumTimeSteps, n_t as f64);
-        diagnostics.insert_key(crate::core::DiagKey::NumSpaceSteps, n_s as f64);
-        diagnostics.insert_key(crate::core::DiagKey::SMax, s_max);
-        diagnostics.insert_key(crate::core::DiagKey::Vol, vol);
+        diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);
+        diagnostics.insert_key(DiagKey::NumSpaceSteps, n_s as f64);
+        diagnostics.insert_key(DiagKey::SMax, s_max);
+        diagnostics.insert_key(DiagKey::Vol, vol);
 
         Ok(PricingResult {
             price,
@@ -308,91 +213,5 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
             greeks: None,
             diagnostics,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::PricingEngine;
-    use crate::engines::pde::crank_nicolson::CrankNicolsonEngine;
-    use crate::pricing::european::black_scholes_price;
-
-    #[test]
-    fn european_call_matches_black_scholes() {
-        let option = VanillaOption::european_call(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = ImplicitFdEngine::new(400, 400)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Call, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn european_put_matches_black_scholes() {
-        let option = VanillaOption::european_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.0)
-            .flat_vol(0.20)
-            .build()
-            .unwrap();
-
-        let pde = ImplicitFdEngine::new(400, 400)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let bs = black_scholes_price(OptionType::Put, 100.0, 100.0, 0.05, 0.20, 1.0);
-
-        assert!(
-            (pde.price - bs).abs() <= 0.01,
-            "PDE/BS mismatch: pde={} bs={}",
-            pde.price,
-            bs
-        );
-    }
-
-    #[test]
-    fn american_put_matches_crank_nicolson() {
-        let option = VanillaOption::american_put(100.0, 1.0);
-        let market = Market::builder()
-            .spot(100.0)
-            .rate(0.05)
-            .dividend_yield(0.02)
-            .flat_vol(0.30)
-            .build()
-            .unwrap();
-
-        let pde = ImplicitFdEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-        let cn = CrankNicolsonEngine::new(200, 200)
-            .with_s_max_multiplier(4.0)
-            .price(&option, &market)
-            .unwrap();
-
-        assert!(
-            (pde.price - cn.price).abs() <= 0.05,
-            "Implicit/CN mismatch: implicit={} cn={}",
-            pde.price,
-            cn.price
-        );
     }
 }

--- a/src/engines/pde/mod.rs
+++ b/src/engines/pde/mod.rs
@@ -10,11 +10,14 @@
 //!
 //! When to use: use PDE engines for early-exercise and barrier-style boundary problems in low dimensions; switch to Monte Carlo or trees for high-dimensional state spaces.
 
+pub mod adi;
 pub mod crank_nicolson;
 pub mod explicit_fd;
+mod fd_common;
 pub mod hopscotch;
 pub mod implicit_fd;
 
+pub use adi::{AdiHestonEngine, AdiScheme};
 pub use crank_nicolson::{BermudanPdeOutput, CrankNicolsonEngine, PdeExerciseBoundaryPoint};
 pub use explicit_fd::ExplicitFdEngine;
 pub use hopscotch::HopscotchEngine;

--- a/tests/pde_solvers_issue35.rs
+++ b/tests/pde_solvers_issue35.rs
@@ -1,0 +1,286 @@
+use openferric::core::{OptionType, PricingEngine, PricingError};
+use openferric::engines::analytic::black_scholes::bs_price;
+use openferric::engines::fft::heston_price_fft;
+use openferric::engines::pde::{
+    AdiHestonEngine, AdiScheme, ExplicitFdEngine, HopscotchEngine, ImplicitFdEngine,
+};
+use openferric::instruments::vanilla::VanillaOption;
+use openferric::market::Market;
+use openferric::models::stochastic::Heston;
+
+fn rel_err(x: f64, y: f64) -> f64 {
+    let denom = y.abs().max(1.0e-8);
+    (x - y).abs() / denom
+}
+
+fn vanilla_market() -> Market {
+    Market::builder()
+        .spot(100.0)
+        .rate(0.05)
+        .dividend_yield(0.0)
+        .flat_vol(0.20)
+        .build()
+        .expect("valid market")
+}
+
+#[test]
+fn european_call_put_match_black_scholes_within_half_percent() {
+    let market = vanilla_market();
+    let call = VanillaOption::european_call(100.0, 1.0);
+    let put = VanillaOption::european_put(100.0, 1.0);
+
+    let bs_call = bs_price(OptionType::Call, 100.0, 100.0, 0.05, 0.0, 0.20, 1.0);
+    let bs_put = bs_price(OptionType::Put, 100.0, 100.0, 0.05, 0.0, 0.20, 1.0);
+
+    let explicit = ExplicitFdEngine::new(3_000, 120)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&call, &market)
+        .expect("explicit call price");
+    let explicit_put = ExplicitFdEngine::new(3_000, 120)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&put, &market)
+        .expect("explicit put price");
+
+    let implicit = ImplicitFdEngine::new(320, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&call, &market)
+        .expect("implicit call price");
+    let implicit_put = ImplicitFdEngine::new(320, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&put, &market)
+        .expect("implicit put price");
+
+    let hopscotch = HopscotchEngine::new(320, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&call, &market)
+        .expect("hopscotch call price");
+    let hopscotch_put = HopscotchEngine::new(320, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&put, &market)
+        .expect("hopscotch put price");
+
+    assert!(rel_err(explicit.price, bs_call) <= 0.005);
+    assert!(rel_err(explicit_put.price, bs_put) <= 0.005);
+    assert!(rel_err(implicit.price, bs_call) <= 0.005);
+    assert!(rel_err(implicit_put.price, bs_put) <= 0.005);
+    assert!(rel_err(hopscotch.price, bs_call) <= 0.005);
+    assert!(rel_err(hopscotch_put.price, bs_put) <= 0.005);
+}
+
+#[test]
+fn american_put_exceeds_european_put_for_1d_solvers() {
+    let option_eu = VanillaOption::european_put(100.0, 1.0);
+    let option_am = VanillaOption::american_put(100.0, 1.0);
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.06)
+        .dividend_yield(0.0)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+
+    let ex_engine = ExplicitFdEngine::new(1_400, 90)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.15);
+    let eu_ex = ex_engine
+        .price(&option_eu, &market)
+        .expect("explicit eu put");
+    let am_ex = ex_engine
+        .price(&option_am, &market)
+        .expect("explicit am put");
+    assert!(
+        am_ex.price > eu_ex.price,
+        "explicit American put should exceed European put"
+    );
+
+    let im_engine = ImplicitFdEngine::new(260, 140)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.15);
+    let eu_im = im_engine
+        .price(&option_eu, &market)
+        .expect("implicit eu put");
+    let am_im = im_engine
+        .price(&option_am, &market)
+        .expect("implicit am put");
+    assert!(
+        am_im.price > eu_im.price,
+        "implicit American put should exceed European put"
+    );
+
+    let hs_engine = HopscotchEngine::new(260, 140)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.15);
+    let eu_hs = hs_engine
+        .price(&option_eu, &market)
+        .expect("hopscotch eu put");
+    let am_hs = hs_engine
+        .price(&option_am, &market)
+        .expect("hopscotch am put");
+    assert!(
+        am_hs.price > eu_hs.price,
+        "hopscotch American put should exceed European put"
+    );
+}
+
+#[test]
+fn implicit_grid_refinement_improves_accuracy() {
+    let market = vanilla_market();
+    let option = VanillaOption::european_call(100.0, 1.0);
+    let bs = bs_price(OptionType::Call, 100.0, 100.0, 0.05, 0.0, 0.20, 1.0);
+
+    let coarse = ImplicitFdEngine::new(120, 90)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&option, &market)
+        .expect("coarse implicit");
+    let fine = ImplicitFdEngine::new(360, 180)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&option, &market)
+        .expect("fine implicit");
+
+    let coarse_err = (coarse.price - bs).abs();
+    let fine_err = (fine.price - bs).abs();
+    assert!(
+        fine_err <= coarse_err,
+        "finer grid should not increase BS error: coarse={coarse_err} fine={fine_err}"
+    );
+}
+
+#[test]
+fn explicit_solver_detects_cfl_violation() {
+    let market = vanilla_market();
+    let option = VanillaOption::european_call(100.0, 1.0);
+
+    let err = ExplicitFdEngine::new(60, 180)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.15)
+        .price(&option, &market)
+        .expect_err("expected CFL violation to be detected");
+
+    match err {
+        PricingError::ConvergenceFailure(msg) => {
+            assert!(msg.contains("CFL"), "expected CFL message, got {msg}");
+        }
+        other => panic!("unexpected error variant: {other}"),
+    }
+}
+
+#[test]
+fn hopscotch_and_implicit_have_comparable_accuracy() {
+    let market = vanilla_market();
+    let option = VanillaOption::european_put(100.0, 1.0);
+    let bs = bs_price(OptionType::Put, 100.0, 100.0, 0.05, 0.0, 0.20, 1.0);
+
+    let implicit = ImplicitFdEngine::new(280, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&option, &market)
+        .expect("implicit put");
+    let hopscotch = HopscotchEngine::new(280, 160)
+        .with_s_max_multiplier(4.0)
+        .with_grid_stretch(0.18)
+        .price(&option, &market)
+        .expect("hopscotch put");
+
+    let implicit_err = (implicit.price - bs).abs();
+    let hopscotch_err = (hopscotch.price - bs).abs();
+
+    assert!(
+        hopscotch_err <= 8.0 * implicit_err + 1.0e-4,
+        "hopscotch should be reasonably close to implicit accuracy: hop={hopscotch_err} imp={implicit_err}"
+    );
+}
+
+#[test]
+fn adi_heston_matches_fft_reference_values() {
+    let model = Heston {
+        mu: 0.0,
+        kappa: 2.0,
+        theta: 0.04,
+        xi: 0.25,
+        rho: -0.6,
+        v0: 0.04,
+    };
+
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .flat_vol(0.20)
+        .build()
+        .expect("valid market");
+    let option = VanillaOption::european_call(100.0, 1.0);
+
+    let ref_call = heston_price_fft(
+        market.spot,
+        &[option.strike],
+        market.rate,
+        market.dividend_yield,
+        model.v0,
+        model.kappa,
+        model.theta,
+        model.xi,
+        model.rho,
+        option.expiry,
+    )[0]
+    .1;
+
+    let dr = AdiHestonEngine::new(model, 120, 90, 60)
+        .with_scheme(AdiScheme::DouglasRachford)
+        .with_s_max_multiplier(4.0)
+        .with_v_max_multiplier(5.0)
+        .price(&option, &market)
+        .expect("Douglas-Rachford price");
+    let cs = AdiHestonEngine::new(model, 120, 90, 60)
+        .with_scheme(AdiScheme::CraigSneyd)
+        .with_s_max_multiplier(4.0)
+        .with_v_max_multiplier(5.0)
+        .price(&option, &market)
+        .expect("Craig-Sneyd price");
+
+    let dr_err = rel_err(dr.price, ref_call);
+    let cs_err = rel_err(cs.price, ref_call);
+
+    assert!(dr_err <= 0.04, "DR relative error too high: {dr_err}");
+    assert!(cs_err <= 0.03, "CS relative error too high: {cs_err}");
+}
+
+#[test]
+fn adi_enforces_feller_condition_when_requested() {
+    let violating = Heston {
+        mu: 0.0,
+        kappa: 0.5,
+        theta: 0.02,
+        xi: 0.6,
+        rho: -0.4,
+        v0: 0.02,
+    };
+
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.02)
+        .dividend_yield(0.0)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+    let option = VanillaOption::european_call(100.0, 1.0);
+
+    let err = AdiHestonEngine::new(violating, 80, 60, 40)
+        .with_enforce_feller(true)
+        .price(&option, &market)
+        .expect_err("expected Feller-condition validation error");
+
+    match err {
+        PricingError::InvalidInput(msg) => {
+            assert!(msg.contains("Feller"), "unexpected message: {msg}");
+        }
+        other => panic!("unexpected error variant: {other}"),
+    }
+}


### PR DESCRIPTION
## Summary
Complete PDE solver suite:

- **Explicit FD** — forward Euler with CFL stability checking
- **Implicit FD** — backward Euler with Thomas algorithm tridiagonal solve
- **Hopscotch** — Gourlay-McKee checkerboard alternating explicit/implicit
- **ADI** — Douglas-Rachford and Craig-Sneyd splitting for 2D Heston PDE
- **Shared utilities** — non-uniform grid stretching (sinh), operator coefficients for non-uniform grids, boundary conditions, tridiagonal solver

All 1D solvers support European + American + Bermudan exercise.

### Tests (7 independent)
- European call/put vs analytic BS (within 0.5%)
- American put early exercise premium > European put
- Grid refinement convergence (implicit)
- CFL violation detection (explicit)
- Hopscotch vs implicit accuracy comparison
- ADI Heston vs FFT reference values
- Feller condition enforcement

1410 lines added. Closes #35