### PR TITLE
feat(lsp): add Rust-native LSP server for DSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +160,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -352,6 +380,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +423,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -412,10 +474,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -429,8 +547,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -656,6 +779,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -682,10 +811,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -776,6 +1013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +1038,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -834,6 +1090,17 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1023,6 +1290,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "openferric-lsp"
+version = "0.1.0"
+dependencies = [
+ "openferric",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
+]
+
+[[package]]
 name = "openferric-python"
 version = "0.1.0"
 dependencies = [
@@ -1038,6 +1316,8 @@ dependencies = [
  "getrandom 0.4.1",
  "js-sys",
  "openferric",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1091,6 +1371,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1447,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1541,10 +1856,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simba"
@@ -1581,6 +1917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1934,12 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1647,6 +1999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +2065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +2082,138 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1744,6 +2249,25 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -2029,7 +2553,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2045,7 +2569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2058,7 +2582,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2095,7 +2619,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2105,7 +2629,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2123,14 +2656,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2140,10 +2690,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2152,10 +2714,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2164,10 +2738,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2176,10 +2762,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2279,10 +2877,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -2298,6 +2925,60 @@ name = "zerocopy-derive"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "openferric-wasm", "openferric-python"]
+members = [".", "openferric-wasm", "openferric-python", "openferric-lsp"]
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/openferric-lsp/Cargo.toml
+++ b/openferric-lsp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "openferric-lsp"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "openferric-lsp"
+path = "src/main.rs"
+
+[dependencies]
+openferric = { path = ".." }
+tower-lsp = "0.20"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/openferric-lsp/src/backend.rs
+++ b/openferric-lsp/src/backend.rs
@@ -1,0 +1,261 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use openferric::dsl::ast::ProductDef;
+use openferric::dsl::ir::CompiledProduct;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer};
+
+use crate::codelens;
+use crate::completion;
+use crate::diagnostics;
+use crate::document_symbols;
+use crate::goto_def;
+use crate::hover;
+use crate::semantic_tokens;
+use crate::symbols::{self, SymbolTable};
+
+/// Per-document state cached by the LSP server.
+pub struct DocumentState {
+    pub source: String,
+    pub ast: Option<ProductDef>,
+    pub product: Option<CompiledProduct>,
+    pub symbols: SymbolTable,
+}
+
+pub struct Backend {
+    client: Client,
+    documents: Mutex<HashMap<Url, DocumentState>>,
+    pricing_enabled: Mutex<bool>,
+    pricing_config: Mutex<PricingConfig>,
+    market_config: Mutex<Option<serde_json::Value>>,
+}
+
+#[derive(Clone)]
+pub struct PricingConfig {
+    pub num_paths: u32,
+    pub num_steps: u32,
+    pub seed: u64,
+}
+
+impl Default for PricingConfig {
+    fn default() -> Self {
+        Self {
+            num_paths: 50_000,
+            num_steps: 100,
+            seed: 42,
+        }
+    }
+}
+
+impl Backend {
+    pub fn new(client: Client) -> Self {
+        Self {
+            client,
+            documents: Mutex::new(HashMap::new()),
+            pricing_enabled: Mutex::new(true),
+            pricing_config: Mutex::new(PricingConfig::default()),
+            market_config: Mutex::new(None),
+        }
+    }
+
+    fn update_document(&self, uri: &Url, source: String) -> Vec<Diagnostic> {
+        let (ast, product, diags) = diagnostics::parse_and_diagnose(&source);
+        let symbol_table = ast
+            .as_ref()
+            .map(|a| symbols::build_symbol_table(a, &source))
+            .unwrap_or_default();
+
+        let state = DocumentState {
+            source,
+            ast,
+            product,
+            symbols: symbol_table,
+        };
+        self.documents.lock().unwrap().insert(uri.clone(), state);
+        diags
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        // Read initialization options for pricing config.
+        if let Some(opts) = params.initialization_options {
+            if let Some(pricing) = opts.get("pricing") {
+                let mut cfg = self.pricing_config.lock().unwrap();
+                if let Some(v) = pricing.get("numPaths").and_then(|v| v.as_u64()) {
+                    cfg.num_paths = v as u32;
+                }
+                if let Some(v) = pricing.get("numSteps").and_then(|v| v.as_u64()) {
+                    cfg.num_steps = v as u32;
+                }
+                if let Some(v) = pricing.get("seed").and_then(|v| v.as_u64()) {
+                    cfg.seed = v;
+                }
+                if let Some(v) = pricing.get("enabled").and_then(|v| v.as_bool()) {
+                    *self.pricing_enabled.lock().unwrap() = v;
+                }
+            }
+            if let Some(market) = opts.get("market") {
+                *self.market_config.lock().unwrap() = Some(market.clone());
+            }
+        }
+
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![
+                        " ".into(),
+                        ".".into(),
+                        "(".into(),
+                    ]),
+                    ..Default::default()
+                }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                definition_provider: Some(OneOf::Left(true)),
+                document_symbol_provider: Some(OneOf::Left(true)),
+                code_lens_provider: Some(CodeLensOptions {
+                    resolve_provider: Some(false),
+                }),
+                semantic_tokens_provider: Some(
+                    SemanticTokensServerCapabilities::SemanticTokensOptions(
+                        semantic_tokens::capabilities(),
+                    ),
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "openferric-lsp initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
+        let diags = self.update_document(&uri, params.text_document.text);
+        self.client
+            .publish_diagnostics(uri, diags, None)
+            .await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
+        if let Some(change) = params.content_changes.into_iter().last() {
+            let diags = self.update_document(&uri, change.text);
+            self.client
+                .publish_diagnostics(uri, diags, None)
+                .await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+        self.documents.lock().unwrap().remove(&uri);
+        self.client
+            .publish_diagnostics(uri, vec![], None)
+            .await;
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let pos = params.text_document_position.position;
+        let docs = self.documents.lock().unwrap();
+        let items = match docs.get(uri) {
+            Some(state) => completion::completions(state, pos),
+            None => vec![],
+        };
+        Ok(Some(CompletionResponse::Array(items)))
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        let docs = self.documents.lock().unwrap();
+        Ok(docs.get(uri).and_then(|state| hover::hover(state, pos)))
+    }
+
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> Result<Option<GotoDefinitionResponse>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+        let docs = self.documents.lock().unwrap();
+        Ok(docs.get(uri).and_then(|state| {
+            goto_def::goto_definition(state, pos).map(|range| {
+                GotoDefinitionResponse::Scalar(Location {
+                    uri: uri.clone(),
+                    range,
+                })
+            })
+        }))
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let uri = &params.text_document.uri;
+        let docs = self.documents.lock().unwrap();
+        Ok(docs.get(uri).map(|state| {
+            DocumentSymbolResponse::Flat(document_symbols::document_symbols(state, uri))
+        }))
+    }
+
+    async fn code_lens(&self, params: CodeLensParams) -> Result<Option<Vec<CodeLens>>> {
+        let enabled = *self.pricing_enabled.lock().unwrap();
+        if !enabled {
+            return Ok(None);
+        }
+        let uri = &params.text_document.uri;
+        // Extract data under the lock, then release before pricing.
+        let code_lens_input = {
+            let docs = self.documents.lock().unwrap();
+            docs.get(uri).and_then(|state| {
+                let product = state.product.clone()?;
+                let product_span_start = state.ast.as_ref().map(|a| a.span.start).unwrap_or(0);
+                let source = state.source.clone();
+                Some((product, product_span_start, source))
+            })
+        };
+        let Some((product, product_span_start, source)) = code_lens_input else {
+            return Ok(None);
+        };
+        let pricing_cfg = self.pricing_config.lock().unwrap().clone();
+        let market_cfg = self.market_config.lock().unwrap().clone();
+        Ok(Some(codelens::code_lenses(
+            &product,
+            product_span_start,
+            &source,
+            &pricing_cfg,
+            market_cfg.as_ref(),
+        )))
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let uri = &params.text_document.uri;
+        let docs = self.documents.lock().unwrap();
+        Ok(docs.get(uri).map(|state| {
+            SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: semantic_tokens::semantic_tokens(state),
+            })
+        }))
+    }
+}

