### PR TITLE
Add hardware acceleration strategy report for pricing hot paths

### DIFF
--- a/docs/HARDWARE_ACCELERATION_REPORT.md
+++ b/docs/HARDWARE_ACCELERATION_REPORT.md
@@ -1,0 +1,266 @@
+# OpenFerric Hardware-Acceleration Report (Creative + Forward-Looking)
+
+## Scope and review method
+
+This report focuses on the pricing hot paths and execution kernels that dominate runtime in OpenFerric:
+
+- Analytic pricing batch paths (`bs_simd`), including branch-free CDF and SIMD dispatch.
+- Monte Carlo kernels (`mc_engine`, `mc_parallel`, `mc_simd`) including exact-terminal simulation, inverse-CDF bottlenecks, SIMD AVX2/FMA loops, and path batching.
+- GPU Monte Carlo (`gpu_mc` + WGSL shader) including RNG, per-path simulation, and host-device reduction/readback.
+- FFT infrastructure (`fft_core`) including plan/scratch caches and transform execution.
+- Existing benchmark targets (`benches/pricing_bench.rs`) as the practical performance baseline suite.
+
+The ideas below intentionally include unpublished / speculative techniques when they are technically plausible and aligned with modern CPU/GPU/accelerator trends.
+
+---
+
+## 1) Hot path map (what likely matters most)
+
+## 1.1 Monte Carlo (CPU) is still the largest acceleration opportunity
+
+OpenFerric already does several strong things well:
+
+- Uses exact single-step GBM terminal sampling for European options (eliminates per-step path loops when possible).
+- Has AVX2+FMA fast paths and batched normal generation.
+- Has parallel chunked MC using Rayon.
+
+This means the next gains are no longer “basic vectorization”; they are mostly about:
+
+1. **RNG + normal generation throughput** (often the true bottleneck after exact GBM).
+2. **Memory traffic / write avoidance** (store less, reduce passes).
+3. **Cross-core scaling efficiency** (NUMA and deterministic stream partitioning).
+
+## 1.2 GPU MC has upside but currently likely pays readback tax
+
+The current GPU path computes one payoff per thread and copies all payoffs back for CPU-side reduction. For large path counts this can become bandwidth-limited and offsets compute gains.
+
+## 1.3 Analytic batch pricing and FFT are already optimized, but still tunable
+
+- Analytic SIMD paths are mature and should benefit mostly from wider SIMD and better transcendental handling.
+- FFT core already caches plans/scratch; remaining gains likely come from batching policies, precision strategy, and backend specialization.
+
+---
+
+## 2) Novel CPU ideas (modern instruction sets + microarchitecture aware)
+
+## 2.1 AVX-512 multi-versioning with lane-scaled kernels
+
+Today’s AVX2 kernels can be extended via function multi-versioning:
+
+- AVX2/FMA path (existing)
+- AVX-512F + AVX-512DQ path (8 x f64 lanes)
+- Optional AVX-512ER/IFMA-specialized variants when available
+
+Creative angle: **lane-adaptive work scheduling**. If path count tail is small, dispatch a masked AVX-512 tail kernel instead of scalar fallback. This improves utilization on irregular batch sizes.
+
+Expected effect: 1.3x–1.8x over AVX2 in compute-heavy sections, depending on exp/inv-CDF costs.
+
+## 2.2 Software-pipelined “RNG -> inverse CDF -> payoff” triple buffering
+
+Instead of generating normals then consuming them in separate phases, use a staged ring buffer per thread:
+
+- Stage A: generate uniforms (SIMD)
+- Stage B: transform previous block to normals
+- Stage C: consume earlier normals for payoff
+
+This overlaps dependency chains and hides transcendental latency. It is similar to instruction-level pipelining but done explicitly at kernel design level.
+
+## 2.3 Counter-based RNG to remove mutable RNG state contention and improve vectorization
+
+Adopt a counter-based RNG (Philox/Threefry-like design) for MC kernels:
+
+- `random(path_id, step_id, global_seed)` style generation.
+- No mutable per-thread state updates.
+- Better reproducibility across CPU/GPU and different thread counts.
+- Easier SIMD packing and deterministic replay.
+
+This also enables **vector-friendly skip-ahead for Sobol + scrambling hybrids** in future QMC paths.
+
+## 2.4 Mixed polynomial approximants for inverse CDF and exp chosen by error budget
+
+Introduce accuracy tiers:
+
+- Tier A (risk/PnL): high-accuracy approximants.
+- Tier B (scenario sweeps): lower-degree minimax approximants.
+
+Novel twist: choose tier dynamically by **target MC standard error**. If stochastic error dominates approximation error by 10x+, use lower-cost approximants automatically.
+
+## 2.5 AMX / matrix engine abuse for batched path propagation
+
+On Intel Sapphire Rapids and beyond, AMX tiles are intended for matrix math, but can be used for:
+
+- batched affine transforms in factor models,
+- blockwise Cholesky applications for correlated normals,
+- low-rank covariance updates.
+
+This is unconventional for quant code but viable for large correlated MC where linear algebra dominates.
+
+## 2.6 NUMA-aware Monte Carlo placement
+
+For dual-socket servers:
+
+- Partition path chunks by NUMA node.
+- Bind threads and allocate local buffers per node.
+- Perform node-local reductions then one final global reduction.
+
+This can materially improve scaling for >32 cores where memory locality dominates.
+
+## 2.7 “Always-on profile-guided binaries” for production workloads
+
+Build three shipping binaries:
+
+- latency profile (small trades)
+- throughput profile (large batches)
+- calibration profile (iterative loops)
+
+Use PGO + BOLT post-link optimization with representative workloads. Modern CPUs get surprisingly large wins from better i-cache and branch layout in numerically dense code.
+
+---
+
+## 3) GPU-first ideas (beyond current implementation)
+
+## 3.1 On-GPU hierarchical reduction (eliminate payoff readback)
+
+Current pattern writes all payoffs and copies to CPU for mean/variance. Replace with:
+
+1. per-workgroup reduction to partial sums/sumsq,
+2. second reduction pass on GPU,
+3. copy back only a tiny summary buffer.
+
+This can be one of the single highest-return GPU changes.
+
+## 3.2 Warp-specialized RNG/normal generation
+
+Box-Muller is serviceable but not necessarily optimal on modern GPUs. Explore:
+
+- Ziggurat-like table methods tuned for shader hardware,
+- pair-sharing of transcendentals across lanes,
+- precomputed scrambled quasi-random tiles in GPU memory for repeatable low-variance runs.
+
+## 3.3 Persistent-kernel Monte Carlo service mode
+
+For repeated pricing requests:
+
+- launch long-lived kernel workers once,
+- stream compact parameter blocks,
+- avoid repeated pipeline/buffer setup overhead.
+
+Particularly effective for low-latency pricing APIs and intraday risk refresh.
+
+## 3.4 Multi-instrument fused kernel batches
+
+Instead of one instrument per dispatch, batch heterogeneous but structurally similar instruments (same model/time grid) and process in one launch with structure-of-arrays parameter blocks. This improves occupancy and amortizes launch overhead.
+
+## 3.5 Tensor-core assisted approximations
+
+Even for non-ML workloads, tensor cores can accelerate polynomial/rational approximants in mixed precision:
+
+- evaluate approximant basis in FP16/BF16,
+- accumulate in FP32,
+- final correction in FP64 on host or final shader stage.
+
+Not “textbook quant,” but potentially high-throughput for exploratory scenario generation.
+
+---
+
+## 4) TPU/NPU/AI-accelerator-inspired techniques
+
+These are intentionally creative and may be unpublished in this exact form.
+
+## 4.1 Learned control variates (“neural CV coprocessor”)
+
+Train a lightweight model to predict payoff (or continuation value) and use residual MC:
+
+`price = E[model(x)] + E[payoff(x) - model(x)]`
+
+Run model inference on NPU/TPU, residual simulation on CPU/GPU. If model captures 80–95% variance, MC path count can drop massively.
+
+## 4.2 Learned surrogate for inverse CDF in bounded domain
+
+Use a tiny piecewise neural/rational surrogate for `Phi^{-1}(u)` over clipped `u` ranges. Deploy on tensor accelerators where transcendental ops are expensive but fused matmul is cheap.
+
+## 4.3 Auto-tuned kernel policy via reinforcement learning
+
+At startup, benchmark micro-kernels and let a policy choose per-job routing:
+
+- CPU scalar / AVX2 / AVX-512
+- GPU kernel variants
+- approximation tier
+
+Essentially “self-driving pricer backend” that adapts to machine + workload mix.
+
+---
+
+## 5) Data layout + algorithm co-design opportunities
+
+## 5.1 Path-state compression and delayed materialization
+
+For path-dependent products, store compressed state (running averages, barrier flags, extrema) rather than full paths unless explicitly needed. This reduces bandwidth and cache pressure.
+
+## 5.2 Fused Greeks estimation kernels
+
+Where feasible, compute price + pathwise Greeks in one traversal (common random numbers, shared intermediates), avoiding repeated path generation.
+
+## 5.3 Strike-bucketed vector packs
+
+For analytic batch pricing, reorder instruments by moneyness/tenor buckets so branches and numerical regimes align per SIMD pack, reducing divergence and improving approximation stability.
+
+## 5.4 Adaptive precision pipeline
+
+- simulate in FP32,
+- accumulate in FP64 (Kahan/pairwise),
+- selectively resimulate “sensitive tails” in FP64.
+
+This is especially useful on GPUs where FP64 is expensive.
+
+---
+
+## 6) Practical roadmap (high ROI first)
+
+## Phase 1 (fastest return)
+
+1. **GPU on-device reduction** for mean/variance.
+2. **CPU AVX-512 multi-version path** with masked tails.
+3. **Counter-based RNG prototype** for deterministic scalable streams.
+4. **Approximation tiering** linked to target MC error.
+
+## Phase 2 (medium effort)
+
+1. Persistent GPU kernel service mode.
+2. NUMA-aware MC scheduler.
+3. Fused price+Greeks MC kernels.
+4. Path-state compression for exotics.
+
+## Phase 3 (speculative / moonshots)
+
+1. Neural control variate coprocessor (NPU/TPU).
+2. RL kernel policy selector.
+3. Tensor-core approximant engine.
+
+---
+
+## 7) What to measure while implementing
+
+For each idea, capture:
+
+- Throughput (prices/sec), latency (p50/p95), and joules per pricing request.
+- Numerical error decomposition:
+  - model error,
+  - MC sampling error,
+  - approximation error,
+  - precision-induced error.
+- Scalability curves:
+  - paths vs speed,
+  - cores vs speed,
+  - GPU occupancy vs speed.
+- Determinism/reproducibility across hardware backends.
+
+A useful acceptance criterion for production acceleration ideas: **>= 20% speedup at equal (or bounded) error and equal reproducibility guarantees**.
+
+---
+
+## 8) Closing note
+
+OpenFerric already has strong foundations: exact terminal MC shortcuts, SIMD kernels, parallel MC, and a GPU implementation. The most promising frontier is now **cross-layer optimization** (RNG + approximants + memory traffic + backend routing), not isolated micro-optimizations.
+
+If desired, next step can be a concrete engineering plan with rough implementation estimates (S/M/L), risk ratings, and a benchmark matrix mapped to existing `pricing_bench`, `mc_bench`, `parallel_bench`, and `fft_bench` suites.


### PR DESCRIPTION
### Motivation
- Capture a creative, forward-looking set of hardware- and accelerator-oriented ideas to speed up OpenFerric pricing hot paths (MC, analytic SIMD, GPU, FFT) after reviewing the repository layout and benchmarks.

### Description
- Add a new report at `docs/HARDWARE_ACCELERATION_REPORT.md` that maps hot paths and documents CPU/GPU/TPU-focused optimizations, approximation tiers, data-layout changes, and a phased roadmap.
- The report highlights concrete opportunities (AVX-512 multi-versioning, counter-based RNGs, on-GPU hierarchical reduction, persistent kernels, tensor-core/NPU uses, NUMA placement, approximation tiering) and measurement guidance tied to existing benches like `benches/pricing_bench.rs`.

### Testing
- Confirmed the new file was created and committed with `git add docs/HARDWARE_ACCELERATION_REPORT.md` and `git commit -m "Add hardware acceleration strategy report for pricing hot paths"` which succeeded.
- No automated unit or integration tests were run against source code as part of this change (documentation-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c02e5f1288320bd92faf554c27c2f)