--- a/openferric-lsp/src/codelens.rs
+++ b/openferric-lsp/src/codelens.rs
@@ -1,0 +1,140 @@
+use openferric::dsl::engine::DslMonteCarloEngine;
+use openferric::dsl::ir::CompiledProduct;
+use openferric::dsl::market::{AssetData, MultiAssetMarket};
+use tower_lsp::lsp_types::*;
+
+use crate::backend::PricingConfig;
+use crate::diagnostics::offset_to_position;
+
+/// Generate CodeLens items showing live price and Greeks.
+///
+/// Takes decomposed document state (not a reference to DocumentState) so the
+/// caller can release the document mutex before pricing runs.
+pub fn code_lenses(
+    product: &CompiledProduct,
+    product_span_start: usize,
+    source: &str,
+    pricing_cfg: &PricingConfig,
+    market_json: Option<&serde_json::Value>,
+) -> Vec<CodeLens> {
+    // Build market data.
+    let market = build_market(product.num_underlyings, market_json);
+    let market = match market {
+        Some(m) => m,
+        None => return vec![],
+    };
+
+    let engine = DslMonteCarloEngine::new(
+        pricing_cfg.num_paths as usize,
+        pricing_cfg.num_steps as usize,
+        pricing_cfg.seed,
+    );
+
+    let mut lenses = Vec::new();
+    let product_line_pos = offset_to_position(source, product_span_start);
+    let range = Range {
+        start: product_line_pos,
+        end: product_line_pos,
+    };
+
+    // Price.
+    match engine.price_multi_asset(product, &market) {
+        Ok(result) => {
+            let stderr_str = result
+                .stderr
+                .map(|s| format!(" | StdErr: {s:.4}"))
+                .unwrap_or_default();
+            lenses.push(CodeLens {
+                range,
+                command: Some(Command {
+                    title: format!("Price: {:.4}{stderr_str}", result.price),
+                    command: String::new(),
+                    arguments: None,
+                }),
+                data: None,
+            });
+        }
+        Err(e) => {
+            lenses.push(CodeLens {
+                range,
+                command: Some(Command {
+                    title: format!("Pricing error: {e}"),
+                    command: String::new(),
+                    arguments: None,
+                }),
+                data: None,
+            });
+        }
+    }
+
+    // Greeks for asset 0.
+    if product.num_underlyings > 0
+        && let Ok(greeks) = engine.greeks_multi_asset(product, &market, 0)
+    {
+        lenses.push(CodeLens {
+            range,
+            command: Some(Command {
+                title: format!(
+                    "Delta: {:.4} | Gamma: {:.4} | Vega: {:.4} | Rho: {:.4}",
+                    greeks.delta,
+                    greeks.gamma,
+                    greeks.vega,
+                    greeks.rho,
+                ),
+                command: String::new(),
+                arguments: None,
+            }),
+            data: None,
+        });
+    }
+
+    lenses
+}
+
+fn build_market(num_underlyings: usize, market_json: Option<&serde_json::Value>) -> Option<MultiAssetMarket> {
+    // Try to parse from config.
+    if let Some(json) = market_json
+        && let Ok(mut market) = serde_json::from_value::<MultiAssetMarket>(json.clone())
+    {
+        // Pad assets if the product needs more.
+        while market.assets.len() < num_underlyings {
+            market.assets.push(AssetData {
+                spot: 100.0,
+                vol: 0.20,
+                dividend_yield: 0.02,
+            });
+        }
+        // Pad correlation matrix.
+        let n = market.assets.len();
+        if market.correlation.len() < n {
+            market.correlation = identity_correlation(n);
+        }
+        return Some(market);
+    }
+
+    // Default market.
+    let assets: Vec<AssetData> = (0..num_underlyings)
+        .map(|_| AssetData {
+            spot: 100.0,
+            vol: 0.20,
+            dividend_yield: 0.02,
+        })
+        .collect();
+    let correlation = identity_correlation(num_underlyings);
+
+    Some(MultiAssetMarket {
+        assets,
+        correlation,
+        rate: 0.05,
+    })
+}
+
+fn identity_correlation(n: usize) -> Vec<Vec<f64>> {
+    (0..n)
+        .map(|i| {
+            (0..n)
+                .map(|j| if i == j { 1.0 } else { 0.0 })
+                .collect()
+        })
+        .collect()
+}

--- a/openferric-lsp/src/completion.rs
+++ b/openferric-lsp/src/completion.rs
@@ -1,0 +1,214 @@
+use tower_lsp::lsp_types::*;
+
+use crate::backend::DocumentState;
+use crate::diagnostics::position_to_offset;
+use crate::symbols::SymbolKind;
+
+/// Provide context-aware completions.
+pub fn completions(state: &DocumentState, pos: Position) -> Vec<CompletionItem> {
+    let offset = position_to_offset(&state.source, pos);
+    let context = determine_context(&state.source, offset);
+
+    match context {
+        Context::TopLevel => top_level_completions(),
+        Context::AfterSchedule => frequency_completions(),
+        Context::StatementPosition => statement_completions(),
+        Context::Expression => expression_completions(state),
+        Context::AfterSet => state_var_completions(state),
+        Context::TypePosition => type_completions(),
+    }
+}
+
+#[derive(Debug)]
+enum Context {
+    TopLevel,
+    AfterSchedule,
+    StatementPosition,
+    Expression,
+    AfterSet,
+    TypePosition,
+}
+
+fn determine_context(source: &str, offset: usize) -> Context {
+    let before = &source[..offset.min(source.len())];
+
+    // Get the current line up to the cursor.
+    let line_start = before.rfind('\n').map_or(0, |nl| nl + 1);
+    let line = before[line_start..].trim();
+
+    // After "set " → state variable names.
+    if line.starts_with("set ") && !line.contains('=') {
+        return Context::AfterSet;
+    }
+
+    // After "schedule" keyword on the same line → frequency.
+    if line.starts_with("schedule") && !line.contains("from") {
+        return Context::AfterSchedule;
+    }
+
+    // After ":" in state declaration → type position.
+    if line.contains(':') && !line.contains('=') {
+        // Check if we're inside a state block.
+        if is_in_state_block(before) {
+            return Context::TypePosition;
+        }
+    }
+
+    // Inside a schedule body (indented inside schedule) → statement or expression.
+    if is_in_schedule_body(before) {
+        if line.is_empty() || line_is_statement_start(line) {
+            return Context::StatementPosition;
+        }
+        return Context::Expression;
+    }
+
+    // Top-level (inside product body).
+    Context::TopLevel
+}
+
+fn is_in_state_block(before: &str) -> bool {
+    // Check if we see "state" as a block keyword above.
+    for line in before.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed == "state" {
+            return true;
+        }
+        if trimmed.starts_with("schedule")
+            || trimmed.starts_with("underlyings")
+            || trimmed.starts_with("product")
+        {
+            return false;
+        }
+    }
+    false
+}
+
+fn is_in_schedule_body(before: &str) -> bool {
+    for line in before.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("schedule") {
+            return true;
+        }
+        if trimmed.starts_with("product") || trimmed.starts_with("underlyings") || trimmed == "state" {
+            return false;
+        }
+    }
+    false
+}
+
+fn line_is_statement_start(line: &str) -> bool {
+    let first_word = line.split_whitespace().next().unwrap_or("");
+    matches!(
+        first_word,
+        "" | "let" | "if" | "pay" | "redeem" | "set" | "skip" | "else"
+    )
+}
+
+fn top_level_completions() -> Vec<CompletionItem> {
+    vec![
+        keyword_item("notional:", "Product face value"),
+        keyword_item("maturity:", "Product maturity in year fractions"),
+        keyword_item("underlyings", "Declare underlying assets"),
+        keyword_item("state", "Declare mutable state variables"),
+        keyword_item("schedule", "Define observation schedule"),
+    ]
+}
+
+fn frequency_completions() -> Vec<CompletionItem> {
+    vec![
+        enum_item("monthly", "Every month (period = 1/12)"),
+        enum_item("quarterly", "Every quarter (period = 0.25)"),
+        enum_item("semi_annual", "Every 6 months (period = 0.5)"),
+        enum_item("annual", "Every year (period = 1.0)"),
+    ]
+}
+
+fn statement_completions() -> Vec<CompletionItem> {
+    vec![
+        keyword_item("let", "Bind a local variable"),
+        keyword_item("if", "Conditional branch"),
+        keyword_item("pay", "Record a cashflow payment"),
+        keyword_item("redeem", "Final payment and terminate"),
+        keyword_item("set", "Update a state variable"),
+        keyword_item("skip", "Skip this observation date"),
+    ]
+}
+
+fn expression_completions(state: &DocumentState) -> Vec<CompletionItem> {
+    let mut items = Vec::new();
+
+    // Declared symbols (locals, state vars, underlyings).
+    for sym in &state.symbols.declarations {
+        match sym.kind {
+            SymbolKind::Local | SymbolKind::StateVar | SymbolKind::Underlying => {
+                items.push(CompletionItem {
+                    label: sym.name.clone(),
+                    kind: Some(CompletionItemKind::VARIABLE),
+                    detail: Some(format!("{}: {}", sym.name, sym.type_hint)),
+                    documentation: Some(Documentation::String(sym.doc.to_string())),
+                    ..Default::default()
+                });
+            }
+            SymbolKind::Builtin => {
+                items.push(CompletionItem {
+                    label: sym.name.clone(),
+                    kind: Some(CompletionItemKind::CONSTANT),
+                    detail: Some(format!("{}: {}", sym.name, sym.type_hint)),
+                    documentation: Some(Documentation::String(sym.doc.to_string())),
+                    ..Default::default()
+                });
+            }
+            SymbolKind::BuiltinFn => {
+                items.push(CompletionItem {
+                    label: sym.name.clone(),
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    detail: Some(sym.type_hint.to_string()),
+                    documentation: Some(Documentation::String(sym.doc.to_string())),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    items
+}
+
+fn state_var_completions(state: &DocumentState) -> Vec<CompletionItem> {
+    state
+        .symbols
+        .declarations
+        .iter()
+        .filter(|s| s.kind == SymbolKind::StateVar)
+        .map(|s| CompletionItem {
+            label: s.name.clone(),
+            kind: Some(CompletionItemKind::VARIABLE),
+            detail: Some(format!("{}: {}", s.name, s.type_hint)),
+            ..Default::default()
+        })
+        .collect()
+}
+
+fn type_completions() -> Vec<CompletionItem> {
+    vec![
+        keyword_item("bool", "Boolean type"),
+        keyword_item("float", "Floating-point number type"),
+    ]
+}
+
+fn keyword_item(label: &str, detail: &str) -> CompletionItem {
+    CompletionItem {
+        label: label.into(),
+        kind: Some(CompletionItemKind::KEYWORD),
+        detail: Some(detail.into()),
+        ..Default::default()
+    }
+}
+
+fn enum_item(label: &str, detail: &str) -> CompletionItem {
+    CompletionItem {
+        label: label.into(),
+        kind: Some(CompletionItemKind::ENUM_MEMBER),
+        detail: Some(detail.into()),
+        ..Default::default()
+    }
+}

--- a/openferric-lsp/src/diagnostics.rs
+++ b/openferric-lsp/src/diagnostics.rs
@@ -1,0 +1,90 @@
+use openferric::dsl::ast::ProductDef;
+use openferric::dsl::error::DslError;
+use openferric::dsl::ir::CompiledProduct;
+use openferric::dsl::{lexer, parser, compiler};
+use tower_lsp::lsp_types::*;
+
+/// Parse and compile source, returning the AST, compiled product, and diagnostics.
+pub fn parse_and_diagnose(
+    source: &str,
+) -> (Option<ProductDef>, Option<CompiledProduct>, Vec<Diagnostic>) {
+    let tokens = match lexer::tokenize(source) {
+        Ok(t) => t,
+        Err(e) => return (None, None, vec![error_to_diagnostic(source, &e)]),
+    };
+
+    let ast = match parser::parse(tokens) {
+        Ok(a) => a,
+        Err(e) => return (None, None, vec![error_to_diagnostic(source, &e)]),
+    };
+
+    match compiler::compile(&ast) {
+        Ok(product) => (Some(ast), Some(product), vec![]),
+        Err(e) => (Some(ast), None, vec![error_to_diagnostic(source, &e)]),
+    }
+}
+
+fn error_to_diagnostic(source: &str, error: &DslError) -> Diagnostic {
+    let (message, range) = match error {
+        DslError::LexError { message, span } => {
+            (message.clone(), span_to_range(source, span.start, span.end))
+        }
+        DslError::ParseError { message, span } => {
+            (message.clone(), span_to_range(source, span.start, span.end))
+        }
+        DslError::CompileError { message, span } => {
+            let range = span
+                .map(|s| span_to_range(source, s.start, s.end))
+                .unwrap_or(Range {
+                    start: Position::new(0, 0),
+                    end: Position::new(0, 1),
+                });
+            (message.clone(), range)
+        }
+        DslError::EvalError(msg) => (
+            msg.clone(),
+            Range {
+                start: Position::new(0, 0),
+                end: Position::new(0, 1),
+            },
+        ),
+    };
+
+    Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::ERROR),
+        source: Some("openferric-dsl".into()),
+        message,
+        ..Default::default()
+    }
+}
+
+/// Convert byte offsets to LSP Position range by counting newlines.
+fn span_to_range(source: &str, start: usize, end: usize) -> Range {
+    Range {
+        start: offset_to_position(source, start),
+        end: offset_to_position(source, end),
+    }
+}
+
+pub fn offset_to_position(source: &str, offset: usize) -> Position {
+    let offset = offset.min(source.len());
+    let before = &source[..offset];
+    let line = before.matches('\n').count() as u32;
+    let col = before.rfind('\n').map_or(offset, |nl| offset - nl - 1) as u32;
+    Position::new(line, col)
+}
+
+pub fn position_to_offset(source: &str, pos: Position) -> usize {
+    let mut line = 0u32;
+    for (i, c) in source.char_indices() {
+        if line == pos.line {
+            let col_offset = pos.character as usize;
+            return (i + col_offset).min(source.len());
+        }
+        if c == '\n' {
+            line += 1;
+        }
+    }
+    source.len()
+}

--- a/openferric-lsp/src/document_symbols.rs
+++ b/openferric-lsp/src/document_symbols.rs
@@ -1,0 +1,160 @@
+use openferric::dsl::ast::*;
+use tower_lsp::lsp_types::*;
+
+use crate::backend::DocumentState;
+use crate::diagnostics::offset_to_position;
+
+/// Build document symbols for the outline panel.
+#[allow(deprecated)] // SymbolInformation::deprecated field
+pub fn document_symbols(state: &DocumentState, uri: &Url) -> Vec<SymbolInformation> {
+    let ast = match &state.ast {
+        Some(a) => a,
+        None => return vec![],
+    };
+
+    let mut symbols = Vec::new();
+
+    // Product itself.
+    symbols.push(SymbolInformation {
+        name: format!("product \"{}\"", ast.name),
+        kind: tower_lsp::lsp_types::SymbolKind::CLASS,
+        location: Location {
+            uri: uri.clone(), // placeholder, overridden by client
+            range: span_to_range(&state.source, ast.span.start, ast.span.end),
+        },
+        tags: None,
+        deprecated: None,
+        container_name: None,
+    });
+
+    for item in &ast.body {
+        match item {
+            ProductItem::Notional(val, span) => {
+                symbols.push(SymbolInformation {
+                    name: format!("notional: {val}"),
+                    kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(&state.source, span.start, span.end),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: Some(ast.name.clone()),
+                });
+            }
+            ProductItem::Maturity(val, span) => {
+                symbols.push(SymbolInformation {
+                    name: format!("maturity: {val}"),
+                    kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(&state.source, span.start, span.end),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: Some(ast.name.clone()),
+                });
+            }
+            ProductItem::Underlyings(decls, span) => {
+                symbols.push(SymbolInformation {
+                    name: "underlyings".into(),
+                    kind: tower_lsp::lsp_types::SymbolKind::NAMESPACE,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(&state.source, span.start, span.end),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: Some(ast.name.clone()),
+                });
+                for decl in decls {
+                    symbols.push(SymbolInformation {
+                        name: format!("{} = asset({})", decl.name, decl.asset_index),
+                        kind: tower_lsp::lsp_types::SymbolKind::VARIABLE,
+                        location: Location {
+                            uri: uri.clone(),
+                            range: span_to_range(
+                                &state.source,
+                                decl.span.start,
+                                decl.span.end,
+                            ),
+                        },
+                        tags: None,
+                        deprecated: None,
+                        container_name: Some("underlyings".into()),
+                    });
+                }
+            }
+            ProductItem::State(decls, span) => {
+                symbols.push(SymbolInformation {
+                    name: "state".into(),
+                    kind: tower_lsp::lsp_types::SymbolKind::NAMESPACE,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(&state.source, span.start, span.end),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: Some(ast.name.clone()),
+                });
+                for decl in decls {
+                    symbols.push(SymbolInformation {
+                        name: format!("{}: {}", decl.name, decl.type_name),
+                        kind: tower_lsp::lsp_types::SymbolKind::VARIABLE,
+                        location: Location {
+                            uri: uri.clone(),
+                            range: span_to_range(
+                                &state.source,
+                                decl.span.start,
+                                decl.span.end,
+                            ),
+                        },
+                        tags: None,
+                        deprecated: None,
+                        container_name: Some("state".into()),
+                    });
+                }
+            }
+            ProductItem::Schedule(sched) => {
+                let freq = match sched.frequency {
+                    ScheduleFreq::Monthly => "monthly",
+                    ScheduleFreq::Quarterly => "quarterly",
+                    ScheduleFreq::SemiAnnual => "semi_annual",
+                    ScheduleFreq::Annual => "annual",
+                    ScheduleFreq::Custom(p) => {
+                        // Use a static str for common custom values, else fallback.
+                        if (p - 1.0 / 12.0).abs() < 1e-10 {
+                            "monthly"
+                        } else {
+                            "custom"
+                        }
+                    }
+                };
+                symbols.push(SymbolInformation {
+                    name: format!("schedule {freq} {}..{}", sched.start, sched.end),
+                    kind: tower_lsp::lsp_types::SymbolKind::EVENT,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(
+                            &state.source,
+                            sched.span.start,
+                            sched.span.end,
+                        ),
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: Some(ast.name.clone()),
+                });
+            }
+        }
+    }
+
+    symbols
+}
+
+fn span_to_range(source: &str, start: usize, end: usize) -> Range {
+    Range {
+        start: offset_to_position(source, start),
+        end: offset_to_position(source, end),
+    }
+}

--- a/openferric-lsp/src/goto_def.rs
+++ b/openferric-lsp/src/goto_def.rs
@@ -1,0 +1,28 @@
+use tower_lsp::lsp_types::*;
+
+use crate::backend::DocumentState;
+use crate::diagnostics::{offset_to_position, position_to_offset};
+use crate::symbols::SymbolKind;
+
+/// Go to the definition of the symbol at the cursor position.
+pub fn goto_definition(state: &DocumentState, pos: Position) -> Option<Range> {
+    let offset = position_to_offset(&state.source, pos);
+
+    // Find the reference at cursor.
+    let sym_ref = state.symbols.reference_at(offset)?;
+
+    // Builtins have no source definition.
+    if sym_ref.kind == SymbolKind::Builtin || sym_ref.kind == SymbolKind::BuiltinFn {
+        return None;
+    }
+
+    // Zero span means no real definition (builtins).
+    if sym_ref.def_span.start == 0 && sym_ref.def_span.end == 0 {
+        return None;
+    }
+
+    Some(Range {
+        start: offset_to_position(&state.source, sym_ref.def_span.start),
+        end: offset_to_position(&state.source, sym_ref.def_span.end),
+    })
+}

--- a/openferric-lsp/src/hover.rs
+++ b/openferric-lsp/src/hover.rs
@@ -1,0 +1,144 @@
+use tower_lsp::lsp_types::*;
+
+use crate::backend::DocumentState;
+use crate::diagnostics::{offset_to_position, position_to_offset};
+use crate::symbols::SymbolKind;
+
+/// Provide hover information at the cursor position.
+pub fn hover(state: &DocumentState, pos: Position) -> Option<Hover> {
+    let offset = position_to_offset(&state.source, pos);
+
+    // Check if cursor is on a reference.
+    if let Some(sym_ref) = state.symbols.reference_at(offset) {
+        let markdown = format_symbol_hover(
+            &sym_ref.name,
+            sym_ref.kind,
+            sym_ref.type_hint,
+            sym_ref.doc,
+        );
+        return Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: markdown,
+            }),
+            range: Some(span_to_range(&state.source, sym_ref.span.start, sym_ref.span.end)),
+        });
+    }
+
+    // Check if cursor is on a declaration.
+    if let Some(sym) = state.symbols.declaration_at(offset) {
+        let markdown = format_symbol_hover(&sym.name, sym.kind, sym.type_hint, sym.doc);
+        return Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: markdown,
+            }),
+            range: Some(span_to_range(&state.source, sym.def_span.start, sym.def_span.end)),
+        });
+    }
+
+    // Check if cursor is on a keyword.
+    keyword_hover(state, offset)
+}
+
+fn format_symbol_hover(name: &str, kind: SymbolKind, type_hint: &str, doc: &str) -> String {
+    let kind_label = match kind {
+        SymbolKind::Underlying => "underlying equity",
+        SymbolKind::StateVar => "state variable (mutable across dates)",
+        SymbolKind::Local => "local variable",
+        SymbolKind::Builtin => "built-in",
+        SymbolKind::BuiltinFn => "built-in function",
+    };
+
+    match kind {
+        SymbolKind::BuiltinFn => {
+            format!("`{type_hint}` \u{2014} {doc}")
+        }
+        _ => {
+            format!("`{name}: {type_hint}` \u{2014} {kind_label}")
+        }
+    }
+}
+
+fn keyword_hover(state: &DocumentState, offset: usize) -> Option<Hover> {
+    let word = word_at_offset(&state.source, offset)?;
+
+    let doc = match word.text {
+        "product" => "Define a structured product",
+        "notional" => "Product face value",
+        "maturity" => "Product maturity in year fractions",
+        "underlyings" => "Declare underlying assets for the product",
+        "state" => "Declare mutable state variables that persist across observation dates",
+        "schedule" => "Define an observation schedule with frequency and date range",
+        "let" => "Bind a local variable within the current observation",
+        "if" => "Conditional branch",
+        "then" => "Begin the body of a conditional branch",
+        "else" => "Alternative branch of a conditional",
+        "pay" => "Record a cashflow payment at the current observation date",
+        "redeem" => "Record final payment and terminate the product",
+        "set" => "Update a state variable's value",
+        "skip" => "Skip the current observation date without payment",
+        "and" => "Logical AND operator",
+        "or" => "Logical OR operator",
+        "not" => "Logical NOT operator",
+        "from" => "Schedule start date",
+        "to" => "Schedule end date",
+        "monthly" => "Schedule frequency: every month (period = 1/12)",
+        "quarterly" => "Schedule frequency: every quarter (period = 0.25)",
+        "semi_annual" => "Schedule frequency: every 6 months (period = 0.5)",
+        "annual" => "Schedule frequency: every year (period = 1.0)",
+        "true" | "false" => "Boolean literal",
+        "bool" => "Boolean type",
+        "float" => "Floating-point number type",
+        "asset" => "Reference an underlying by index: asset(N)",
+        _ => return None,
+    };
+
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!("`{0}` \u{2014} {doc}", word.text),
+        }),
+        range: Some(span_to_range(&state.source, word.start, word.end)),
+    })
+}
+
+struct WordAt<'a> {
+    text: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn word_at_offset(source: &str, offset: usize) -> Option<WordAt<'_>> {
+    if offset > source.len() {
+        return None;
+    }
+    let bytes = source.as_bytes();
+    let mut start = offset;
+    while start > 0 && is_ident_char(bytes[start - 1]) {
+        start -= 1;
+    }
+    let mut end = offset;
+    while end < bytes.len() && is_ident_char(bytes[end]) {
+        end += 1;
+    }
+    if start == end {
+        return None;
+    }
+    Some(WordAt {
+        text: &source[start..end],
+        start,
+        end,
+    })
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+fn span_to_range(source: &str, start: usize, end: usize) -> Range {
+    Range {
+        start: offset_to_position(source, start),
+        end: offset_to_position(source, end),
+    }
+}

--- a/openferric-lsp/src/main.rs
+++ b/openferric-lsp/src/main.rs
@@ -1,0 +1,20 @@
+mod backend;
+mod codelens;
+mod completion;
+mod diagnostics;
+mod document_symbols;
+mod goto_def;
+mod hover;
+mod semantic_tokens;
+mod symbols;
+
+use tower_lsp::{LspService, Server};
+
+#[tokio::main]
+async fn main() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(backend::Backend::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/openferric-lsp/src/semantic_tokens.rs
+++ b/openferric-lsp/src/semantic_tokens.rs
@@ -1,0 +1,152 @@
+use openferric::dsl::lexer::{self, TokenKind};
+use tower_lsp::lsp_types::*;
+
+use crate::backend::DocumentState;
+use crate::diagnostics::offset_to_position;
+use crate::symbols::SymbolKind;
+
+// Semantic token types — indices into LEGEND_TYPE.
+const KEYWORD: u32 = 0;
+const VARIABLE: u32 = 1;
+const FUNCTION: u32 = 2;
+const NUMBER: u32 = 3;
+const STRING: u32 = 4;
+const OPERATOR: u32 = 5;
+const ENUM_MEMBER: u32 = 6;
+#[allow(dead_code)]
+const COMMENT: u32 = 7;
+
+const LEGEND_TYPE: &[SemanticTokenType] = &[
+    SemanticTokenType::KEYWORD,
+    SemanticTokenType::VARIABLE,
+    SemanticTokenType::FUNCTION,
+    SemanticTokenType::NUMBER,
+    SemanticTokenType::STRING,
+    SemanticTokenType::OPERATOR,
+    SemanticTokenType::ENUM_MEMBER,
+    SemanticTokenType::COMMENT,
+];
+
+pub fn capabilities() -> SemanticTokensOptions {
+    SemanticTokensOptions {
+        legend: SemanticTokensLegend {
+            token_types: LEGEND_TYPE.to_vec(),
+            token_modifiers: vec![],
+        },
+        full: Some(SemanticTokensFullOptions::Bool(true)),
+        range: None,
+        ..Default::default()
+    }
+}
+
+pub fn semantic_tokens(state: &DocumentState) -> Vec<SemanticToken> {
+    let tokens = match lexer::tokenize(&state.source) {
+        Ok(t) => t,
+        Err(_) => return vec![],
+    };
+
+    let mut result = Vec::new();
+    let mut prev_line = 0u32;
+    let mut prev_start = 0u32;
+
+    for token in &tokens {
+        let token_type = match &token.kind {
+            // Keywords
+            TokenKind::Product
+            | TokenKind::Notional
+            | TokenKind::Maturity
+            | TokenKind::Underlyings
+            | TokenKind::State
+            | TokenKind::Schedule
+            | TokenKind::From
+            | TokenKind::To
+            | TokenKind::Let
+            | TokenKind::If
+            | TokenKind::Then
+            | TokenKind::Else
+            | TokenKind::Pay
+            | TokenKind::Redeem
+            | TokenKind::Set
+            | TokenKind::Skip
+            | TokenKind::Asset
+            | TokenKind::Bool
+            | TokenKind::Float
+            | TokenKind::True
+            | TokenKind::False => KEYWORD,
+
+            // Logical operators as keywords
+            TokenKind::And | TokenKind::Or | TokenKind::Not => OPERATOR,
+
+            // Frequencies
+            TokenKind::Monthly
+            | TokenKind::Quarterly
+            | TokenKind::SemiAnnual
+            | TokenKind::Annual => ENUM_MEMBER,
+
+            // Literals
+            TokenKind::Number(_) => NUMBER,
+            TokenKind::StringLit(_) => STRING,
+
+            // Identifiers — resolve via symbol table
+            TokenKind::Ident(name) => {
+                if let Some(sym_ref) = state.symbols.reference_at(token.span.start) {
+                    match sym_ref.kind {
+                        SymbolKind::BuiltinFn => FUNCTION,
+                        SymbolKind::Builtin => VARIABLE,
+                        SymbolKind::Local => VARIABLE,
+                        SymbolKind::StateVar => VARIABLE,
+                        SymbolKind::Underlying => VARIABLE,
+                    }
+                } else {
+                    // Check if it's a known function name
+                    match name.as_str() {
+                        "worst_of" | "best_of" | "performances" | "price" | "min" | "max"
+                        | "abs" | "exp" | "log" => FUNCTION,
+                        _ => VARIABLE,
+                    }
+                }
+            }
+
+            // Skip indentation and punctuation tokens
+            TokenKind::Indent | TokenKind::Dedent => continue,
+            TokenKind::LParen
+            | TokenKind::RParen
+            | TokenKind::Colon
+            | TokenKind::Comma => continue,
+            TokenKind::Eq
+            | TokenKind::EqEq
+            | TokenKind::Ne
+            | TokenKind::Lt
+            | TokenKind::Le
+            | TokenKind::Gt
+            | TokenKind::Ge
+            | TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Slash => OPERATOR,
+        };
+
+        let pos = offset_to_position(&state.source, token.span.start);
+        let length = (token.span.end - token.span.start) as u32;
+
+        let delta_line = pos.line - prev_line;
+        let delta_start = if delta_line == 0 {
+            pos.character - prev_start
+        } else {
+            pos.character
+        };
+
+        result.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type,
+            token_modifiers_bitset: 0,
+        });
+
+        prev_line = pos.line;
+        prev_start = pos.character;
+    }
+
+    result
+}

--- a/openferric-lsp/src/symbols.rs
+++ b/openferric-lsp/src/symbols.rs
@@ -1,0 +1,272 @@
+use openferric::dsl::ast::*;
+use openferric::dsl::error::Span;
+
+/// Kind of symbol in the DSL.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolKind {
+    Underlying,
+    StateVar,
+    Local,
+    Builtin,
+    BuiltinFn,
+}
+
+/// Scope in which a symbol is visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum SymbolScope {
+    Product,
+    Schedule(usize),
+}
+
+/// Information about a declared symbol.
+#[derive(Debug, Clone)]
+pub struct SymbolInfo {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub type_hint: &'static str,
+    pub def_span: Span,
+    pub scope: SymbolScope,
+    pub doc: &'static str,
+}
+
+/// A reference to a symbol at a specific location in the source.
+#[derive(Debug, Clone)]
+pub struct SymbolRef {
+    pub name: String,
+    pub span: Span,
+    pub def_span: Span,
+    pub kind: SymbolKind,
+    pub type_hint: &'static str,
+    pub doc: &'static str,
+}
+
+/// Symbol table built from the AST.
+#[derive(Debug, Default)]
+pub struct SymbolTable {
+    pub declarations: Vec<SymbolInfo>,
+    pub references: Vec<SymbolRef>,
+}
+
+impl SymbolTable {
+    /// Find a declaration whose span contains the given byte offset.
+    pub fn declaration_at(&self, offset: usize) -> Option<&SymbolInfo> {
+        self.declarations
+            .iter()
+            .find(|s| offset >= s.def_span.start && offset < s.def_span.end)
+    }
+
+    /// Find a reference whose span contains the given byte offset.
+    pub fn reference_at(&self, offset: usize) -> Option<&SymbolRef> {
+        self.references
+            .iter()
+            .find(|r| offset >= r.span.start && offset < r.span.end)
+    }
+}
+
+/// Build a symbol table from a parsed AST.
+pub fn build_symbol_table(ast: &ProductDef, source: &str) -> SymbolTable {
+    let mut declarations = Vec::new();
+    let mut references = Vec::new();
+
+    // Add builtins (no source span — use 0..0).
+    let builtins = [
+        ("notional", "float", "Product face value"),
+        ("observation_date", "float", "Current observation date in year fractions"),
+        ("is_final", "bool", "True on the last observation date"),
+        ("maturity", "float", "Product maturity in year fractions"),
+    ];
+    for (name, ty, doc) in &builtins {
+        declarations.push(SymbolInfo {
+            name: name.to_string(),
+            kind: SymbolKind::Builtin,
+            type_hint: ty,
+            def_span: Span::new(0, 0),
+            scope: SymbolScope::Product,
+            doc,
+        });
+    }
+
+    let builtin_fns: &[(&str, &str, &str)] = &[
+        ("worst_of", "worst_of(values: [float]) -> float", "Minimum of a vector"),
+        ("best_of", "best_of(values: [float]) -> float", "Maximum of a vector"),
+        ("performances", "performances() -> [float]", "Spot/initial for each underlying"),
+        ("price", "price(asset_index: int) -> float", "Current spot price of underlying"),
+        ("min", "min(a: float, b: float) -> float", "Minimum of two values"),
+        ("max", "max(a: float, b: float) -> float", "Maximum of two values"),
+        ("abs", "abs(x: float) -> float", "Absolute value"),
+        ("exp", "exp(x: float) -> float", "Exponential function"),
+        ("log", "log(x: float) -> float", "Natural logarithm"),
+    ];
+    for (name, ty, doc) in builtin_fns {
+        declarations.push(SymbolInfo {
+            name: name.to_string(),
+            kind: SymbolKind::BuiltinFn,
+            type_hint: ty,
+            def_span: Span::new(0, 0),
+            scope: SymbolScope::Product,
+            doc,
+        });
+    }
+
+    // Walk AST items.
+    let mut schedule_index = 0usize;
+    for item in &ast.body {
+        match item {
+            ProductItem::Underlyings(decls, _) => {
+                for decl in decls {
+                    declarations.push(SymbolInfo {
+                        name: decl.name.clone(),
+                        kind: SymbolKind::Underlying,
+                        type_hint: "float",
+                        def_span: decl.span,
+                        scope: SymbolScope::Product,
+                        doc: "Underlying equity",
+                    });
+                }
+            }
+            ProductItem::State(decls, _) => {
+                for decl in decls {
+                    let type_hint = match decl.type_name.as_str() {
+                        "bool" => "bool",
+                        "float" => "float",
+                        _ => "unknown",
+                    };
+                    declarations.push(SymbolInfo {
+                        name: decl.name.clone(),
+                        kind: SymbolKind::StateVar,
+                        type_hint,
+                        def_span: decl.span,
+                        scope: SymbolScope::Product,
+                        doc: "State variable (mutable across dates)",
+                    });
+                }
+            }
+            ProductItem::Schedule(sched) => {
+                // Clone the product-level declarations as the scope for this schedule.
+                let mut scope_decls = declarations.clone();
+                walk_statements(
+                    &sched.body,
+                    &mut scope_decls,
+                    &mut references,
+                    &mut declarations,
+                    SymbolScope::Schedule(schedule_index),
+                    source,
+                );
+                schedule_index += 1;
+            }
+            _ => {}
+        }
+    }
+
+    SymbolTable {
+        declarations,
+        references,
+    }
+}
+
+/// Walk statements, collecting local declarations and references.
+///
+/// `scope_decls` is the set of symbols visible for identifier resolution (including locals added
+/// during this walk). `out_decls` is the output list where new declarations are appended.
+fn walk_statements(
+    stmts: &[AstStatement],
+    scope_decls: &mut Vec<SymbolInfo>,
+    refs: &mut Vec<SymbolRef>,
+    out_decls: &mut Vec<SymbolInfo>,
+    scope: SymbolScope,
+    source: &str,
+) {
+    for stmt in stmts {
+        match &stmt.kind {
+            AstStatementKind::Let { name, expr } => {
+                walk_expr(expr, scope_decls, refs);
+                let info = SymbolInfo {
+                    name: name.clone(),
+                    kind: SymbolKind::Local,
+                    type_hint: "float",
+                    def_span: stmt.span,
+                    scope,
+                    doc: "Local variable",
+                };
+                scope_decls.push(info.clone());
+                out_decls.push(info);
+            }
+            AstStatementKind::If {
+                condition,
+                then_body,
+                else_body,
+            } => {
+                walk_expr(condition, scope_decls, refs);
+                walk_statements(then_body, scope_decls, refs, out_decls, scope, source);
+                walk_statements(else_body, scope_decls, refs, out_decls, scope, source);
+            }
+            AstStatementKind::Pay { amount } => {
+                walk_expr(amount, scope_decls, refs);
+            }
+            AstStatementKind::Redeem { amount } => {
+                walk_expr(amount, scope_decls, refs);
+            }
+            AstStatementKind::SetState { name, expr } => {
+                walk_expr(expr, scope_decls, refs);
+                if let Some(decl) = scope_decls.iter().find(|d| d.name == *name) {
+                    // Find the actual position of the identifier name within the statement span.
+                    let stmt_text = &source[stmt.span.start..stmt.span.end.min(source.len())];
+                    let name_offset = stmt_text
+                        .find(name.as_str())
+                        .map(|i| stmt.span.start + i)
+                        .unwrap_or(stmt.span.start + 4);
+                    refs.push(SymbolRef {
+                        name: name.clone(),
+                        span: Span::new(name_offset, name_offset + name.len()),
+                        def_span: decl.def_span,
+                        kind: decl.kind,
+                        type_hint: decl.type_hint,
+                        doc: decl.doc,
+                    });
+                }
+            }
+            AstStatementKind::Skip => {}
+        }
+    }
+}
+
+fn walk_expr(expr: &AstExpr, scope_decls: &[SymbolInfo], refs: &mut Vec<SymbolRef>) {
+    match &expr.kind {
+        AstExprKind::Ident(name) => {
+            if let Some(d) = scope_decls.iter().find(|d| d.name == *name) {
+                refs.push(SymbolRef {
+                    name: name.clone(),
+                    span: expr.span,
+                    def_span: d.def_span,
+                    kind: d.kind,
+                    type_hint: d.type_hint,
+                    doc: d.doc,
+                });
+            }
+        }
+        AstExprKind::BinOp { lhs, rhs, .. } => {
+            walk_expr(lhs, scope_decls, refs);
+            walk_expr(rhs, scope_decls, refs);
+        }
+        AstExprKind::UnaryOp { operand, .. } => {
+            walk_expr(operand, scope_decls, refs);
+        }
+        AstExprKind::FnCall { name, args } => {
+            if let Some(d) = scope_decls.iter().find(|d| d.name == *name) {
+                refs.push(SymbolRef {
+                    name: name.clone(),
+                    span: Span::new(expr.span.start, expr.span.start + name.len()),
+                    def_span: d.def_span,
+                    kind: d.kind,
+                    type_hint: d.type_hint,
+                    doc: d.doc,
+                });
+            }
+            for arg in args {
+                walk_expr(arg, scope_decls, refs);
+            }
+        }
+        AstExprKind::NumberLit(_) | AstExprKind::BoolLit(_) => {}
+    }
+}

--- a/vscode-ext/.gitignore
+++ b/vscode-ext/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+wasm/pkg/
+*.vsix

--- a/vscode-ext/.vscodeignore
+++ b/vscode-ext/.vscodeignore
@@ -1,0 +1,6 @@
+.vscode/**
+node_modules/**
+src/**
+tsconfig.json
+**/*.ts
+**/*.map

--- a/vscode-ext/language-configuration.json
+++ b/vscode-ext/language-configuration.json
@@ -1,0 +1,23 @@
+{
+  "comments": {
+    "lineComment": "//"
+  },
+  "brackets": [
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" }
+  ],
+  "folding": {
+    "offSide": true
+  },
+  "indentationRules": {
+    "increaseIndentPattern": "^\\s*(product|underlyings|state|schedule|if\\b.*\\bthen|else)\\b",
+    "decreaseIndentPattern": "^\\s*(else)\\b"
+  }
+}

--- a/vscode-ext/package-lock.json
+++ b/vscode-ext/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "openferric-dsl",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openferric-dsl",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.109.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+      "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "openferric-dsl",
+  "displayName": "OpenFerric DSL",
+  "description": "Language support for OpenFerric structured product DSL via LSP",
+  "version": "0.2.0",
+  "publisher": "openferric",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Programming Languages"],
+  "activationEvents": [
+    "onLanguage:openferric-dsl"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "openferric-dsl",
+        "aliases": ["OpenFerric DSL", "openferric-dsl"],
+        "extensions": [".dsl"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "openferric-dsl",
+        "scopeName": "source.openferric-dsl",
+        "path": "./syntaxes/openferric-dsl.tmLanguage.json"
+      }
+    ],
+    "configuration": {
+      "title": "OpenFerric DSL",
+      "properties": {
+        "openferricDsl.lsp.path": {
+          "type": "string",
+          "default": "openferric-lsp",
+          "description": "Path to the openferric-lsp binary"
+        },
+        "openferricDsl.pricing.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable live pricing via CodeLens"
+        },
+        "openferricDsl.pricing.numPaths": {
+          "type": "number",
+          "default": 50000,
+          "description": "Number of Monte Carlo paths"
+        },
+        "openferricDsl.pricing.numSteps": {
+          "type": "number",
+          "default": 100,
+          "description": "Number of time steps per path"
+        },
+        "openferricDsl.pricing.seed": {
+          "type": "number",
+          "default": 42,
+          "description": "RNG seed for reproducibility"
+        },
+        "openferricDsl.market.default": {
+          "type": "object",
+          "default": {
+            "assets": [
+              { "spot": 100.0, "vol": 0.20, "dividend_yield": 0.02 }
+            ],
+            "correlation": [[1.0]],
+            "rate": 0.05
+          },
+          "description": "Default market data (MultiAssetMarket JSON)"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -1,0 +1,57 @@
+import * as vscode from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+} from "vscode-languageclient/node";
+
+const LANGUAGE_ID = "openferric-dsl";
+let client: LanguageClient | undefined;
+
+export function activate(context: vscode.ExtensionContext): void {
+  const config = vscode.workspace.getConfiguration("openferricDsl");
+  const lspPath = config.get<string>(
+    "lsp.path",
+    "openferric-lsp"
+  );
+
+  const serverOptions: ServerOptions = {
+    command: lspPath,
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ language: LANGUAGE_ID }],
+    initializationOptions: {
+      pricing: {
+        enabled: config.get<boolean>("pricing.enabled", true),
+        numPaths: config.get<number>("pricing.numPaths", 50000),
+        numSteps: config.get<number>("pricing.numSteps", 100),
+        seed: config.get<number>("pricing.seed", 42),
+      },
+      market: config.get("market.default"),
+    },
+  };
+
+  client = new LanguageClient(
+    "openferric-dsl",
+    "OpenFerric DSL",
+    serverOptions,
+    clientOptions
+  );
+
+  client.start();
+  context.subscriptions.push({
+    dispose: () => {
+      if (client) {
+        client.stop();
+      }
+    },
+  });
+}
+
+export function deactivate(): Promise<void> | undefined {
+  if (client) {
+    return client.stop();
+  }
+  return undefined;
+}

--- a/vscode-ext/syntaxes/openferric-dsl.tmLanguage.json
+++ b/vscode-ext/syntaxes/openferric-dsl.tmLanguage.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "OpenFerric DSL",
+  "scopeName": "source.openferric-dsl",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#numbers" },
+    { "include": "#declaration-keywords" },
+    { "include": "#block-keywords" },
+    { "include": "#statement-keywords" },
+    { "include": "#frequency-constants" },
+    { "include": "#boolean-constants" },
+    { "include": "#type-keywords" },
+    { "include": "#builtin-functions" },
+    { "include": "#builtin-variables" },
+    { "include": "#logical-operators" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.openferric-dsl",
+          "match": "//.*$"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.openferric-dsl",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.openferric-dsl",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.openferric-dsl",
+          "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?([eE][+-]?\\d+)?\\b"
+        }
+      ]
+    },
+    "declaration-keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.product.openferric-dsl",
+          "match": "\\bproduct\\b"
+        },
+        {
+          "name": "keyword.other.declaration.openferric-dsl",
+          "match": "\\b(notional|maturity)(?=\\s*:)"
+        }
+      ]
+    },
+    "block-keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.block.openferric-dsl",
+          "match": "\\b(underlyings|state|schedule)\\b"
+        },
+        {
+          "name": "keyword.other.range.openferric-dsl",
+          "match": "\\b(from|to)\\b"
+        }
+      ]
+    },
+    "statement-keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.statement.openferric-dsl",
+          "match": "\\b(let|if|then|else|pay|redeem|set|skip)\\b"
+        }
+      ]
+    },
+    "frequency-constants": {
+      "patterns": [
+        {
+          "name": "constant.language.frequency.openferric-dsl",
+          "match": "\\b(monthly|quarterly|semi_annual|annual)\\b"
+        }
+      ]
+    },
+    "boolean-constants": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.openferric-dsl",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "type-keywords": {
+      "patterns": [
+        {
+          "name": "storage.type.openferric-dsl",
+          "match": "\\b(bool|float)\\b"
+        }
+      ]
+    },
+    "builtin-functions": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.openferric-dsl",
+          "match": "\\b(worst_of|best_of|performances|price|min|max|abs|exp|log|asset)\\b"
+        }
+      ]
+    },
+    "builtin-variables": {
+      "patterns": [
+        {
+          "name": "variable.language.builtin.openferric-dsl",
+          "match": "\\b(notional|observation_date|is_final)\\b(?!\\s*:)"
+        }
+      ]
+    },
+    "logical-operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.openferric-dsl",
+          "match": "\\b(and|or|not)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.comparison.openferric-dsl",
+          "match": "==|!=|<=|>=|<|>"
+        },
+        {
+          "name": "keyword.operator.assignment.openferric-dsl",
+          "match": "="
+        },
+        {
+          "name": "keyword.operator.arithmetic.openferric-dsl",
+          "match": "[+\\-*/]"
+        }
+      ]
+    }
+  }
+}

--- a/vscode-ext/tsconfig.json
+++ b/vscode-ext/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": ["ES2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules", "out", "wasm"]
+}


### PR DESCRIPTION
## Summary

- Add `openferric-lsp` crate: a tower-lsp based LSP server that calls the DSL compiler directly, providing diagnostics, completions, hover, go-to-definition, semantic tokens, document symbols, and live MC pricing CodeLens
- Rewrite VS Code extension as a thin LSP client (`vscode-languageclient`), removing the WASM bridge (`wasm-bridge.ts`, `diagnostics.ts`, `codelens.ts`, `types.ts`)
- Works with any LSP-capable editor (VS Code, Neovim, Helix, Emacs, Sublime)

## New crate: `openferric-lsp/`

| File | Feature |
|------|---------|
| `main.rs` | Tokio entrypoint, tower-lsp Server on stdin/stdout |
| `backend.rs` | LanguageServer impl with per-document state |
| `diagnostics.rs` | Lex/parse/compile pipeline → LSP Diagnostic |
| `symbols.rs` | AST walker building symbol table (declarations + references) |
| `completion.rs` | Context-aware completions (keywords, builtins, declared vars) |
| `hover.rs` | Type info + docs for variables, functions, keywords |
| `goto_def.rs` | Identifier → declaration span |
| `semantic_tokens.rs` | Token classification from lexer |
| `document_symbols.rs` | Product outline for symbols panel |
| `codelens.rs` | Live MC pricing + Greeks (mutex released before pricing) |

## Test plan

- [x] `cargo build -p openferric-lsp` compiles
- [x] `cargo clippy -p openferric-lsp` passes (1 intentional dead_code warning)
- [x] `cargo test` — all 465 existing tests pass
- [x] `cargo build -p openferric-lsp --release` compiles
- [ ] Open `.dsl` file in VS Code → diagnostics appear on errors, clear on fix
- [ ] Type `w` inside schedule → completion offers `worst_of`
- [ ] Hover over `ki_hit` → shows type info
- [ ] Ctrl+click `wof` → jumps to `let wof = ...`
- [ ] Document outline shows product structure
- [ ] CodeLens shows price + Greeks above `product` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)