### PR TITLE
feat: OpenFerric MCP server — full quant pricing for AI agents (#113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "openferric-mcp"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "openferric",
+ "serde",
+ "serde_json",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
 name = "openferric-python"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = [".", "openferric-wasm", "openferric-python", "openferric-lsp"]
+members = [
+    ".",
+    "openferric-wasm",
+    "openferric-python",
+    "openferric-lsp",
+    "openferric-mcp",
+]
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"

--- a/openferric-mcp/Cargo.toml
+++ b/openferric-mcp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "openferric-mcp"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "openferric-mcp"
+path = "src/main.rs"
+
+[dependencies]
+openferric = { path = ".." }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+ureq = { version = "3", features = ["json"] }
+chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/openferric-mcp/src/main.rs
+++ b/openferric-mcp/src/main.rs
@@ -1,0 +1,296 @@
+use serde_json::{Map, Value, json};
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+
+mod tools;
+
+const SERVER_NAME: &str = "openferric-mcp";
+const SERVER_VERSION: &str = "0.1.0";
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    eprintln!("{SERVER_NAME} starting on stdio");
+
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut lines = BufReader::new(stdin).lines();
+    let mut out = BufWriter::new(stdout);
+
+    while let Some(line) = lines.next_line().await? {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let parsed = match serde_json::from_str::<Value>(line) {
+            Ok(v) => v,
+            Err(err) => {
+                eprintln!("invalid JSON: {err}");
+                let resp = error_response(Value::Null, -32700, "parse error", None);
+                write_response(&mut out, &resp).await?;
+                continue;
+            }
+        };
+
+        let responses = handle_incoming(parsed);
+        for response in responses {
+            write_response(&mut out, &response).await?;
+        }
+    }
+
+    eprintln!("{SERVER_NAME} shutting down");
+    Ok(())
+}
+
+fn handle_incoming(message: Value) -> Vec<Value> {
+    if let Some(batch) = message.as_array() {
+        if batch.is_empty() {
+            return vec![error_response(
+                Value::Null,
+                -32600,
+                "invalid request: empty batch",
+                None,
+            )];
+        }
+
+        let mut out = Vec::new();
+        for item in batch {
+            if let Some(resp) = handle_request(item) {
+                out.push(resp);
+            }
+        }
+        return out;
+    }
+
+    handle_request(&message).into_iter().collect()
+}
+
+fn handle_request(request: &Value) -> Option<Value> {
+    let obj = match request.as_object() {
+        Some(v) => v,
+        None => {
+            return Some(error_response(
+                Value::Null,
+                -32600,
+                "invalid request: expected object",
+                None,
+            ));
+        }
+    };
+
+    let id = obj.get("id").cloned();
+    let method = match obj.get("method").and_then(Value::as_str) {
+        Some(m) => m,
+        None => {
+            return id.map(|idv| {
+                error_response(idv, -32600, "invalid request: missing string method", None)
+            });
+        }
+    };
+
+    let params = obj.get("params").cloned().unwrap_or_else(|| json!({}));
+    let response = match dispatch_method(method, &params) {
+        Ok(result) => success_response(id.clone().unwrap_or(Value::Null), result),
+        Err((code, message, data)) => {
+            error_response(id.clone().unwrap_or(Value::Null), code, message, data)
+        }
+    };
+
+    if id.is_none() { None } else { Some(response) }
+}
+
+fn dispatch_method(
+    method: &str,
+    params: &Value,
+) -> Result<Value, (i64, &'static str, Option<Value>)> {
+    match method {
+        "initialize" => Ok(handle_initialize(params)),
+        "tools/list" => Ok(handle_tools_list()),
+        "tools/call" => handle_tools_call(params),
+        "resources/list" => Ok(handle_resources_list()),
+        "resources/read" => handle_resources_read(params),
+        _ => Err((
+            -32601,
+            "method not found",
+            Some(json!({ "method": method })),
+        )),
+    }
+}
+
+fn handle_initialize(_params: &Value) -> Value {
+    json!({
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": { "listChanged": false },
+            "resources": { "subscribe": false, "listChanged": false }
+        },
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION
+        },
+        "instructions": "OpenFerric quant MCP server exposing pricing, rates, credit, volatility, calibration, risk, models, DSL, and market data tools."
+    })
+}
+
+fn handle_tools_list() -> Value {
+    let tools = tools::all_specs()
+        .into_iter()
+        .map(|spec| {
+            json!({
+                "name": spec.name,
+                "description": spec.description,
+                "inputSchema": spec.input_schema
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({ "tools": tools })
+}
+
+fn handle_tools_call(params: &Value) -> Result<Value, (i64, &'static str, Option<Value>)> {
+    let params_obj = params
+        .as_object()
+        .ok_or((-32602, "invalid params: expected object", None))?;
+
+    let name = params_obj.get("name").and_then(Value::as_str).ok_or((
+        -32602,
+        "invalid params: missing `name`",
+        None,
+    ))?;
+
+    let arguments = params_obj
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    if !arguments.is_object() {
+        return Err((
+            -32602,
+            "invalid params: `arguments` must be an object",
+            None,
+        ));
+    }
+
+    match tools::call_tool(name, &arguments) {
+        Ok(value) => Ok(json!({
+            "content": [{
+                "type": "text",
+                "text": serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+            }],
+            "structuredContent": value,
+            "isError": false
+        })),
+        Err(message) => Ok(json!({
+            "content": [{
+                "type": "text",
+                "text": message
+            }],
+            "isError": true
+        })),
+    }
+}
+
+fn handle_resources_list() -> Value {
+    json!({
+        "resources": [
+            {
+                "uri": "openferric://tools/catalog",
+                "name": "Tool Catalog",
+                "description": "JSON catalog of all OpenFerric MCP tools and schemas.",
+                "mimeType": "application/json"
+            },
+            {
+                "uri": "openferric://dsl/examples",
+                "name": "DSL Examples",
+                "description": "Bundled OpenFerric DSL example contracts.",
+                "mimeType": "application/json"
+            },
+            {
+                "uri": "openferric://server/info",
+                "name": "Server Info",
+                "description": "OpenFerric MCP server metadata and protocol info.",
+                "mimeType": "application/json"
+            }
+        ]
+    })
+}
+
+fn handle_resources_read(params: &Value) -> Result<Value, (i64, &'static str, Option<Value>)> {
+    let params_obj = params
+        .as_object()
+        .ok_or((-32602, "invalid params: expected object", None))?;
+    let uri = params_obj.get("uri").and_then(Value::as_str).ok_or((
+        -32602,
+        "invalid params: missing `uri`",
+        None,
+    ))?;
+
+    let payload = match uri {
+        "openferric://tools/catalog" => handle_tools_list(),
+        "openferric://dsl/examples" => {
+            let examples = tools::call_tool("dsl_examples", &json!({})).map_err(|e| {
+                (
+                    -32603,
+                    "failed to load DSL examples",
+                    Some(json!({ "error": e })),
+                )
+            })?;
+            json!({ "examples": examples })
+        }
+        "openferric://server/info" => json!({
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+            "protocolVersion": PROTOCOL_VERSION
+        }),
+        _ => {
+            return Err((
+                -32602,
+                "invalid params: unknown resource uri",
+                Some(json!({ "uri": uri })),
+            ));
+        }
+    };
+
+    let text = serde_json::to_string_pretty(&payload)
+        .map_err(|_| (-32603, "internal error: could not serialize resource", None))?;
+
+    Ok(json!({
+        "contents": [{
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": text
+        }]
+    }))
+}
+
+fn success_response(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn error_response(id: Value, code: i64, message: &str, data: Option<Value>) -> Value {
+    let mut err = Map::new();
+    err.insert("code".to_string(), json!(code));
+    err.insert("message".to_string(), json!(message));
+    if let Some(data) = data {
+        err.insert("data".to_string(), data);
+    }
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": Value::Object(err)
+    })
+}
+
+async fn write_response(out: &mut BufWriter<io::Stdout>, response: &Value) -> io::Result<()> {
+    let text = serde_json::to_string(response).unwrap_or_else(|_| {
+        r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"internal serialization error"}}"#
+            .to_string()
+    });
+    out.write_all(text.as_bytes()).await?;
+    out.write_all(b"\n").await?;
+    out.flush().await
+}

--- a/openferric-mcp/src/tools/calibration.rs
+++ b/openferric-mcp/src/tools/calibration.rs
@@ -1,0 +1,300 @@
+use openferric::calibration::{
+    Calibrator, HestonCalibrator, OptionVolQuote, SabrCalibrator, SviCalibrationParams,
+    SviCalibrator, SviParameterization, SwaptionVolQuote,
+};
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, curve_from_value, req_array_f64, req_f64, req_value};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "calibrate_heston",
+            description: "Calibrate Heston parameters to option vol grid.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "rate": {"type":"number"},
+                    "market_vols": {"type":"array"},
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "expiries": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["spot","rate","market_vols","strikes","expiries"]
+            }),
+        },
+        ToolSpec {
+            name: "calibrate_sabr",
+            description: "Calibrate SABR parameters to one maturity smile.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "forward": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "vols": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["forward","expiry","strikes","vols"]
+            }),
+        },
+        ToolSpec {
+            name: "calibrate_hull_white",
+            description: "Calibrate Hull-White (a, sigma) to swaption vol quotes.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "yield_curve": {"type":"object"},
+                    "swaption_vols": {
+                        "type":"array",
+                        "items": {
+                            "type":"object",
+                            "properties": {
+                                "expiry": {"type":"number"},
+                                "tenor": {"type":"number"},
+                                "vol": {"type":"number"}
+                            },
+                            "required": ["expiry","tenor","vol"]
+                        }
+                    }
+                },
+                "required": ["yield_curve","swaption_vols"]
+            }),
+        },
+        ToolSpec {
+            name: "calibrate_svi",
+            description: "Calibrate SVI raw parameters from total-variance slice.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "forward": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "total_variances": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["forward","expiry","strikes","total_variances"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "calibrate_heston" => Some(calibrate_heston(args)),
+        "calibrate_sabr" => Some(calibrate_sabr(args)),
+        "calibrate_hull_white" => Some(calibrate_hull_white(args)),
+        "calibrate_svi" => Some(calibrate_svi(args)),
+        _ => None,
+    }
+}
+
+fn calibrate_heston(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let rate = req_f64(args, "rate")?;
+    let strikes = req_array_f64(args, "strikes")?;
+    let expiries = req_array_f64(args, "expiries")?;
+    let market_vols = req_value(args, "market_vols")?;
+
+    if strikes.is_empty() || expiries.is_empty() {
+        return Err("strikes and expiries cannot be empty".to_string());
+    }
+
+    let matrix = parse_vol_matrix(market_vols, expiries.len(), strikes.len())?;
+
+    let mut quotes = Vec::with_capacity(expiries.len() * strikes.len());
+    for (ei, t) in expiries.iter().enumerate() {
+        for (si, k) in strikes.iter().enumerate() {
+            quotes.push(OptionVolQuote::new(
+                format!("T{ei}_K{si}"),
+                *k,
+                *t,
+                matrix[ei][si],
+            ));
+        }
+    }
+
+    let calibrator = HestonCalibrator {
+        spot,
+        rate,
+        dividend_yield: 0.0,
+        ..HestonCalibrator::default()
+    };
+
+    let result = calibrator.calibrate(&quotes).map_err(|e| e.to_string())?;
+    Ok(json!({
+        "v0": result.params.v0,
+        "kappa": result.params.kappa,
+        "theta": result.params.theta,
+        "sigma": result.params.sigma_v,
+        "rho": result.params.rho,
+        "fit_error": result.diagnostics.fit_quality.rmse
+    }))
+}
+
+fn calibrate_sabr(args: &Value) -> ToolCallResult {
+    let forward = req_f64(args, "forward")?;
+    let expiry = req_f64(args, "expiry")?;
+    let strikes = req_array_f64(args, "strikes")?;
+    let vols = req_array_f64(args, "vols")?;
+
+    if strikes.len() != vols.len() || strikes.is_empty() {
+        return Err("strikes and vols must be non-empty and equal-length".to_string());
+    }
+
+    let quotes = strikes
+        .iter()
+        .zip(vols.iter())
+        .enumerate()
+        .map(|(i, (k, v))| OptionVolQuote::new(format!("q{i}"), *k, expiry, *v))
+        .collect::<Vec<_>>();
+
+    let calibrator = SabrCalibrator {
+        forward,
+        maturity: expiry,
+        beta_pin: Some(0.5),
+        use_global_search: false,
+        ..SabrCalibrator::default()
+    };
+
+    let result = calibrator.calibrate(&quotes).map_err(|e| e.to_string())?;
+    Ok(json!({
+        "alpha": result.params.alpha,
+        "beta": result.params.beta,
+        "rho": result.params.rho,
+        "nu": result.params.nu
+    }))
+}
+
+fn calibrate_hull_white(args: &Value) -> ToolCallResult {
+    let _curve = curve_from_value(req_value(args, "yield_curve")?)?;
+
+    let quotes_val = req_value(args, "swaption_vols")?
+        .as_array()
+        .ok_or_else(|| "swaption_vols must be an array".to_string())?;
+
+    let mut quotes = Vec::with_capacity(quotes_val.len());
+    for (i, q) in quotes_val.iter().enumerate() {
+        let obj_map = q
+            .as_object()
+            .ok_or_else(|| "swaption_vol entries must be objects".to_string())?;
+        let expiry = obj_map
+            .get("expiry")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| "swaption_vol expiry must be numeric".to_string())?;
+        let tenor = obj_map
+            .get("tenor")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| "swaption_vol tenor must be numeric".to_string())?;
+        let vol = obj_map
+            .get("vol")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| "swaption_vol vol must be numeric".to_string())?;
+        quotes.push(SwaptionVolQuote::new(format!("swp{i}"), expiry, tenor, vol));
+    }
+
+    let calibrator = openferric::calibration::HullWhiteCalibrator::default();
+    let result = calibrator.calibrate(&quotes).map_err(|e| e.to_string())?;
+
+    Ok(json!({
+        "a": result.params.a,
+        "sigma": result.params.sigma,
+        "fit_error": result.diagnostics.fit_quality.rmse
+    }))
+}
+
+fn calibrate_svi(args: &Value) -> ToolCallResult {
+    let forward = req_f64(args, "forward")?;
+    let expiry = req_f64(args, "expiry")?;
+    let strikes = req_array_f64(args, "strikes")?;
+    let total_variances = req_array_f64(args, "total_variances")?;
+
+    if strikes.len() != total_variances.len() || strikes.is_empty() {
+        return Err("strikes and total_variances must be non-empty and equal-length".to_string());
+    }
+
+    let vols = total_variances
+        .iter()
+        .map(|w| (w.max(1.0e-12) / expiry.max(1.0e-12)).sqrt())
+        .collect::<Vec<_>>();
+
+    let quotes = strikes
+        .iter()
+        .zip(vols.iter())
+        .enumerate()
+        .map(|(i, (k, v))| OptionVolQuote::new(format!("svi{i}"), *k, expiry, *v))
+        .collect::<Vec<_>>();
+
+    let calibrator = SviCalibrator {
+        forward,
+        maturity: expiry,
+        parameterization: SviParameterization::Raw,
+        use_global_search: false,
+        ..SviCalibrator::default()
+    };
+
+    let result = calibrator.calibrate(&quotes).map_err(|e| e.to_string())?;
+
+    match result.params {
+        SviCalibrationParams::Raw(raw) => Ok(json!({
+            "a": raw.a,
+            "b": raw.b,
+            "rho": raw.rho,
+            "m": raw.m,
+            "sigma": raw.sigma
+        })),
+        SviCalibrationParams::JumpWings(_) => {
+            Err("unexpected SVI jump-wings result when raw requested".to_string())
+        }
+    }
+}
+
+fn parse_vol_matrix(
+    value: &Value,
+    n_expiries: usize,
+    n_strikes: usize,
+) -> Result<Vec<Vec<f64>>, String> {
+    if let Some(rows) = value.as_array() {
+        if rows.len() == n_expiries && rows.first().and_then(Value::as_array).is_some() {
+            let matrix = rows
+                .iter()
+                .map(|row| {
+                    row.as_array()
+                        .ok_or_else(|| "market_vols must be a matrix".to_string())?
+                        .iter()
+                        .map(|v| {
+                            v.as_f64()
+                                .ok_or_else(|| "market_vols entries must be numeric".to_string())
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            if matrix.iter().any(|row| row.len() != n_strikes) {
+                return Err("market_vols row length must match strikes length".to_string());
+            }
+            return Ok(matrix);
+        }
+
+        if rows.len() == n_expiries * n_strikes {
+            let flat = rows
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .ok_or_else(|| "market_vols entries must be numeric".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let mut out = vec![vec![0.0; n_strikes]; n_expiries];
+            for e in 0..n_expiries {
+                for s in 0..n_strikes {
+                    out[e][s] = flat[e * n_strikes + s];
+                }
+            }
+            return Ok(out);
+        }
+    }
+
+    Err(
+        "market_vols must be a matrix [expiry][strike] or flat vector of length expiries*strikes"
+            .to_string(),
+    )
+}

--- a/openferric-mcp/src/tools/credit.rs
+++ b/openferric-mcp/src/tools/credit.rs
@@ -1,0 +1,273 @@
+use openferric::credit::cds_option::{CdsOption, risky_annuity};
+use openferric::credit::{CdoTranche, Cds, CdsIndex, SurvivalCurve, SyntheticCdo};
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, curve_from_value, req_array_f64, req_f64, req_value};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "cds_price",
+            description: "Price a single-name CDS from spread, recovery, and discount curve.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spread": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "recovery": {"type": "number"},
+                    "yield_curve": {"type": "object"},
+                    "notional": {"type": "number"}
+                },
+                "required": ["spread", "maturity", "recovery", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "cds_index_price",
+            description: "Price a CDS index as weighted single-name constituents.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spreads": {"type": "array", "items": {"type": "number"}},
+                    "weights": {"type": "array", "items": {"type": "number"}},
+                    "maturity": {"type": "number"},
+                    "recovery": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["spreads", "weights", "maturity", "recovery", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "cds_option_price",
+            description: "Price a CDS spread option via Black model on forward spread.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "forward_spread": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "recovery": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["forward_spread", "strike", "vol", "maturity", "recovery", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "survival_curve_build",
+            description: "Bootstrap survival curve from tenor-spread CDS quotes.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "tenors": {"type": "array"},
+                    "spreads": {"type": "array", "items": {"type": "number"}},
+                    "recovery": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["tenors", "spreads", "recovery", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "cdo_tranche_price",
+            description: "Price a synthetic CDO tranche under LHP Gaussian model.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "attachment": {"type": "number"},
+                    "detachment": {"type": "number"},
+                    "spreads": {"type": "array", "items": {"type": "number"}},
+                    "correlation": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "recovery": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["attachment", "detachment", "spreads", "correlation", "maturity", "recovery", "yield_curve"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "cds_price" => Some(cds_price(args)),
+        "cds_index_price" => Some(cds_index_price(args)),
+        "cds_option_price" => Some(cds_option_price(args)),
+        "survival_curve_build" => Some(survival_curve_build(args)),
+        "cdo_tranche_price" => Some(cdo_tranche_price(args)),
+        _ => None,
+    }
+}
+
+fn cds_price(args: &Value) -> ToolCallResult {
+    let spread = req_f64(args, "spread")?;
+    let maturity = req_f64(args, "maturity")?;
+    let recovery = req_f64(args, "recovery")?;
+    let curve = curve_from_value(req_value(args, "yield_curve")?)?;
+    let notional = super::opt_f64(args, "notional", 1_000_000.0)?;
+
+    let hazard = if (1.0 - recovery).abs() > 1.0e-12 {
+        (spread / (1.0 - recovery)).max(0.0)
+    } else {
+        0.0
+    };
+    let survival = SurvivalCurve::from_piecewise_hazard(&[maturity], &[hazard]);
+
+    let cds = Cds {
+        notional,
+        spread,
+        maturity,
+        recovery_rate: recovery,
+        payment_freq: 4,
+    };
+
+    let price = cds.npv(&curve, &survival);
+    let bump = 1.0e-4;
+    let cds_up = Cds {
+        spread: spread + bump,
+        ..cds.clone()
+    };
+    let cds_dn = Cds {
+        spread: (spread - bump).max(0.0),
+        ..cds.clone()
+    };
+    let dv01 = (cds_up.npv(&curve, &survival) - cds_dn.npv(&curve, &survival)) / 2.0;
+    let spread_duration = if notional.abs() > 1.0e-12 {
+        -dv01 / notional
+    } else {
+        0.0
+    };
+
+    Ok(json!({
+        "price": price,
+        "dv01": dv01,
+        "spread_duration": spread_duration
+    }))
+}
+
+fn cds_index_price(args: &Value) -> ToolCallResult {
+    let spreads = req_array_f64(args, "spreads")?;
+    let weights = req_array_f64(args, "weights")?;
+    let maturity = req_f64(args, "maturity")?;
+    let recovery = req_f64(args, "recovery")?;
+    let curve = curve_from_value(req_value(args, "yield_curve")?)?;
+
+    if spreads.len() != weights.len() {
+        return Err("spreads and weights length mismatch".to_string());
+    }
+    if spreads.is_empty() {
+        return Err("spreads cannot be empty".to_string());
+    }
+
+    let constituents = spreads
+        .iter()
+        .map(|s| Cds {
+            notional: 1.0,
+            spread: *s,
+            maturity,
+            recovery_rate: recovery,
+            payment_freq: 4,
+        })
+        .collect::<Vec<_>>();
+
+    let curves = spreads
+        .iter()
+        .map(|s| {
+            let h = if (1.0 - recovery).abs() > 1.0e-12 {
+                (*s / (1.0 - recovery)).max(0.0)
+            } else {
+                0.0
+            };
+            SurvivalCurve::from_piecewise_hazard(&[maturity], &[h])
+        })
+        .collect::<Vec<_>>();
+
+    let index = CdsIndex {
+        constituents,
+        weights,
+    };
+
+    Ok(json!({ "price": index.npv(&curve, &curves) }))
+}
+
+fn cds_option_price(args: &Value) -> ToolCallResult {
+    let forward_spread = req_f64(args, "forward_spread")?;
+    let strike = req_f64(args, "strike")?;
+    let vol = req_f64(args, "vol")?;
+    let maturity = req_f64(args, "maturity")?;
+    let recovery = req_f64(args, "recovery")?;
+    let curve = curve_from_value(req_value(args, "yield_curve")?)?;
+
+    let rf = curve.zero_rate(maturity.max(1.0e-6));
+    let hazard = if (1.0 - recovery).abs() > 1.0e-12 {
+        (forward_spread / (1.0 - recovery)).max(0.0)
+    } else {
+        0.0
+    };
+    let rpv01 = risky_annuity(4, maturity, hazard, rf, recovery);
+
+    let option = CdsOption {
+        notional: 1.0,
+        strike_spread: strike,
+        option_expiry: maturity,
+        cds_maturity: maturity,
+        is_payer: true,
+        recovery_rate: recovery,
+    };
+
+    let price = option.black_price(forward_spread, vol, rpv01);
+    Ok(json!({ "price": price }))
+}
+
+fn survival_curve_build(args: &Value) -> ToolCallResult {
+    let tenors = super::tenors_from_value(args, "tenors")?;
+    let spreads = req_array_f64(args, "spreads")?;
+    let recovery = req_f64(args, "recovery")?;
+    let curve = curve_from_value(req_value(args, "yield_curve")?)?;
+
+    if tenors.len() != spreads.len() {
+        return Err("tenors/spreads length mismatch".to_string());
+    }
+
+    let quotes = tenors.into_iter().zip(spreads).collect::<Vec<_>>();
+    let survival = SurvivalCurve::bootstrap_from_cds_spreads(&quotes, recovery, 4, &curve);
+
+    let probs = survival.tenors.iter().map(|(_, p)| *p).collect::<Vec<_>>();
+    Ok(json!({
+        "survival_probs": probs,
+        "curve_json": serde_json::to_value(survival).unwrap_or(Value::Null)
+    }))
+}
+
+fn cdo_tranche_price(args: &Value) -> ToolCallResult {
+    let attachment = req_f64(args, "attachment")?;
+    let detachment = req_f64(args, "detachment")?;
+    let spreads = req_array_f64(args, "spreads")?;
+    let correlation = req_f64(args, "correlation")?;
+    let maturity = req_f64(args, "maturity")?;
+    let recovery = req_f64(args, "recovery")?;
+    let curve = curve_from_value(req_value(args, "yield_curve")?)?;
+
+    if spreads.is_empty() {
+        return Err("spreads cannot be empty".to_string());
+    }
+
+    let avg_spread = spreads.iter().sum::<f64>() / spreads.len() as f64;
+
+    let model = SyntheticCdo {
+        num_names: spreads.len(),
+        pool_spread: avg_spread.max(0.0),
+        recovery_rate: recovery,
+        correlation,
+        risk_free_rate: curve.zero_rate(maturity.max(1.0e-6)),
+        maturity,
+        payment_freq: 4,
+    };
+
+    let tranche = CdoTranche {
+        attachment,
+        detachment,
+        notional: (detachment - attachment).max(0.0),
+        spread: avg_spread,
+    };
+
+    Ok(json!({ "price": model.npv(&tranche) }))
+}

--- a/openferric-mcp/src/tools/dsl.rs
+++ b/openferric-mcp/src/tools/dsl.rs
@@ -1,0 +1,276 @@
+use std::fs;
+use std::path::PathBuf;
+
+use openferric::dsl::{DslMonteCarloEngine, MultiAssetMarket, parse_and_compile};
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, obj, opt_usize, req_str};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "dsl_price",
+            description: "Compile DSL source and price it via multi-asset Monte Carlo.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string" },
+                    "market": {
+                        "type": "object",
+                        "properties": {
+                            "assets": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "spot": { "type": "number" },
+                                        "vol": { "type": "number" },
+                                        "dividend_yield": { "type": "number" }
+                                    },
+                                    "required": ["spot", "vol"]
+                                }
+                            },
+                            "correlation": { "type": "array" },
+                            "rate": { "type": "number" }
+                        }
+                    },
+                    "num_paths": { "type": "integer", "minimum": 1 },
+                    "seed": { "type": "integer", "minimum": 0 }
+                },
+                "required": ["source"]
+            }),
+        },
+        ToolSpec {
+            name: "dsl_greeks",
+            description: "Compile DSL source and compute Greeks for one underlying.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string" },
+                    "market": { "type": "object" },
+                    "asset_index": { "type": "integer", "minimum": 0 },
+                    "num_paths": { "type": "integer", "minimum": 1 },
+                    "seed": { "type": "integer", "minimum": 0 }
+                },
+                "required": ["source"]
+            }),
+        },
+        ToolSpec {
+            name: "dsl_compile",
+            description: "Compile DSL source into IR JSON and report compilation errors.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string" }
+                },
+                "required": ["source"]
+            }),
+        },
+        ToolSpec {
+            name: "dsl_examples",
+            description: "List bundled DSL examples from examples/dsl/.",
+            input_schema: json!({ "type": "object", "properties": {} }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "dsl_price" => Some(dsl_price(args)),
+        "dsl_greeks" => Some(dsl_greeks(args)),
+        "dsl_compile" => Some(dsl_compile(args)),
+        "dsl_examples" => Some(dsl_examples(args)),
+        _ => None,
+    }
+}
+
+fn dsl_price(args: &Value) -> ToolCallResult {
+    let source = req_str(args, "source")?;
+    let product = parse_and_compile(source).map_err(|e| e.to_string())?;
+
+    let market = parse_market(args)?;
+    let num_paths = opt_usize(args, "num_paths", 20_000)?;
+    let seed = opt_usize(args, "seed", 42)? as u64;
+
+    let engine = DslMonteCarloEngine::new(num_paths, 252, seed);
+    let price = engine
+        .price_multi_asset(&product, &market)
+        .map_err(|e| e.to_string())?;
+
+    let greeks = engine
+        .greeks_multi_asset(&product, &market, 0)
+        .map(|g| {
+            json!({
+                "delta": g.delta,
+                "gamma": g.gamma,
+                "vega": g.vega,
+                "theta": g.theta,
+                "rho": g.rho
+            })
+        })
+        .unwrap_or_else(|_| Value::Null);
+
+    Ok(json!({
+        "price": price.price,
+        "stderr": price.stderr,
+        "greeks": greeks
+    }))
+}
+
+fn dsl_greeks(args: &Value) -> ToolCallResult {
+    let source = req_str(args, "source")?;
+    let product = parse_and_compile(source).map_err(|e| e.to_string())?;
+
+    let market = parse_market(args)?;
+    let asset_index = opt_usize(args, "asset_index", 0)?;
+    let num_paths = opt_usize(args, "num_paths", 20_000)?;
+    let seed = opt_usize(args, "seed", 42)? as u64;
+
+    let engine = DslMonteCarloEngine::new(num_paths, 252, seed);
+    let greeks = engine
+        .greeks_multi_asset(&product, &market, asset_index)
+        .map_err(|e| e.to_string())?;
+
+    Ok(json!({
+        "delta": greeks.delta,
+        "gamma": greeks.gamma,
+        "vega": greeks.vega,
+        "theta": greeks.theta,
+        "rho": greeks.rho
+    }))
+}
+
+fn dsl_compile(args: &Value) -> ToolCallResult {
+    let source = req_str(args, "source")?;
+
+    match parse_and_compile(source) {
+        Ok(product) => Ok(json!({
+            "product_json": serde_json::to_value(product).unwrap_or(Value::Null),
+            "errors": []
+        })),
+        Err(e) => Ok(json!({
+            "product_json": Value::Null,
+            "errors": [e.to_string()]
+        })),
+    }
+}
+
+fn dsl_examples(_args: &Value) -> ToolCallResult {
+    let mut dir = PathBuf::from("examples");
+    dir.push("dsl");
+
+    let mut files = fs::read_dir(&dir)
+        .map_err(|e| format!("failed to read {}: {e}", dir.display()))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().and_then(|x| x.to_str()) == Some("of"))
+        .collect::<Vec<_>>();
+
+    files.sort_by_key(|entry| entry.path());
+
+    let examples = files
+        .into_iter()
+        .map(|entry| {
+            let path = entry.path();
+            let source = fs::read_to_string(&path).unwrap_or_default();
+            let name = path
+                .file_stem()
+                .and_then(|x| x.to_str())
+                .unwrap_or("example")
+                .to_string();
+
+            let description = source
+                .lines()
+                .find(|line| line.trim_start().starts_with("product "))
+                .map(|line| line.trim().to_string())
+                .unwrap_or_else(|| "DSL product example".to_string());
+
+            json!({
+                "name": name,
+                "source": source,
+                "description": description
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Value::Array(examples))
+}
+
+fn parse_market(args: &Value) -> Result<MultiAssetMarket, String> {
+    let arg_obj = obj(args, "arguments")?;
+
+    let Some(market_val) = arg_obj.get("market") else {
+        return Ok(MultiAssetMarket::single(100.0, 0.2, 0.03, 0.0));
+    };
+
+    let market_obj = market_val
+        .as_object()
+        .ok_or_else(|| "market must be an object".to_string())?;
+
+    let assets_val = market_obj
+        .get("assets")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "market.assets must be an array".to_string())?;
+
+    if assets_val.is_empty() {
+        return Err("market.assets cannot be empty".to_string());
+    }
+
+    let mut assets = Vec::with_capacity(assets_val.len());
+    for asset in assets_val {
+        let a = asset
+            .as_object()
+            .ok_or_else(|| "market.assets entries must be objects".to_string())?;
+
+        let spot = a
+            .get("spot")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| "market asset `spot` must be numeric".to_string())?;
+        let vol = a
+            .get("vol")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| "market asset `vol` must be numeric".to_string())?;
+        let dividend_yield = a
+            .get("dividend_yield")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0);
+
+        assets.push(openferric::dsl::AssetData {
+            spot,
+            vol,
+            dividend_yield,
+        });
+    }
+
+    let n = assets.len();
+    let correlation = if let Some(rows) = market_obj.get("correlation").and_then(Value::as_array) {
+        rows.iter()
+            .map(|row| {
+                row.as_array()
+                    .ok_or_else(|| "market.correlation must be a matrix".to_string())?
+                    .iter()
+                    .map(|v| {
+                        v.as_f64()
+                            .ok_or_else(|| "market.correlation entries must be numbers".to_string())
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        let mut corr = vec![vec![0.0; n]; n];
+        for (i, row) in corr.iter_mut().enumerate() {
+            row[i] = 1.0;
+        }
+        corr
+    };
+
+    let rate = market_obj
+        .get("rate")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.03);
+
+    Ok(MultiAssetMarket {
+        assets,
+        correlation,
+        rate,
+    })
+}

--- a/openferric-mcp/src/tools/market_data.rs
+++ b/openferric-mcp/src/tools/market_data.rs
@@ -1,0 +1,273 @@
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, opt_f64, opt_str, opt_usize, req_str};
+
+const API_BASE: &str = "https://www.deribit.com/api/v2/public";
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "get_spot",
+            description: "Fetch Deribit index spot for a currency.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {"currency": {"type":"string"}},
+                "required": ["currency"]
+            }),
+        },
+        ToolSpec {
+            name: "get_ticker",
+            description: "Fetch Deribit ticker for a specific instrument.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {"instrument_name": {"type":"string"}},
+                "required": ["instrument_name"]
+            }),
+        },
+        ToolSpec {
+            name: "list_instruments",
+            description: "List Deribit instruments for a currency and kind.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "currency": {"type":"string"},
+                    "kind": {"type":"string"}
+                },
+                "required": ["currency"]
+            }),
+        },
+        ToolSpec {
+            name: "get_orderbook",
+            description: "Fetch Deribit order book snapshot for instrument.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "instrument_name": {"type":"string"},
+                    "depth": {"type":"integer", "minimum": 1}
+                },
+                "required": ["instrument_name"]
+            }),
+        },
+        ToolSpec {
+            name: "get_historical_volatility",
+            description: "Fetch Deribit historical volatility series.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {"currency": {"type":"string"}},
+                "required": ["currency"]
+            }),
+        },
+        ToolSpec {
+            name: "get_vol_index",
+            description: "Fetch Deribit volatility index OHLC data.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "currency": {"type":"string"},
+                    "start": {},
+                    "end": {},
+                    "resolution": {"type":"string"}
+                },
+                "required": ["currency"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "get_spot" => Some(get_spot(args)),
+        "get_ticker" => Some(get_ticker(args)),
+        "list_instruments" => Some(list_instruments(args)),
+        "get_orderbook" => Some(get_orderbook(args)),
+        "get_historical_volatility" => Some(get_historical_volatility(args)),
+        "get_vol_index" => Some(get_vol_index(args)),
+        _ => None,
+    }
+}
+
+fn get_spot(args: &Value) -> ToolCallResult {
+    let currency = req_str(args, "currency")?.to_ascii_lowercase();
+    let index_name = format!("{currency}_usd");
+    let url = format!("{API_BASE}/get_index_price?index_name={index_name}");
+    let payload = fetch_json(&url)?;
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "missing `result` in Deribit response".to_string())?;
+
+    Ok(json!({
+        "spot": result.get("index_price").and_then(Value::as_f64).unwrap_or(f64::NAN),
+        "timestamp": result
+            .get("timestamp")
+            .and_then(Value::as_i64)
+            .or_else(|| payload.get("usOut").and_then(Value::as_i64))
+    }))
+}
+
+fn get_ticker(args: &Value) -> ToolCallResult {
+    let instrument_name = req_str(args, "instrument_name")?;
+    let url = format!("{API_BASE}/ticker?instrument_name={instrument_name}");
+    let payload = fetch_json(&url)?;
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "missing `result` in Deribit response".to_string())?;
+
+    Ok(json!({
+        "mark_price": result.get("mark_price").and_then(Value::as_f64),
+        "iv": result.get("mark_iv").and_then(Value::as_f64),
+        "greeks": result.get("greeks").cloned().unwrap_or(Value::Null),
+        "underlying_price": result.get("underlying_price").and_then(Value::as_f64),
+        "volume": result.get("stats").and_then(|s| s.get("volume")).and_then(Value::as_f64)
+            .or_else(|| result.get("volume").and_then(Value::as_f64))
+    }))
+}
+
+fn list_instruments(args: &Value) -> ToolCallResult {
+    let currency = req_str(args, "currency")?;
+    let kind = opt_str(args, "kind").unwrap_or("option");
+
+    let url = format!(
+        "{API_BASE}/get_instruments?currency={}&kind={}&expired=false",
+        currency.to_ascii_uppercase(),
+        kind
+    );
+
+    let payload = fetch_json(&url)?;
+    let list = payload
+        .get("result")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "missing `result` array in Deribit response".to_string())?;
+
+    let instruments = list
+        .iter()
+        .map(|inst| {
+            json!({
+                "name": inst.get("instrument_name").and_then(Value::as_str),
+                "strike": inst.get("strike").and_then(Value::as_f64),
+                "expiry": inst.get("expiration_timestamp").and_then(Value::as_i64),
+                "type": inst.get("option_type").and_then(Value::as_str)
+                    .or_else(|| inst.get("kind").and_then(Value::as_str))
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Value::Array(instruments))
+}
+
+fn get_orderbook(args: &Value) -> ToolCallResult {
+    let instrument_name = req_str(args, "instrument_name")?;
+    let depth = opt_usize(args, "depth", 20)?;
+
+    let url = format!("{API_BASE}/get_order_book?instrument_name={instrument_name}&depth={depth}");
+    let payload = fetch_json(&url)?;
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "missing `result` in Deribit response".to_string())?;
+
+    Ok(json!({
+        "bids": result.get("bids").cloned().unwrap_or(Value::Array(Vec::new())),
+        "asks": result.get("asks").cloned().unwrap_or(Value::Array(Vec::new())),
+        "mark_price": result.get("mark_price").and_then(Value::as_f64)
+    }))
+}
+
+fn get_historical_volatility(args: &Value) -> ToolCallResult {
+    let currency = req_str(args, "currency")?;
+    let url = format!(
+        "{API_BASE}/get_historical_volatility?currency={}",
+        currency.to_ascii_uppercase()
+    );
+
+    let payload = fetch_json(&url)?;
+    let data = payload
+        .get("result")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "missing `result` array in Deribit response".to_string())?;
+
+    let out = data
+        .iter()
+        .filter_map(|row| {
+            row.as_array().and_then(|arr| {
+                if arr.len() >= 2 {
+                    Some(json!({
+                        "timestamp": arr[0].as_i64(),
+                        "vol": arr[1].as_f64()
+                    }))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Value::Array(out))
+}
+
+fn get_vol_index(args: &Value) -> ToolCallResult {
+    let currency = req_str(args, "currency")?;
+    let start = opt_f64(args, "start", 0.0)?;
+    let end = opt_f64(args, "end", 0.0)?;
+    let resolution = opt_str(args, "resolution").unwrap_or("1D");
+
+    let mut url = format!(
+        "{API_BASE}/get_volatility_index_data?currency={}&resolution={resolution}",
+        currency.to_ascii_uppercase()
+    );
+    if start > 0.0 {
+        url.push_str(&format!("&start_timestamp={}", start as i64));
+    }
+    if end > 0.0 {
+        url.push_str(&format!("&end_timestamp={}", end as i64));
+    }
+
+    let payload = fetch_json(&url)?;
+    let result = payload
+        .get("result")
+        .ok_or_else(|| "missing `result` in Deribit response".to_string())?;
+
+    let rows = if let Some(arr) = result.as_array() {
+        arr.clone()
+    } else if let Some(arr) = result.get("data").and_then(Value::as_array) {
+        arr.clone()
+    } else {
+        Vec::new()
+    };
+
+    let out = rows
+        .iter()
+        .filter_map(|row| {
+            row.as_array().and_then(|arr| {
+                if arr.len() >= 5 {
+                    Some(json!({
+                        "timestamp": arr[0].as_i64(),
+                        "open": arr[1].as_f64(),
+                        "high": arr[2].as_f64(),
+                        "low": arr[3].as_f64(),
+                        "close": arr[4].as_f64()
+                    }))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Value::Array(out))
+}
+
+fn fetch_json(url: &str) -> Result<Value, String> {
+    let mut response = ureq::get(url)
+        .call()
+        .map_err(|e| format!("request failed for `{url}`: {e}"))?;
+
+    let payload: Value = response
+        .body_mut()
+        .read_json()
+        .map_err(|e| format!("invalid JSON response from `{url}`: {e}"))?;
+
+    if let Some(error) = payload.get("error") {
+        return Err(format!("Deribit error: {error}"));
+    }
+
+    Ok(payload)
+}

--- a/openferric-mcp/src/tools/math.rs
+++ b/openferric-mcp/src/tools/math.rs
@@ -1,0 +1,150 @@
+use openferric::pricing::european::{black_scholes_greeks, black_scholes_price};
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, parse_option_type, req_bool, req_f64, req_matrix_f64};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "correlation_matrix",
+            description: "Compute sample Pearson correlation matrix from returns matrix.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "returns": {
+                        "type": "array",
+                        "items": {
+                            "type": "array",
+                            "items": { "type": "number" }
+                        }
+                    }
+                },
+                "required": ["returns"]
+            }),
+        },
+        ToolSpec {
+            name: "black_scholes",
+            description: "Black-Scholes option price and Greeks.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "normal_cdf",
+            description: "Standard normal cumulative distribution function.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "x": {"type": "number"}
+                },
+                "required": ["x"]
+            }),
+        },
+        ToolSpec {
+            name: "normal_pdf",
+            description: "Standard normal probability density function.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "x": {"type": "number"}
+                },
+                "required": ["x"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "correlation_matrix" => Some(correlation_matrix(args)),
+        "black_scholes" => Some(black_scholes(args)),
+        "normal_cdf" => Some(normal_cdf(args)),
+        "normal_pdf" => Some(normal_pdf(args)),
+        _ => None,
+    }
+}
+
+fn correlation_matrix(args: &Value) -> ToolCallResult {
+    let returns = req_matrix_f64(args, "returns")?;
+    if returns.is_empty() {
+        return Err("returns cannot be empty".to_string());
+    }
+
+    let n_obs = returns[0].len();
+    if n_obs < 2 {
+        return Err("each returns series must contain at least two observations".to_string());
+    }
+    if returns.iter().any(|row| row.len() != n_obs) {
+        return Err("all returns series must have the same length".to_string());
+    }
+
+    let n_assets = returns.len();
+    let means = returns
+        .iter()
+        .map(|series| series.iter().sum::<f64>() / n_obs as f64)
+        .collect::<Vec<_>>();
+
+    let mut matrix = vec![vec![0.0; n_assets]; n_assets];
+    for i in 0..n_assets {
+        matrix[i][i] = 1.0;
+        for j in (i + 1)..n_assets {
+            let mut cov = 0.0;
+            let mut var_i = 0.0;
+            let mut var_j = 0.0;
+            for (ri, rj) in returns[i].iter().zip(returns[j].iter()) {
+                let di = *ri - means[i];
+                let dj = *rj - means[j];
+                cov += di * dj;
+                var_i += di * di;
+                var_j += dj * dj;
+            }
+
+            let denom = (var_i * var_j).sqrt();
+            let rho = if denom > 0.0 { cov / denom } else { 0.0 }.clamp(-1.0, 1.0);
+            matrix[i][j] = rho;
+            matrix[j][i] = rho;
+        }
+    }
+
+    Ok(json!({ "matrix": matrix }))
+}
+
+fn black_scholes(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let option_type = parse_option_type(req_bool(args, "is_call")?);
+
+    let price = black_scholes_price(option_type, spot, strike, rate, vol, time);
+    let greeks = black_scholes_greeks(option_type, spot, strike, rate, vol, time);
+
+    Ok(json!({
+        "price": price,
+        "delta": greeks.delta,
+        "gamma": greeks.gamma,
+        "vega": greeks.vega,
+        "theta": greeks.theta,
+        "rho": greeks.rho
+    }))
+}
+
+fn normal_cdf(args: &Value) -> ToolCallResult {
+    let x = req_f64(args, "x")?;
+    Ok(json!({ "value": openferric::math::normal_cdf(x) }))
+}
+
+fn normal_pdf(args: &Value) -> ToolCallResult {
+    let x = req_f64(args, "x")?;
+    Ok(json!({ "value": openferric::math::normal_pdf(x) }))
+}

--- a/openferric-mcp/src/tools/mod.rs
+++ b/openferric-mcp/src/tools/mod.rs
@@ -1,0 +1,468 @@
+use chrono::NaiveDate;
+use openferric::core::OptionType;
+use openferric::credit::SurvivalCurve;
+use openferric::rates::{
+    BusinessDayConvention, DayCountConvention, Frequency, YieldCurve, YieldCurveBuilder,
+};
+use serde_json::{Map, Value, json};
+
+pub mod calibration;
+pub mod credit;
+pub mod dsl;
+pub mod market_data;
+pub mod math;
+pub mod models;
+pub mod pricing;
+pub mod rates;
+pub mod risk;
+pub mod vol;
+
+#[derive(Clone)]
+pub struct ToolSpec {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+}
+
+pub type ToolCallResult = Result<Value, String>;
+
+pub fn all_specs() -> Vec<ToolSpec> {
+    let mut out = Vec::new();
+    out.extend(dsl::specs());
+    out.extend(pricing::specs());
+    out.extend(rates::specs());
+    out.extend(credit::specs());
+    out.extend(vol::specs());
+    out.extend(calibration::specs());
+    out.extend(risk::specs());
+    out.extend(models::specs());
+    out.extend(market_data::specs());
+    out.extend(math::specs());
+    out
+}
+
+pub fn call_tool(name: &str, args: &Value) -> ToolCallResult {
+    let modules: [fn(&str, &Value) -> Option<ToolCallResult>; 10] = [
+        dsl::call,
+        pricing::call,
+        rates::call,
+        credit::call,
+        vol::call,
+        calibration::call,
+        risk::call,
+        models::call,
+        market_data::call,
+        math::call,
+    ];
+
+    for module in modules {
+        if let Some(result) = module(name, args) {
+            return result;
+        }
+    }
+
+    Err(format!("unknown tool: {name}"))
+}
+
+pub fn obj<'a>(value: &'a Value, ctx: &str) -> Result<&'a Map<String, Value>, String> {
+    value
+        .as_object()
+        .ok_or_else(|| format!("{ctx} must be a JSON object"))
+}
+
+pub fn req_value<'a>(args: &'a Value, key: &str) -> Result<&'a Value, String> {
+    let map = obj(args, "arguments")?;
+    map.get(key)
+        .ok_or_else(|| format!("missing required parameter: {key}"))
+}
+
+pub fn req_f64(args: &Value, key: &str) -> Result<f64, String> {
+    req_value(args, key)?
+        .as_f64()
+        .ok_or_else(|| format!("parameter `{key}` must be a number"))
+}
+
+pub fn opt_f64(args: &Value, key: &str, default: f64) -> Result<f64, String> {
+    let map = obj(args, "arguments")?;
+    match map.get(key) {
+        None => Ok(default),
+        Some(v) => v
+            .as_f64()
+            .ok_or_else(|| format!("parameter `{key}` must be a number")),
+    }
+}
+
+pub fn opt_bool(args: &Value, key: &str, default: bool) -> Result<bool, String> {
+    let map = obj(args, "arguments")?;
+    match map.get(key) {
+        None => Ok(default),
+        Some(v) => v
+            .as_bool()
+            .ok_or_else(|| format!("parameter `{key}` must be a boolean")),
+    }
+}
+
+pub fn req_bool(args: &Value, key: &str) -> Result<bool, String> {
+    req_value(args, key)?
+        .as_bool()
+        .ok_or_else(|| format!("parameter `{key}` must be a boolean"))
+}
+
+pub fn req_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    req_value(args, key)?
+        .as_str()
+        .ok_or_else(|| format!("parameter `{key}` must be a string"))
+}
+
+pub fn opt_str<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    obj(args, "arguments")
+        .ok()
+        .and_then(|m| m.get(key))
+        .and_then(Value::as_str)
+}
+
+pub fn opt_usize(args: &Value, key: &str, default: usize) -> Result<usize, String> {
+    let map = obj(args, "arguments")?;
+    match map.get(key) {
+        None => Ok(default),
+        Some(v) => {
+            if let Some(u) = v.as_u64() {
+                usize::try_from(u).map_err(|_| format!("parameter `{key}` is too large"))
+            } else {
+                Err(format!("parameter `{key}` must be a non-negative integer"))
+            }
+        }
+    }
+}
+
+pub fn req_array<'a>(args: &'a Value, key: &str) -> Result<&'a [Value], String> {
+    req_value(args, key)?
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| format!("parameter `{key}` must be an array"))
+}
+
+pub fn req_array_f64(args: &Value, key: &str) -> Result<Vec<f64>, String> {
+    req_array(args, key)?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| format!("parameter `{key}` must be an array of numbers"))
+        })
+        .collect()
+}
+
+pub fn req_matrix_f64(args: &Value, key: &str) -> Result<Vec<Vec<f64>>, String> {
+    req_array(args, key)?
+        .iter()
+        .map(|row| {
+            row.as_array()
+                .ok_or_else(|| format!("parameter `{key}` must be a matrix"))?
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .ok_or_else(|| format!("parameter `{key}` must be a matrix of numbers"))
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect()
+}
+
+pub fn parse_option_type(is_call: bool) -> OptionType {
+    if is_call {
+        OptionType::Call
+    } else {
+        OptionType::Put
+    }
+}
+
+pub fn parse_frequency(value: &str) -> Result<Frequency, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "annual" | "1y" | "yearly" => Ok(Frequency::Annual),
+        "semiannual" | "semi_annual" | "semi-annual" | "6m" => Ok(Frequency::SemiAnnual),
+        "quarterly" | "3m" => Ok(Frequency::Quarterly),
+        "monthly" | "1m" => Ok(Frequency::Monthly),
+        _ => Err(format!(
+            "unsupported frequency `{value}` (expected annual|semiannual|quarterly|monthly)"
+        )),
+    }
+}
+
+pub fn frequency_to_per_year(freq: Frequency) -> usize {
+    match freq {
+        Frequency::Annual => 1,
+        Frequency::SemiAnnual => 2,
+        Frequency::Quarterly => 4,
+        Frequency::Monthly => 12,
+    }
+}
+
+pub fn parse_fixing_frequency_per_year(value: &str) -> Result<usize, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "daily" => Ok(252),
+        "weekly" => Ok(52),
+        "monthly" => Ok(12),
+        "quarterly" => Ok(4),
+        "annual" | "yearly" => Ok(1),
+        other => Err(format!(
+            "unsupported fixing_freq `{other}` (expected daily|weekly|monthly|quarterly|annual)"
+        )),
+    }
+}
+
+pub fn parse_day_count(value: &str) -> Result<DayCountConvention, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "act360" | "act/360" => Ok(DayCountConvention::Act360),
+        "act365" | "act/365" | "act365fixed" => Ok(DayCountConvention::Act365Fixed),
+        "actact" | "act/act" | "actactisda" => Ok(DayCountConvention::ActActISDA),
+        "30/360" | "thirty360" => Ok(DayCountConvention::Thirty360),
+        "30e/360" | "thirtye360" => Ok(DayCountConvention::ThirtyE360),
+        _ => Err(format!("unsupported day count convention `{value}`")),
+    }
+}
+
+pub fn parse_business_day_convention(value: &str) -> Result<BusinessDayConvention, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "following" => Ok(BusinessDayConvention::Following),
+        "modifiedfollowing" | "modified_following" | "modified-following" => {
+            Ok(BusinessDayConvention::ModifiedFollowing)
+        }
+        "preceding" => Ok(BusinessDayConvention::Preceding),
+        "modifiedpreceding" | "modified_preceding" | "modified-preceding" => {
+            Ok(BusinessDayConvention::ModifiedPreceding)
+        }
+        "unadjusted" => Ok(BusinessDayConvention::Unadjusted),
+        "nearest" => Ok(BusinessDayConvention::Nearest),
+        _ => Err(format!("unsupported business-day convention `{value}`")),
+    }
+}
+
+pub fn parse_date(s: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .map_err(|e| format!("invalid date `{s}` (expected YYYY-MM-DD): {e}"))
+}
+
+pub fn tenor_to_years(input: &Value) -> Result<f64, String> {
+    if let Some(v) = input.as_f64() {
+        return Ok(v);
+    }
+
+    let s = input
+        .as_str()
+        .ok_or_else(|| "tenor must be a number or tenor string (e.g. `6M`, `5Y`)".to_string())?;
+
+    let s = s.trim().to_ascii_uppercase();
+    if s.is_empty() {
+        return Err("empty tenor string".to_string());
+    }
+
+    let (num_part, unit) = s.split_at(s.len() - 1);
+    let n: f64 = num_part
+        .parse()
+        .map_err(|_| format!("invalid tenor `{s}`"))?;
+
+    let years = match unit {
+        "D" => n / 365.0,
+        "W" => n / 52.0,
+        "M" => n / 12.0,
+        "Y" => n,
+        _ => return Err(format!("unsupported tenor unit `{unit}` in `{s}`")),
+    };
+
+    Ok(years)
+}
+
+pub fn tenors_from_value(v: &Value, key: &str) -> Result<Vec<f64>, String> {
+    v.get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("parameter `{key}` must be an array"))?
+        .iter()
+        .map(tenor_to_years)
+        .collect()
+}
+
+pub fn parse_curve_interpolation(
+    name: Option<&str>,
+) -> openferric::rates::YieldCurveInterpolationMethod {
+    use openferric::rates::YieldCurveInterpolationMethod;
+
+    match name.unwrap_or("log_linear").to_ascii_lowercase().as_str() {
+        "linear_zero" | "linear_zero_rate" => YieldCurveInterpolationMethod::LinearZeroRate,
+        "monotone_convex" => YieldCurveInterpolationMethod::MonotoneConvex,
+        "tension_spline" => YieldCurveInterpolationMethod::TensionSpline { tension: 0.5 },
+        "hermite_monotone" => YieldCurveInterpolationMethod::HermiteMonotone,
+        "log_cubic_monotone" => YieldCurveInterpolationMethod::LogCubicMonotone,
+        "nelson_siegel" => YieldCurveInterpolationMethod::NelsonSiegel,
+        "nelson_siegel_svensson" => YieldCurveInterpolationMethod::NelsonSiegelSvensson,
+        "smith_wilson" => YieldCurveInterpolationMethod::SmithWilson {
+            ufr: 0.03,
+            alpha: 0.1,
+        },
+        _ => YieldCurveInterpolationMethod::LogLinearDiscount,
+    }
+}
+
+pub fn curve_to_json(curve: &YieldCurve) -> Value {
+    serde_json::to_value(curve).unwrap_or_else(|_| json!({ "tenors": [] }))
+}
+
+pub fn curve_from_value(input: &Value) -> Result<YieldCurve, String> {
+    if let Some(curve_json) = input.get("curve_json") {
+        return curve_from_value(curve_json);
+    }
+
+    if let Ok(curve) = serde_json::from_value::<YieldCurve>(input.clone()) {
+        return Ok(curve);
+    }
+
+    if let Some(obj_map) = input.as_object() {
+        if let Some(points) = obj_map.get("points").and_then(Value::as_array) {
+            let parsed = parse_curve_points(points)?;
+            return Ok(YieldCurve::new(parsed));
+        }
+
+        if let Some(tenors_val) = obj_map.get("tenors") {
+            if let Some(rates_val) = obj_map.get("rates") {
+                let tenors = tenors_val
+                    .as_array()
+                    .ok_or_else(|| "yield_curve.tenors must be an array".to_string())?
+                    .iter()
+                    .map(tenor_to_years)
+                    .collect::<Result<Vec<_>, _>>()?;
+                let rates = rates_val
+                    .as_array()
+                    .ok_or_else(|| "yield_curve.rates must be an array".to_string())?
+                    .iter()
+                    .map(|v| {
+                        v.as_f64().ok_or_else(|| {
+                            "yield_curve.rates must be an array of numbers".to_string()
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                if tenors.len() != rates.len() {
+                    return Err(
+                        "yield_curve.tenors and yield_curve.rates length mismatch".to_string()
+                    );
+                }
+
+                let deposits = tenors.into_iter().zip(rates).collect::<Vec<_>>();
+                return Ok(YieldCurveBuilder::from_deposits(&deposits));
+            }
+
+            let points = tenors_val
+                .as_array()
+                .ok_or_else(|| "yield_curve.tenors must be an array".to_string())?;
+            let parsed = parse_curve_points(points)?;
+            return Ok(YieldCurve::new(parsed));
+        }
+    }
+
+    if let Some(arr) = input.as_array() {
+        let parsed = parse_curve_points(arr)?;
+        return Ok(YieldCurve::new(parsed));
+    }
+
+    Err(
+        "unable to parse yield curve; expected serialized curve or {tenors,rates} style object"
+            .to_string(),
+    )
+}
+
+fn parse_curve_points(points: &[Value]) -> Result<Vec<(f64, f64)>, String> {
+    let mut out = Vec::with_capacity(points.len());
+
+    for point in points {
+        if let Some(arr) = point.as_array() {
+            if arr.len() != 2 {
+                return Err("curve points must be [tenor, discount_factor] pairs".to_string());
+            }
+            let t = tenor_to_years(&arr[0])?;
+            let df = arr[1]
+                .as_f64()
+                .ok_or_else(|| "curve point discount factor must be a number".to_string())?;
+            out.push((t, df));
+            continue;
+        }
+
+        if let Some(obj) = point.as_object() {
+            let t = if let Some(v) = obj.get("tenor") {
+                tenor_to_years(v)?
+            } else if let Some(v) = obj.get("t") {
+                tenor_to_years(v)?
+            } else {
+                return Err("curve point object must contain `tenor`".to_string());
+            };
+
+            let df = obj
+                .get("discount_factor")
+                .or_else(|| obj.get("df"))
+                .and_then(Value::as_f64)
+                .ok_or_else(|| {
+                    "curve point object must contain numeric `discount_factor`".to_string()
+                })?;
+            out.push((t, df));
+            continue;
+        }
+
+        return Err("curve point must be [tenor, discount_factor] or object".to_string());
+    }
+
+    Ok(out)
+}
+
+pub fn survival_curve_from_value(input: &Value) -> Result<SurvivalCurve, String> {
+    if let Ok(curve) = serde_json::from_value::<SurvivalCurve>(input.clone()) {
+        return Ok(curve);
+    }
+
+    let obj_map = input
+        .as_object()
+        .ok_or_else(|| "survival_curve must be an object".to_string())?;
+
+    if let Some(points) = obj_map.get("tenors").and_then(Value::as_array) {
+        let mut out = Vec::with_capacity(points.len());
+        for point in points {
+            if let Some(arr) = point.as_array() {
+                if arr.len() != 2 {
+                    return Err("survival_curve.tenors entries must be [tenor, prob]".to_string());
+                }
+                let t = tenor_to_years(&arr[0])?;
+                let p = arr[1]
+                    .as_f64()
+                    .ok_or_else(|| "survival probability must be numeric".to_string())?;
+                out.push((t, p));
+            } else {
+                return Err("survival_curve.tenors entries must be [tenor, prob]".to_string());
+            }
+        }
+        return Ok(SurvivalCurve::new(out));
+    }
+
+    let tenors = obj_map
+        .get("times")
+        .or_else(|| obj_map.get("tenor_times"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "survival_curve must contain `tenors` or `times`".to_string())?;
+
+    let probs = obj_map
+        .get("survival_probs")
+        .or_else(|| obj_map.get("probs"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| "survival_curve must contain `survival_probs`".to_string())?;
+
+    if tenors.len() != probs.len() {
+        return Err("survival curve times/probabilities length mismatch".to_string());
+    }
+
+    let mut points = Vec::with_capacity(tenors.len());
+    for (t, p) in tenors.iter().zip(probs.iter()) {
+        let tt = tenor_to_years(t)?;
+        let pp = p
+            .as_f64()
+            .ok_or_else(|| "survival probability must be numeric".to_string())?;
+        points.push((tt, pp));
+    }
+
+    Ok(SurvivalCurve::new(points))
+}

--- a/openferric-mcp/src/tools/models.rs
+++ b/openferric-mcp/src/tools/models.rs
@@ -1,0 +1,422 @@
+use openferric::core::OptionType;
+use openferric::engines::fft::carr_madan::{CarrMadanParams, try_heston_price_fft};
+use openferric::models::{HullWhite, VarianceGamma, rbergomi_european_mc};
+use openferric::pricing::european::black_scholes_price;
+use openferric::vol::local_vol::{ImpliedVolSurface as LocalVolSurface, dupire_local_vol};
+use openferric::vol::sabr::SabrParams;
+use serde_json::{Value, json};
+
+use super::{ToolCallResult, ToolSpec, obj, opt_bool, opt_usize, req_f64, req_value};
+
+#[derive(Debug, Clone)]
+struct SimpleSurface {
+    forward: f64,
+    strikes: Vec<f64>,
+    expiries: Vec<f64>,
+    vols: Vec<Vec<f64>>,
+}
+
+impl SimpleSurface {
+    fn vol_at(&self, strike: f64, expiry: f64) -> f64 {
+        let (ei0, ei1, ew) = locate_bounds(&self.expiries, expiry);
+        let (si0, si1, sw) = locate_bounds(&self.strikes, strike);
+
+        if ei0 == ei1 && si0 == si1 {
+            return self.vols[ei0][si0];
+        }
+        if ei0 == ei1 {
+            return self.vols[ei0][si0] + (self.vols[ei0][si1] - self.vols[ei0][si0]) * sw;
+        }
+        if si0 == si1 {
+            return self.vols[ei0][si0] + (self.vols[ei1][si0] - self.vols[ei0][si0]) * ew;
+        }
+
+        let v00 = self.vols[ei0][si0];
+        let v01 = self.vols[ei0][si1];
+        let v10 = self.vols[ei1][si0];
+        let v11 = self.vols[ei1][si1];
+
+        let v0 = v00 + (v01 - v00) * sw;
+        let v1 = v10 + (v11 - v10) * sw;
+        v0 + (v1 - v0) * ew
+    }
+}
+
+impl LocalVolSurface for SimpleSurface {
+    fn implied_vol(&self, strike: f64, expiry: f64) -> f64 {
+        self.vol_at(strike, expiry)
+    }
+}
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "heston_price",
+            description: "Price an option under Heston via FFT.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "rate": {"type":"number"},
+                    "v0": {"type":"number"},
+                    "kappa": {"type":"number"},
+                    "theta": {"type":"number"},
+                    "sigma": {"type":"number"},
+                    "rho": {"type":"number"},
+                    "time": {"type":"number"},
+                    "is_call": {"type":"boolean"}
+                },
+                "required": ["spot","strike","rate","v0","kappa","theta","sigma","rho","time","is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "sabr_vol",
+            description: "Compute SABR implied volatility.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "forward": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "alpha": {"type":"number"},
+                    "rho": {"type":"number"},
+                    "nu": {"type":"number"},
+                    "beta": {"type":"number"}
+                },
+                "required": ["forward","strike","expiry","alpha","rho","nu"]
+            }),
+        },
+        ToolSpec {
+            name: "hull_white_price",
+            description: "Compute Hull-White ZCB price from flat initial curve.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "rate": {"type":"number"},
+                    "a": {"type":"number"},
+                    "sigma": {"type":"number"},
+                    "maturity": {"type":"number"}
+                },
+                "required": ["rate","a","sigma","maturity"]
+            }),
+        },
+        ToolSpec {
+            name: "rough_bergomi_price",
+            description: "Monte Carlo European call pricing under rough Bergomi.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "time": {"type":"number"},
+                    "H": {"type":"number"},
+                    "eta": {"type":"number"},
+                    "rho": {"type":"number"},
+                    "xi": {"type":"number"},
+                    "num_paths": {"type":"integer", "minimum": 1}
+                },
+                "required": ["spot","strike","time","H","eta","rho","xi"]
+            }),
+        },
+        ToolSpec {
+            name: "variance_gamma_price",
+            description: "Price option under Variance-Gamma via FFT.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "rate": {"type":"number"},
+                    "time": {"type":"number"},
+                    "sigma": {"type":"number"},
+                    "theta_vg": {"type":"number"},
+                    "nu": {"type":"number"},
+                    "is_call": {"type":"boolean"}
+                },
+                "required": ["spot","strike","rate","time","sigma","theta_vg","nu","is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "local_vol_price",
+            description: "Approximate local-vol European call price using Dupire local vol level.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "time": {"type":"number"},
+                    "surface": {"type":"object"},
+                    "num_paths": {"type":"integer", "minimum": 1}
+                },
+                "required": ["spot","strike","time","surface"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "heston_price" => Some(heston_price(args)),
+        "sabr_vol" => Some(sabr_vol(args)),
+        "hull_white_price" => Some(hull_white_price(args)),
+        "rough_bergomi_price" => Some(rough_bergomi_price(args)),
+        "variance_gamma_price" => Some(variance_gamma_price(args)),
+        "local_vol_price" => Some(local_vol_price(args)),
+        _ => None,
+    }
+}
+
+fn heston_price(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let v0 = req_f64(args, "v0")?;
+    let kappa = req_f64(args, "kappa")?;
+    let theta = req_f64(args, "theta")?;
+    let sigma = req_f64(args, "sigma")?;
+    let rho = req_f64(args, "rho")?;
+    let time = req_f64(args, "time")?;
+    let is_call = opt_bool(args, "is_call", true)?;
+
+    let priced = try_heston_price_fft(
+        spot,
+        &[strike],
+        rate,
+        0.0,
+        v0,
+        kappa,
+        theta,
+        sigma,
+        rho,
+        time,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let call = priced
+        .first()
+        .map(|(_, p)| *p)
+        .ok_or_else(|| "Heston pricing returned no values".to_string())?;
+
+    let price = if is_call {
+        call
+    } else {
+        call - spot + strike * (-rate * time).exp()
+    };
+
+    Ok(json!({ "price": price }))
+}
+
+fn sabr_vol(args: &Value) -> ToolCallResult {
+    let forward = req_f64(args, "forward")?;
+    let strike = req_f64(args, "strike")?;
+    let expiry = req_f64(args, "expiry")?;
+    let alpha = req_f64(args, "alpha")?;
+    let rho = req_f64(args, "rho")?;
+    let nu = req_f64(args, "nu")?;
+    let beta = super::opt_f64(args, "beta", 0.5)?;
+
+    let params = SabrParams {
+        alpha,
+        beta,
+        rho,
+        nu,
+    };
+
+    Ok(json!({ "vol": params.implied_vol(forward, strike, expiry) }))
+}
+
+fn hull_white_price(args: &Value) -> ToolCallResult {
+    let rate = req_f64(args, "rate")?;
+    let a = req_f64(args, "a")?;
+    let sigma = req_f64(args, "sigma")?;
+    let maturity = req_f64(args, "maturity")?;
+
+    let curve =
+        openferric::rates::YieldCurve::new(vec![(maturity.max(1.0e-8), (-rate * maturity).exp())]);
+    let mut model = HullWhite::new(a, sigma);
+    let times = (0..=20)
+        .map(|i| maturity.max(1.0e-8) * i as f64 / 20.0)
+        .collect::<Vec<_>>();
+    model.calibrate_theta(&curve, &times);
+
+    let r0 = HullWhite::instantaneous_forward(&curve, 0.0);
+    let zcb = model.bond_price(0.0, maturity, r0, &curve);
+
+    Ok(json!({ "zcb_price": zcb }))
+}
+
+fn rough_bergomi_price(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let time = req_f64(args, "time")?;
+    let hurst = req_f64(args, "H")?;
+    let eta = req_f64(args, "eta")?;
+    let rho = req_f64(args, "rho")?;
+    let xi = req_f64(args, "xi")?;
+    let num_paths = opt_usize(args, "num_paths", 20_000)?;
+
+    let n_steps = ((time * 252.0).round() as usize).clamp(16, 512);
+    let result = rbergomi_european_mc(
+        spot, strike, 0.0, 0.0, time, hurst, eta, rho, xi, num_paths, n_steps,
+    );
+
+    Ok(json!({ "price": result.price, "stderr": result.stderr }))
+}
+
+fn variance_gamma_price(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let time = req_f64(args, "time")?;
+    let sigma = req_f64(args, "sigma")?;
+    let theta_vg = req_f64(args, "theta_vg")?;
+    let nu = req_f64(args, "nu")?;
+    let is_call = req_value(args, "is_call").and_then(|v| {
+        v.as_bool()
+            .ok_or_else(|| "parameter `is_call` must be boolean".to_string())
+    })?;
+
+    let vg = VarianceGamma {
+        sigma,
+        theta: theta_vg,
+        nu,
+    };
+
+    let priced = vg
+        .european_calls_fft(spot, &[strike], rate, 0.0, time, CarrMadanParams::default())
+        .map_err(|e| e.to_string())?;
+
+    let call = priced
+        .first()
+        .map(|(_, p)| *p)
+        .ok_or_else(|| "VG pricing returned no values".to_string())?;
+
+    let price = if is_call {
+        call
+    } else {
+        call - spot + strike * (-rate * time).exp()
+    };
+
+    Ok(json!({ "price": price }))
+}
+
+fn local_vol_price(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let time = req_f64(args, "time")?;
+    let surface = parse_surface(req_value(args, "surface")?, Some(spot))?;
+
+    let lv = dupire_local_vol(surface.clone(), surface.forward, strike, time);
+    let num_paths = opt_usize(args, "num_paths", 0)?;
+
+    let price = if num_paths == 0 {
+        black_scholes_price(OptionType::Call, spot, strike, 0.0, lv, time)
+    } else {
+        mc_call_price(spot, strike, time, lv, num_paths, 42)
+    };
+
+    Ok(json!({ "price": price }))
+}
+
+fn parse_surface(value: &Value, forward_fallback: Option<f64>) -> Result<SimpleSurface, String> {
+    let obj_map = obj(value, "surface")?;
+
+    let strikes = obj_map
+        .get("strikes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.strikes must be an array".to_string())?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| "surface.strikes must be numeric".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let expiries = obj_map
+        .get("expiries")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.expiries must be an array".to_string())?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| "surface.expiries must be numeric".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let vols = obj_map
+        .get("vols")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.vols must be a 2D array".to_string())?
+        .iter()
+        .map(|row| {
+            row.as_array()
+                .ok_or_else(|| "surface.vols must be a 2D array".to_string())?
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .ok_or_else(|| "surface.vols entries must be numeric".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if strikes.is_empty() || expiries.is_empty() {
+        return Err("surface grids cannot be empty".to_string());
+    }
+    if vols.len() != expiries.len() || vols.iter().any(|row| row.len() != strikes.len()) {
+        return Err("surface vols shape mismatch".to_string());
+    }
+
+    let forward = obj_map
+        .get("forward")
+        .and_then(Value::as_f64)
+        .or(forward_fallback)
+        .unwrap_or_else(|| strikes[strikes.len() / 2]);
+
+    Ok(SimpleSurface {
+        forward,
+        strikes,
+        expiries,
+        vols,
+    })
+}
+
+fn locate_bounds(grid: &[f64], x: f64) -> (usize, usize, f64) {
+    if x <= grid[0] {
+        return (0, 0, 0.0);
+    }
+    let last = grid.len() - 1;
+    if x >= grid[last] {
+        return (last, last, 0.0);
+    }
+
+    let mut lo = 0usize;
+    for i in 0..last {
+        if x >= grid[i] && x <= grid[i + 1] {
+            lo = i;
+            break;
+        }
+    }
+
+    let hi = lo + 1;
+    let w = (x - grid[lo]) / (grid[hi] - grid[lo]);
+    (lo, hi, w)
+}
+
+fn mc_call_price(spot: f64, strike: f64, time: f64, vol: f64, num_paths: usize, seed: u64) -> f64 {
+    use openferric::math::fast_rng::{FastRng, FastRngKind, sample_standard_normal};
+
+    let mut rng = FastRng::from_seed(FastRngKind::Xoshiro256PlusPlus, seed);
+    let drift = -0.5 * vol * vol * time;
+    let diff = vol * time.sqrt();
+
+    let mut sum = 0.0;
+    for _ in 0..num_paths {
+        let z = sample_standard_normal(&mut rng);
+        let st = spot * (drift + diff * z).exp();
+        sum += (st - strike).max(0.0);
+    }
+
+    sum / num_paths as f64
+}

--- a/openferric-mcp/src/tools/pricing.rs
+++ b/openferric-mcp/src/tools/pricing.rs
@@ -1,0 +1,601 @@
+use openferric::core::PricingEngine;
+use openferric::engines::analytic::digital::DigitalAnalyticEngine;
+use openferric::instruments::autocallable::Autocallable;
+use openferric::instruments::basket::{BasketOption, BasketType};
+use openferric::instruments::digital::CashOrNothingOption;
+use openferric::instruments::range_accrual::RangeAccrual;
+use openferric::instruments::tarf::Tarf;
+use openferric::market::Market;
+use openferric::pricing::american::crr_binomial_american;
+use openferric::pricing::asian::{AsianStrike, arithmetic_asian_price_mc};
+use openferric::pricing::autocallable::price_autocallable;
+use openferric::pricing::barrier::{BarrierDirection, BarrierStyle, barrier_price_mc};
+use openferric::pricing::basket::price_basket_mc;
+use openferric::pricing::bermudan::longstaff_schwartz_bermudan;
+use openferric::pricing::european::{black_scholes_greeks, black_scholes_price};
+use openferric::pricing::range_accrual::range_accrual_mc_price;
+use openferric::pricing::tarf::tarf_mc_price;
+use serde_json::{Value, json};
+
+use super::{
+    ToolCallResult, ToolSpec, frequency_to_per_year, opt_usize, parse_fixing_frequency_per_year,
+    parse_option_type, req_array_f64, req_bool, req_f64, req_matrix_f64, req_str,
+};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "price_european",
+            description: "Black-Scholes European option price and Greeks.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "price_american",
+            description: "CRR-binomial American option price with finite-difference Greeks.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"},
+                    "steps": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "price_asian",
+            description: "Arithmetic Asian option Monte Carlo pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"},
+                    "fixing_freq": {"type": "string"},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call", "fixing_freq"]
+            }),
+        },
+        ToolSpec {
+            name: "price_barrier",
+            description: "Barrier option MC pricing (up/down, in/out).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "barrier": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"},
+                    "barrier_type": {"type": "string"},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "strike", "barrier", "rate", "vol", "time", "is_call", "barrier_type"]
+            }),
+        },
+        ToolSpec {
+            name: "price_autocallable",
+            description: "Single-underlying worst-of autocallable pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "coupon_barrier": {"type": "number"},
+                    "ki_barrier": {"type": "number"},
+                    "coupon_rate": {"type": "number"},
+                    "time": {"type": "number"},
+                    "freq": {"type": ["string", "integer"]},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "coupon_barrier", "ki_barrier", "coupon_rate", "time", "freq", "rate", "vol"]
+            }),
+        },
+        ToolSpec {
+            name: "price_basket",
+            description: "Correlated basket option MC pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spots": {"type": "array", "items": {"type": "number"}},
+                    "vols": {"type": "array", "items": {"type": "number"}},
+                    "correlation": {"type": "array"},
+                    "strike": {"type": "number"},
+                    "time": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "is_call": {"type": "boolean"},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spots", "vols", "correlation", "strike", "time", "rate", "is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "price_bermudan",
+            description: "Longstaff-Schwartz Bermudan option pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"},
+                    "exercise_dates": {"type": "array", "items": {"type": "number"}},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call", "exercise_dates"]
+            }),
+        },
+        ToolSpec {
+            name: "price_digital",
+            description: "Cash-or-nothing digital option analytic pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "is_call": {"type": "boolean"}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "price_range_accrual",
+            description: "Single-rate range accrual MC pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "lower": {"type": "number"},
+                    "upper": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "coupon": {"type": "number"},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "lower", "upper", "rate", "vol", "time", "coupon"]
+            }),
+        },
+        ToolSpec {
+            name: "price_tarf",
+            description: "TARF Monte Carlo pricing.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "spot": {"type": "number"},
+                    "strike": {"type": "number"},
+                    "rate": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "time": {"type": "number"},
+                    "leverage": {"type": "number"},
+                    "ki_barrier": {"type": "number"},
+                    "num_fixings": {"type": "integer", "minimum": 1},
+                    "num_paths": {"type": "integer", "minimum": 1}
+                },
+                "required": ["spot", "strike", "rate", "vol", "time", "leverage", "ki_barrier", "num_fixings"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "price_european" => Some(price_european(args)),
+        "price_american" => Some(price_american(args)),
+        "price_asian" => Some(price_asian(args)),
+        "price_barrier" => Some(price_barrier(args)),
+        "price_autocallable" => Some(price_autocallable_tool(args)),
+        "price_basket" => Some(price_basket_tool(args)),
+        "price_bermudan" => Some(price_bermudan_tool(args)),
+        "price_digital" => Some(price_digital_tool(args)),
+        "price_range_accrual" => Some(price_range_accrual_tool(args)),
+        "price_tarf" => Some(price_tarf_tool(args)),
+        _ => None,
+    }
+}
+
+fn price_european(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+    let option_type = parse_option_type(is_call);
+
+    let price = black_scholes_price(option_type, spot, strike, rate, vol, time);
+    let greeks = black_scholes_greeks(option_type, spot, strike, rate, vol, time);
+
+    Ok(json!({
+        "price": price,
+        "delta": greeks.delta,
+        "gamma": greeks.gamma,
+        "vega": greeks.vega,
+        "theta": greeks.theta,
+        "rho": greeks.rho
+    }))
+}
+
+fn price_american(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+    let steps = opt_usize(args, "steps", 400)?;
+
+    let option_type = parse_option_type(is_call);
+
+    let price_fn = |s: f64, k: f64, r: f64, v: f64, t: f64| -> f64 {
+        crr_binomial_american(option_type, s, k, r, v, t.max(1.0e-8), steps)
+    };
+
+    let price = price_fn(spot, strike, rate, vol, time);
+
+    let ds = (0.01 * spot.abs()).max(1.0e-6);
+    let dv = 0.01;
+    let dr = 1.0e-4;
+    let dt = time.clamp(1.0e-6, 1.0 / 365.0);
+
+    let p_up = price_fn(spot + ds, strike, rate, vol, time);
+    let p_dn = price_fn((spot - ds).max(1.0e-8), strike, rate, vol, time);
+    let delta = (p_up - p_dn) / (2.0 * ds);
+    let gamma = (p_up - 2.0 * price + p_dn) / (ds * ds);
+
+    let p_vu = price_fn(spot, strike, rate, vol + dv, time);
+    let p_vd = price_fn(spot, strike, rate, (vol - dv).max(1.0e-8), time);
+    let vega = (p_vu - p_vd) / (2.0 * dv);
+
+    let p_ru = price_fn(spot, strike, rate + dr, vol, time);
+    let p_rd = price_fn(spot, strike, rate - dr, vol, time);
+    let rho = (p_ru - p_rd) / (2.0 * dr);
+
+    let p_tu = price_fn(spot, strike, rate, vol, (time - dt).max(1.0e-8));
+    let theta = (p_tu - price) / dt;
+
+    Ok(json!({
+        "price": price,
+        "greeks": {
+            "delta": delta,
+            "gamma": gamma,
+            "vega": vega,
+            "theta": theta,
+            "rho": rho
+        }
+    }))
+}
+
+fn price_asian(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+    let fixing_freq = req_str(args, "fixing_freq")?;
+    let num_paths = opt_usize(args, "num_paths", 50_000)?;
+
+    let option_type = parse_option_type(is_call);
+    let per_year = parse_fixing_frequency_per_year(fixing_freq)?;
+    let steps = ((time.max(1.0e-6) * per_year as f64).round() as usize).max(1);
+
+    let (price, stderr) = arithmetic_asian_price_mc(
+        option_type,
+        AsianStrike::Fixed(strike),
+        spot,
+        rate,
+        vol,
+        time,
+        steps,
+        num_paths,
+        42,
+    );
+
+    Ok(json!({ "price": price, "stderr": stderr }))
+}
+
+fn price_barrier(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let barrier = req_f64(args, "barrier")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+    let barrier_type = req_str(args, "barrier_type")?;
+    let num_paths = opt_usize(args, "num_paths", 50_000)?;
+
+    let option_type = parse_option_type(is_call);
+    let (style, direction) = parse_barrier_type(barrier_type)?;
+    let steps = ((time.max(1.0e-6) * 252.0).round() as usize).max(8);
+
+    let (price, stderr) = barrier_price_mc(
+        option_type,
+        style,
+        direction,
+        spot,
+        strike,
+        barrier,
+        rate,
+        vol,
+        time,
+        steps,
+        num_paths,
+        42,
+    );
+
+    Ok(json!({ "price": price, "stderr": stderr }))
+}
+
+fn price_autocallable_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let coupon_barrier = req_f64(args, "coupon_barrier")?;
+    let ki_barrier = req_f64(args, "ki_barrier")?;
+    let coupon_rate = req_f64(args, "coupon_rate")?;
+    let time = req_f64(args, "time")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let num_paths = opt_usize(args, "num_paths", 40_000)?;
+
+    let freq_per_year = parse_freq_per_year(args)?;
+    let dates = schedule_times(time, freq_per_year);
+
+    let instrument = Autocallable {
+        underlyings: vec![0],
+        notional: 1.0,
+        autocall_dates: dates,
+        autocall_barrier: coupon_barrier,
+        coupon_rate,
+        ki_barrier,
+        ki_strike: 1.0,
+        maturity: time,
+    };
+
+    let corr = vec![vec![1.0]];
+    let n_steps = ((time.max(1.0e-6) * 252.0).round() as usize).max(8);
+    let priced = price_autocallable(
+        &instrument,
+        &[spot],
+        &[vol],
+        &corr,
+        rate,
+        0.0,
+        num_paths,
+        n_steps,
+    );
+
+    Ok(json!({ "price": priced.price }))
+}
+
+fn price_basket_tool(args: &Value) -> ToolCallResult {
+    let spots = req_array_f64(args, "spots")?;
+    let vols = req_array_f64(args, "vols")?;
+    let corr = req_matrix_f64(args, "correlation")?;
+    let strike = req_f64(args, "strike")?;
+    let time = req_f64(args, "time")?;
+    let rate = req_f64(args, "rate")?;
+    let is_call = req_bool(args, "is_call")?;
+    let num_paths = opt_usize(args, "num_paths", 60_000)?;
+
+    if spots.len() != vols.len() {
+        return Err("spots and vols length mismatch".to_string());
+    }
+
+    let n = spots.len();
+    if n == 0 {
+        return Err("spots cannot be empty".to_string());
+    }
+
+    let weights = vec![1.0 / n as f64; n];
+    let dividends = vec![0.0; n];
+
+    let instrument = BasketOption {
+        weights,
+        strike,
+        maturity: time,
+        is_call,
+        basket_type: BasketType::Average,
+    };
+
+    let priced = price_basket_mc(
+        &instrument,
+        &spots,
+        &vols,
+        &corr,
+        rate,
+        &dividends,
+        num_paths,
+    );
+
+    Ok(json!({ "price": priced.price, "stderr": priced.stderr }))
+}
+
+fn price_bermudan_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+    let exercise_dates = req_array_f64(args, "exercise_dates")?;
+    let num_paths = opt_usize(args, "num_paths", 50_000)?;
+
+    let option_type = parse_option_type(is_call);
+    let steps = ((time.max(1.0e-6) * 252.0).round() as usize).max(16);
+
+    let exercise_steps = exercise_dates
+        .iter()
+        .map(|t| ((*t / time.max(1.0e-8) * steps as f64).round() as usize).min(steps))
+        .collect::<Vec<_>>();
+
+    let price = longstaff_schwartz_bermudan(
+        option_type,
+        spot,
+        strike,
+        rate,
+        vol,
+        time,
+        steps,
+        &exercise_steps,
+        num_paths,
+        42,
+    );
+
+    Ok(json!({ "price": price }))
+}
+
+fn price_digital_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let is_call = req_bool(args, "is_call")?;
+
+    let market = Market::builder()
+        .spot(spot)
+        .rate(rate)
+        .dividend_yield(0.0)
+        .flat_vol(vol)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let instrument = CashOrNothingOption::new(parse_option_type(is_call), strike, 1.0, time);
+    let result = DigitalAnalyticEngine::new()
+        .price(&instrument, &market)
+        .map_err(|e| e.to_string())?;
+
+    Ok(json!({ "price": result.price }))
+}
+
+fn price_range_accrual_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let lower = req_f64(args, "lower")?;
+    let upper = req_f64(args, "upper")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let coupon = req_f64(args, "coupon")?;
+    let num_paths = opt_usize(args, "num_paths", 20_000)?;
+
+    let fixings = ((time * 252.0).round() as usize).max(1);
+    let fixing_times = (1..=fixings)
+        .map(|i| i as f64 * time / fixings as f64)
+        .collect::<Vec<_>>();
+
+    let instrument = RangeAccrual {
+        notional: 1.0,
+        coupon_rate: coupon,
+        lower_bound: lower,
+        upper_bound: upper,
+        fixing_times,
+        payment_time: time,
+    };
+
+    let result = range_accrual_mc_price(&instrument, spot, 1.0, spot, vol, rate, num_paths, 42)
+        .map_err(|e| e.to_string())?;
+
+    Ok(json!({ "price": result.price, "stderr": result.std_error }))
+}
+
+fn price_tarf_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let vol = req_f64(args, "vol")?;
+    let time = req_f64(args, "time")?;
+    let leverage = req_f64(args, "leverage")?;
+    let ki_barrier = req_f64(args, "ki_barrier")?;
+    let num_fixings = opt_usize(args, "num_fixings", 52)?;
+    let num_paths = opt_usize(args, "num_paths", 20_000)?;
+
+    let fixing_times = (1..=num_fixings)
+        .map(|i| i as f64 * time / num_fixings as f64)
+        .collect::<Vec<_>>();
+
+    let tarf = Tarf::standard(
+        strike,
+        1.0,
+        ki_barrier,
+        1.0,
+        leverage.max(0.0),
+        fixing_times,
+    );
+
+    let result =
+        tarf_mc_price(&tarf, spot, rate, 0.0, vol, num_paths, 42).map_err(|e| e.to_string())?;
+
+    Ok(json!({ "price": result.price, "stderr": result.std_error }))
+}
+
+fn parse_barrier_type(value: &str) -> Result<(BarrierStyle, BarrierDirection), String> {
+    match value.to_ascii_lowercase().as_str() {
+        "up_in" | "up-and-in" | "ui" => Ok((BarrierStyle::In, BarrierDirection::Up)),
+        "up_out" | "up-and-out" | "uo" => Ok((BarrierStyle::Out, BarrierDirection::Up)),
+        "down_in" | "down-and-in" | "di" => Ok((BarrierStyle::In, BarrierDirection::Down)),
+        "down_out" | "down-and-out" | "do" => Ok((BarrierStyle::Out, BarrierDirection::Down)),
+        _ => Err(format!(
+            "unsupported barrier_type `{value}` (expected up_in|up_out|down_in|down_out)"
+        )),
+    }
+}
+
+fn parse_freq_per_year(args: &Value) -> Result<usize, String> {
+    let freq_value = super::req_value(args, "freq")?;
+    if let Some(v) = freq_value.as_u64() {
+        return usize::try_from(v).map_err(|_| "freq is too large".to_string());
+    }
+
+    let freq = freq_value
+        .as_str()
+        .ok_or_else(|| "freq must be a string or integer".to_string())?;
+
+    let per_year = match freq.to_ascii_lowercase().as_str() {
+        "annual" | "yearly" => 1,
+        "semiannual" | "semi-annual" | "6m" => 2,
+        "quarterly" | "3m" => 4,
+        "monthly" | "1m" => 12,
+        "weekly" => 52,
+        _ => {
+            let f = super::parse_frequency(freq)?;
+            frequency_to_per_year(f)
+        }
+    };
+
+    Ok(per_year)
+}
+
+fn schedule_times(maturity: f64, freq_per_year: usize) -> Vec<f64> {
+    let n = ((maturity * freq_per_year as f64).round() as usize).max(1);
+    (1..=n)
+        .map(|i| i as f64 * maturity / n as f64)
+        .collect::<Vec<_>>()
+}

--- a/openferric-mcp/src/tools/rates.rs
+++ b/openferric-mcp/src/tools/rates.rs
@@ -1,0 +1,445 @@
+use chrono::{Duration, NaiveDate};
+use openferric::math::ExtrapolationMode;
+use openferric::rates::{
+    Calendar, CapFloor, DayCountConvention, FixedRateBond, ForwardRateAgreement, InterestRateSwap,
+    OvernightIndexSwap, ScheduleConfig, Swaption, YieldCurve, YieldCurveBuilder,
+    YieldCurveInterpolationSettings, generate_schedule_with_config,
+};
+use serde_json::{Value, json};
+
+use super::{
+    ToolCallResult, ToolSpec, curve_from_value, curve_to_json, opt_bool, opt_str,
+    parse_business_day_convention, parse_curve_interpolation, parse_date, parse_day_count,
+    parse_frequency, req_f64, req_str, tenors_from_value,
+};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "yield_curve_build",
+            description: "Build a discount curve from tenors and deposit rates.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "tenors": {"type": "array"},
+                    "rates": {"type": "array", "items": {"type": "number"}},
+                    "interp": {"type": "string"}
+                },
+                "required": ["tenors", "rates"]
+            }),
+        },
+        ToolSpec {
+            name: "bond_price",
+            description: "Price a fixed-rate bond and return risk measures.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "face": {"type": "number"},
+                    "coupon_rate": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["face", "coupon_rate", "maturity", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "swap_rate",
+            description: "Compute par swap rate, PV01, and DV01.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "fixed_freq": {"type": "string"},
+                    "float_freq": {"type": "string"},
+                    "maturity": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["fixed_freq", "float_freq", "maturity", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "swaption_price",
+            description: "Price a Black-76 swaption and return finite-difference Greeks.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "strike": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "swap_tenor": {"type": "number"},
+                    "vol": {"type": "number"},
+                    "yield_curve": {"type": "object"},
+                    "is_payer": {"type": "boolean"}
+                },
+                "required": ["strike", "maturity", "swap_tenor", "vol", "yield_curve", "is_payer"]
+            }),
+        },
+        ToolSpec {
+            name: "fra_price",
+            description: "Price a forward rate agreement.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start": {"type": "number"},
+                    "end": {"type": "number"},
+                    "fixed_rate": {"type": "number"},
+                    "notional": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["start", "end", "fixed_rate", "notional", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "cap_floor_price",
+            description: "Price an IR cap/floor and return finite-difference Greeks.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "strike": {"type": "number"},
+                    "maturity": {"type": "number"},
+                    "freq": {"type": "string"},
+                    "vol": {"type": "number"},
+                    "yield_curve": {"type": "object"},
+                    "is_cap": {"type": "boolean"}
+                },
+                "required": ["strike", "maturity", "freq", "vol", "yield_curve", "is_cap"]
+            }),
+        },
+        ToolSpec {
+            name: "ois_rate",
+            description: "Compute OIS par fixed rate.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "maturity": {"type": "number"},
+                    "yield_curve": {"type": "object"}
+                },
+                "required": ["maturity", "yield_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "day_count",
+            description: "Compute year fraction under a day-count convention.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start_date": {"type": "string"},
+                    "end_date": {"type": "string"},
+                    "convention": {"type": "string"}
+                },
+                "required": ["start_date", "end_date", "convention"]
+            }),
+        },
+        ToolSpec {
+            name: "schedule_generate",
+            description: "Generate a coupon schedule between two dates.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start": {"type": "string"},
+                    "end": {"type": "string"},
+                    "freq": {"type": "string"},
+                    "convention": {"type": "string"}
+                },
+                "required": ["start", "end", "freq"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "yield_curve_build" => Some(yield_curve_build(args)),
+        "bond_price" => Some(bond_price(args)),
+        "swap_rate" => Some(swap_rate(args)),
+        "swaption_price" => Some(swaption_price(args)),
+        "fra_price" => Some(fra_price(args)),
+        "cap_floor_price" => Some(cap_floor_price(args)),
+        "ois_rate" => Some(ois_rate(args)),
+        "day_count" => Some(day_count(args)),
+        "schedule_generate" => Some(schedule_generate(args)),
+        _ => None,
+    }
+}
+
+fn yield_curve_build(args: &Value) -> ToolCallResult {
+    let tenors = tenors_from_value(args, "tenors")?;
+    let rates = args
+        .get("rates")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "parameter `rates` must be an array".to_string())?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| "parameter `rates` must be numeric".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if tenors.len() != rates.len() {
+        return Err("tenors/rates length mismatch".to_string());
+    }
+
+    let method = parse_curve_interpolation(opt_str(args, "interp"));
+    let settings = YieldCurveInterpolationSettings {
+        method,
+        extrapolation: ExtrapolationMode::Linear,
+    };
+
+    let deposits = tenors.into_iter().zip(rates).collect::<Vec<_>>();
+    let curve = YieldCurveBuilder::from_deposits_with_settings(&deposits, settings)
+        .map_err(|e| format!("curve build failed: {e:?}"))?;
+
+    Ok(json!({ "curve_json": curve_to_json(&curve) }))
+}
+
+fn bond_price(args: &Value) -> ToolCallResult {
+    let face = req_f64(args, "face")?;
+    let coupon_rate = req_f64(args, "coupon_rate")?;
+    let maturity = req_f64(args, "maturity")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+
+    let bond = FixedRateBond {
+        face_value: face,
+        coupon_rate,
+        frequency: 2,
+        maturity,
+        day_count: DayCountConvention::Act365Fixed,
+    };
+
+    let dirty = bond.dirty_price(&curve);
+    let settlement = 0.0;
+    let accrued = bond.accrued_interest(settlement);
+    let clean = bond.clean_price(&curve, settlement);
+    let duration = bond.duration(&curve);
+    let convexity = bond.convexity(&curve);
+
+    let bumped = bump_curve_parallel(&curve, 1.0e-4);
+    let dv01 = bond.dirty_price(&bumped) - dirty;
+
+    Ok(json!({
+        "dirty_price": dirty,
+        "clean_price": clean,
+        "accrued": accrued,
+        "duration": duration,
+        "convexity": convexity,
+        "dv01": dv01
+    }))
+}
+
+fn swap_rate(args: &Value) -> ToolCallResult {
+    let fixed_freq = parse_frequency(req_str(args, "fixed_freq")?)?;
+    let float_freq = parse_frequency(req_str(args, "float_freq")?)?;
+    let maturity = req_f64(args, "maturity")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+
+    let start =
+        NaiveDate::from_ymd_opt(2026, 1, 1).ok_or_else(|| "invalid base date".to_string())?;
+    let end = start + Duration::days((maturity * 365.0).round() as i64);
+
+    let swap = InterestRateSwap::builder()
+        .notional(1.0)
+        .fixed_rate(0.0)
+        .start_date(start)
+        .end_date(end)
+        .fixed_freq(fixed_freq)
+        .float_freq(float_freq)
+        .build();
+
+    let par_rate = swap.par_rate(&curve);
+    let npv_at_zero = swap.npv(&curve);
+
+    let swap_1bp = InterestRateSwap::builder()
+        .notional(1.0)
+        .fixed_rate(1.0e-4)
+        .start_date(start)
+        .end_date(end)
+        .fixed_freq(fixed_freq)
+        .float_freq(float_freq)
+        .build();
+    let pv01 = (npv_at_zero - swap_1bp.npv(&curve)).abs();
+
+    let dv01 = swap.dv01(&curve);
+
+    Ok(json!({ "par_rate": par_rate, "pv01": pv01, "dv01": dv01 }))
+}
+
+fn swaption_price(args: &Value) -> ToolCallResult {
+    let strike = req_f64(args, "strike")?;
+    let maturity = req_f64(args, "maturity")?;
+    let swap_tenor = req_f64(args, "swap_tenor")?;
+    let vol = req_f64(args, "vol")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+    let is_payer = opt_bool(args, "is_payer", true)?;
+
+    let swaption = Swaption {
+        notional: 1.0,
+        strike,
+        option_expiry: maturity,
+        swap_tenor,
+        is_payer,
+    };
+
+    let price = swaption.price(&curve, vol);
+
+    let dk = (0.01 * strike.abs()).max(1.0e-6);
+    let dv = 0.01;
+    let dt = maturity.clamp(1.0e-6, 1.0 / 365.0);
+    let dr = 1.0e-4;
+
+    let mut up = swaption;
+    up.strike = strike + dk;
+    let mut dn = swaption;
+    dn.strike = (strike - dk).max(1.0e-8);
+    let p_up = up.price(&curve, vol);
+    let p_dn = dn.price(&curve, vol);
+    let delta = (p_up - p_dn) / (2.0 * dk);
+    let gamma = (p_up - 2.0 * price + p_dn) / (dk * dk);
+
+    let vega = (swaption.price(&curve, vol + dv) - swaption.price(&curve, (vol - dv).max(1.0e-8)))
+        / (2.0 * dv);
+
+    let mut t_short = swaption;
+    t_short.option_expiry = (maturity - dt).max(1.0e-8);
+    let theta = (t_short.price(&curve, vol) - price) / dt;
+
+    let curve_up = bump_curve_parallel(&curve, dr);
+    let curve_dn = bump_curve_parallel(&curve, -dr);
+    let rho = (swaption.price(&curve_up, vol) - swaption.price(&curve_dn, vol)) / (2.0 * dr);
+
+    Ok(json!({
+        "price": price,
+        "greeks": {
+            "delta": delta,
+            "gamma": gamma,
+            "vega": vega,
+            "theta": theta,
+            "rho": rho
+        }
+    }))
+}
+
+fn fra_price(args: &Value) -> ToolCallResult {
+    let start = req_f64(args, "start")?;
+    let end = req_f64(args, "end")?;
+    let fixed_rate = req_f64(args, "fixed_rate")?;
+    let notional = req_f64(args, "notional")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+
+    let base =
+        NaiveDate::from_ymd_opt(2026, 1, 1).ok_or_else(|| "invalid base date".to_string())?;
+    let fra = ForwardRateAgreement {
+        notional,
+        fixed_rate,
+        start_date: base + Duration::days((start * 365.0).round() as i64),
+        end_date: base + Duration::days((end * 365.0).round() as i64),
+        day_count: DayCountConvention::Act365Fixed,
+    };
+
+    Ok(json!({ "price": fra.npv(&curve) }))
+}
+
+fn cap_floor_price(args: &Value) -> ToolCallResult {
+    let strike = req_f64(args, "strike")?;
+    let maturity = req_f64(args, "maturity")?;
+    let freq = parse_frequency(req_str(args, "freq")?)?;
+    let vol = req_f64(args, "vol")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+    let is_cap = opt_bool(args, "is_cap", true)?;
+
+    let start =
+        NaiveDate::from_ymd_opt(2026, 1, 1).ok_or_else(|| "invalid base date".to_string())?;
+    let end = start + Duration::days((maturity * 365.0).round() as i64);
+
+    let instrument = CapFloor {
+        notional: 1.0,
+        strike,
+        start_date: start,
+        end_date: end,
+        frequency: freq,
+        day_count: DayCountConvention::Act365Fixed,
+        is_cap,
+    };
+
+    let price = instrument.price(&curve, vol);
+    let dv = 0.01;
+    let dr = 1.0e-4;
+
+    let vega = (instrument.price(&curve, vol + dv)
+        - instrument.price(&curve, (vol - dv).max(1.0e-8)))
+        / (2.0 * dv);
+
+    let curve_up = bump_curve_parallel(&curve, dr);
+    let curve_dn = bump_curve_parallel(&curve, -dr);
+    let rho = (instrument.price(&curve_up, vol) - instrument.price(&curve_dn, vol)) / (2.0 * dr);
+
+    Ok(json!({
+        "price": price,
+        "greeks": {
+            "delta": 0.0,
+            "gamma": 0.0,
+            "vega": vega,
+            "theta": 0.0,
+            "rho": rho
+        }
+    }))
+}
+
+fn ois_rate(args: &Value) -> ToolCallResult {
+    let maturity = req_f64(args, "maturity")?;
+    let curve = curve_from_value(super::req_value(args, "yield_curve")?)?;
+
+    let ois = OvernightIndexSwap {
+        notional: 1.0,
+        fixed_rate: 0.0,
+        float_spread: 0.0,
+        tenor: maturity,
+    };
+
+    let rate = ois.par_fixed_rate(&curve, &curve);
+    Ok(json!({ "rate": rate }))
+}
+
+fn day_count(args: &Value) -> ToolCallResult {
+    let start = parse_date(req_str(args, "start_date")?)?;
+    let end = parse_date(req_str(args, "end_date")?)?;
+    let convention = parse_day_count(req_str(args, "convention")?)?;
+
+    let fraction = openferric::rates::year_fraction(start, end, convention);
+    Ok(json!({ "fraction": fraction }))
+}
+
+fn schedule_generate(args: &Value) -> ToolCallResult {
+    let start = parse_date(req_str(args, "start")?)?;
+    let end = parse_date(req_str(args, "end")?)?;
+    let freq = parse_frequency(req_str(args, "freq")?)?;
+
+    let convention = opt_str(args, "convention")
+        .map(parse_business_day_convention)
+        .transpose()?
+        .unwrap_or(openferric::rates::BusinessDayConvention::ModifiedFollowing);
+
+    let config = ScheduleConfig {
+        calendar: Calendar::weekends_only(),
+        business_day_convention: convention,
+        stub_convention: openferric::rates::StubConvention::ShortBack,
+        roll_convention: openferric::rates::RollConvention::None,
+    };
+
+    let dates = generate_schedule_with_config(start, end, freq, &config)
+        .into_iter()
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .collect::<Vec<_>>();
+
+    Ok(json!({ "dates": dates }))
+}
+
+fn bump_curve_parallel(curve: &YieldCurve, bump: f64) -> YieldCurve {
+    let bumped = curve
+        .tenors
+        .iter()
+        .map(|(t, df)| {
+            let z = if *t > 0.0 { -df.ln() / *t } else { 0.0 };
+            (*t, (-(z + bump) * *t).exp())
+        })
+        .collect::<Vec<_>>();
+
+    YieldCurve::new(bumped)
+}

--- a/openferric-mcp/src/tools/risk.rs
+++ b/openferric-mcp/src/tools/risk.rs
@@ -1,0 +1,519 @@
+use openferric::core::Greeks;
+use openferric::pricing::european::black_scholes_price;
+use openferric::risk::{
+    Portfolio, Position, XvaCalculator, delta_normal_var, historical_expected_shortfall,
+    historical_var,
+};
+use serde_json::{Value, json};
+
+use super::{
+    ToolCallResult, ToolSpec, curve_from_value, obj, req_array, req_array_f64, req_f64, req_value,
+    survival_curve_from_value,
+};
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "var_historical",
+            description: "Historical VaR/CVaR/ES on return or PnL samples.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "returns": {"type":"array", "items": {"type":"number"}},
+                    "confidence": {"type":"number"},
+                    "horizon": {"type":"number"}
+                },
+                "required": ["returns", "confidence"]
+            }),
+        },
+        ToolSpec {
+            name: "var_parametric",
+            description: "Parametric Gaussian VaR from mean/std/confidence.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "mean": {"type":"number"},
+                    "std": {"type":"number"},
+                    "confidence": {"type":"number"},
+                    "horizon": {"type":"number"}
+                },
+                "required": ["mean", "std", "confidence"]
+            }),
+        },
+        ToolSpec {
+            name: "portfolio_risk",
+            description: "Aggregate portfolio Greeks and simple delta-normal VaR.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "positions": {"type":"array"},
+                    "market": {"type":"object"}
+                },
+                "required": ["positions", "market"]
+            }),
+        },
+        ToolSpec {
+            name: "scenario_analysis",
+            description: "Run Greek-based scenario PnL over scenario set.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "positions": {"type":"array"},
+                    "scenarios": {"type":"array"}
+                },
+                "required": ["positions", "scenarios"]
+            }),
+        },
+        ToolSpec {
+            name: "sensitivity_ladder",
+            description: "Price/delta ladder for a European option over spot bumps.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "instrument": {"type":"object"},
+                    "market": {"type":"object"},
+                    "bump_sizes": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["instrument", "market", "bump_sizes"]
+            }),
+        },
+        ToolSpec {
+            name: "cva",
+            description: "Compute CVA from exposure profile and survival curve.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "exposure_profile": {"type":"object"},
+                    "survival_curve": {"type":"object"},
+                    "recovery": {"type":"number"}
+                },
+                "required": ["exposure_profile", "survival_curve", "recovery"]
+            }),
+        },
+        ToolSpec {
+            name: "dva",
+            description: "Compute DVA from exposure profile and own survival curve.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "exposure_profile": {"type":"object"},
+                    "own_survival": {"type":"object"},
+                    "recovery": {"type":"number"}
+                },
+                "required": ["exposure_profile", "own_survival", "recovery"]
+            }),
+        },
+        ToolSpec {
+            name: "fva",
+            description: "Compute FVA from exposure profile and funding curve.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "exposure_profile": {"type":"object"},
+                    "funding_curve": {"type":"object"}
+                },
+                "required": ["exposure_profile", "funding_curve"]
+            }),
+        },
+        ToolSpec {
+            name: "xva_all",
+            description: "Compute CVA/DVA/FVA and total XVA.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "exposure_profile": {"type":"object"},
+                    "counterparty_curve": {"type":"object"},
+                    "own_curve": {"type":"object"},
+                    "funding_curve": {"type":"object"},
+                    "recovery": {"type":"number"}
+                },
+                "required": ["exposure_profile", "counterparty_curve", "own_curve", "funding_curve", "recovery"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "var_historical" => Some(var_historical(args)),
+        "var_parametric" => Some(var_parametric(args)),
+        "portfolio_risk" => Some(portfolio_risk(args)),
+        "scenario_analysis" => Some(scenario_analysis(args)),
+        "sensitivity_ladder" => Some(sensitivity_ladder(args)),
+        "cva" => Some(cva(args)),
+        "dva" => Some(dva(args)),
+        "fva" => Some(fva(args)),
+        "xva_all" => Some(xva_all(args)),
+        _ => None,
+    }
+}
+
+fn var_historical(args: &Value) -> ToolCallResult {
+    let returns = req_array_f64(args, "returns")?;
+    let confidence = req_f64(args, "confidence")?;
+    let horizon = super::opt_f64(args, "horizon", 1.0)?;
+
+    let var = historical_var(&returns, confidence) * horizon.sqrt();
+    let es = historical_expected_shortfall(&returns, confidence) * horizon.sqrt();
+
+    Ok(json!({
+        "var": var,
+        "cvar": es,
+        "es": es
+    }))
+}
+
+fn var_parametric(args: &Value) -> ToolCallResult {
+    let mean = req_f64(args, "mean")?;
+    let std = req_f64(args, "std")?;
+    let confidence = req_f64(args, "confidence")?;
+    let horizon = super::opt_f64(args, "horizon", 1.0)?;
+
+    let z = openferric::math::normal_inv_cdf(confidence);
+    let sigma_h = std.abs() * horizon.sqrt();
+    let var = (-mean * horizon + z * sigma_h).max(0.0);
+
+    Ok(json!({ "var": var }))
+}
+
+fn portfolio_risk(args: &Value) -> ToolCallResult {
+    let positions = parse_positions(req_value(args, "positions")?)?;
+    let market_obj = obj(req_value(args, "market")?, "market")?;
+    let annual_vol = market_obj
+        .get("annual_volatility")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.2);
+    let confidence = market_obj
+        .get("confidence")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.99);
+    let horizon = market_obj
+        .get("horizon")
+        .and_then(Value::as_f64)
+        .unwrap_or(1.0);
+
+    let portfolio = Portfolio::new(positions);
+    let total_delta = portfolio.total_delta();
+    let total_gamma = portfolio.total_gamma();
+    let total_vega = portfolio.total_vega();
+    let var = delta_normal_var(total_delta, annual_vol, confidence, horizon);
+
+    Ok(json!({
+        "total_delta": total_delta,
+        "total_gamma": total_gamma,
+        "total_vega": total_vega,
+        "var": var
+    }))
+}
+
+fn scenario_analysis(args: &Value) -> ToolCallResult {
+    let positions = parse_positions(req_value(args, "positions")?)?;
+    let scenarios = req_array(args, "scenarios")?;
+
+    let portfolio = Portfolio::new(positions);
+    let agg = portfolio.aggregate_greeks();
+
+    let rows = scenarios
+        .iter()
+        .map(|scenario| {
+            let s = scenario
+                .as_object()
+                .ok_or_else(|| "scenario entries must be objects".to_string())?;
+            let name = s
+                .get("scenario")
+                .or_else(|| s.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("scenario")
+                .to_string();
+            let spot_shock = s
+                .get("spot_shock_pct")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let vol_shock = s
+                .get("vol_shock_pct")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let horizon = s
+                .get("horizon_years")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+
+            let pnl = portfolio.scenario_pnl_with_horizon(spot_shock, vol_shock, horizon);
+            Ok(json!({
+                "scenario": name,
+                "pnl": pnl,
+                "greeks": {
+                    "delta": agg.delta,
+                    "gamma": agg.gamma,
+                    "vega": agg.vega,
+                    "theta": agg.theta
+                }
+            }))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    Ok(Value::Array(rows))
+}
+
+fn sensitivity_ladder(args: &Value) -> ToolCallResult {
+    let instrument = obj(req_value(args, "instrument")?, "instrument")?;
+    let bump_sizes = req_array_f64(args, "bump_sizes")?;
+
+    let spot = instrument
+        .get("spot")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| "instrument.spot must be numeric".to_string())?;
+    let strike = instrument
+        .get("strike")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| "instrument.strike must be numeric".to_string())?;
+    let rate = instrument
+        .get("rate")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| "instrument.rate must be numeric".to_string())?;
+    let vol = instrument
+        .get("vol")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| "instrument.vol must be numeric".to_string())?;
+    let time = instrument
+        .get("time")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| "instrument.time must be numeric".to_string())?;
+    let is_call = instrument
+        .get("is_call")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
+    let option_type = if is_call {
+        openferric::core::OptionType::Call
+    } else {
+        openferric::core::OptionType::Put
+    };
+
+    let ladder = bump_sizes
+        .iter()
+        .map(|bump| {
+            let bumped_spot = (spot * (1.0 + bump)).max(1.0e-8);
+            let price = black_scholes_price(option_type, bumped_spot, strike, rate, vol, time);
+
+            let ds = (0.01 * bumped_spot).max(1.0e-6);
+            let p_up = black_scholes_price(option_type, bumped_spot + ds, strike, rate, vol, time);
+            let p_dn = black_scholes_price(
+                option_type,
+                (bumped_spot - ds).max(1.0e-8),
+                strike,
+                rate,
+                vol,
+                time,
+            );
+            let delta = (p_up - p_dn) / (2.0 * ds);
+
+            json!({ "bump": bump, "price": price, "delta": delta })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Value::Array(ladder))
+}
+
+fn cva(args: &Value) -> ToolCallResult {
+    let (times, values) = parse_profile(req_value(args, "exposure_profile")?)?;
+    let curve = survival_curve_from_value(req_value(args, "survival_curve")?)?;
+    let recovery = req_f64(args, "recovery")?;
+
+    let discount = unit_discount_curve(&times);
+    let calc = XvaCalculator::new(
+        discount,
+        curve.clone(),
+        curve,
+        (1.0 - recovery).clamp(0.0, 1.0),
+        (1.0 - recovery).clamp(0.0, 1.0),
+    );
+
+    Ok(json!({ "cva": calc.cva_from_expected_exposure(&times, &values) }))
+}
+
+fn dva(args: &Value) -> ToolCallResult {
+    let (times, values) = parse_profile(req_value(args, "exposure_profile")?)?;
+    let own_curve = survival_curve_from_value(req_value(args, "own_survival")?)?;
+    let recovery = req_f64(args, "recovery")?;
+
+    let discount = unit_discount_curve(&times);
+    let calc = XvaCalculator::new(
+        discount,
+        own_curve.clone(),
+        own_curve,
+        (1.0 - recovery).clamp(0.0, 1.0),
+        (1.0 - recovery).clamp(0.0, 1.0),
+    );
+
+    Ok(json!({ "dva": calc.dva_from_negative_expected_exposure(&times, &values) }))
+}
+
+fn fva(args: &Value) -> ToolCallResult {
+    let (times, values) = parse_profile(req_value(args, "exposure_profile")?)?;
+    let funding_curve = curve_from_value(req_value(args, "funding_curve")?)?;
+
+    let spreads = times
+        .iter()
+        .map(|t| funding_curve.zero_rate(*t).max(0.0))
+        .collect::<Vec<_>>();
+
+    let fva_value = openferric::risk::fva_from_profile(&times, &values, &spreads, &funding_curve);
+    Ok(json!({ "fva": fva_value }))
+}
+
+fn xva_all(args: &Value) -> ToolCallResult {
+    let (times, values) = parse_profile(req_value(args, "exposure_profile")?)?;
+    let counterparty = survival_curve_from_value(req_value(args, "counterparty_curve")?)?;
+    let own = survival_curve_from_value(req_value(args, "own_curve")?)?;
+    let funding_curve = curve_from_value(req_value(args, "funding_curve")?)?;
+    let recovery = req_f64(args, "recovery")?;
+
+    let discount = unit_discount_curve(&times);
+    let lgd = (1.0 - recovery).clamp(0.0, 1.0);
+    let calc = XvaCalculator::new(discount, counterparty, own, lgd, lgd);
+
+    let cva = calc.cva_from_expected_exposure(&times, &values);
+    let dva = calc.dva_from_negative_expected_exposure(&times, &values);
+    let spreads = times
+        .iter()
+        .map(|t| funding_curve.zero_rate(*t).max(0.0))
+        .collect::<Vec<_>>();
+    let fva = openferric::risk::fva_from_profile(&times, &values, &spreads, &funding_curve);
+
+    Ok(json!({
+        "cva": cva,
+        "dva": dva,
+        "fva": fva,
+        "total": cva + dva + fva
+    }))
+}
+
+fn parse_positions(value: &Value) -> Result<Vec<Position<String>>, String> {
+    let arr = value
+        .as_array()
+        .ok_or_else(|| "positions must be an array".to_string())?;
+
+    let mut out = Vec::with_capacity(arr.len());
+    for (i, p) in arr.iter().enumerate() {
+        let obj_map = p
+            .as_object()
+            .ok_or_else(|| "position entries must be objects".to_string())?;
+
+        let quantity = obj_map
+            .get("quantity")
+            .and_then(Value::as_f64)
+            .unwrap_or(1.0);
+        let spot = obj_map.get("spot").and_then(Value::as_f64).unwrap_or(100.0);
+        let implied_vol = obj_map
+            .get("implied_vol")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.2);
+
+        let greeks_obj = obj_map
+            .get("greeks")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        let delta = greeks_obj
+            .get("delta")
+            .and_then(Value::as_f64)
+            .or_else(|| obj_map.get("delta").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+        let gamma = greeks_obj
+            .get("gamma")
+            .and_then(Value::as_f64)
+            .or_else(|| obj_map.get("gamma").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+        let vega = greeks_obj
+            .get("vega")
+            .and_then(Value::as_f64)
+            .or_else(|| obj_map.get("vega").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+        let theta = greeks_obj
+            .get("theta")
+            .and_then(Value::as_f64)
+            .or_else(|| obj_map.get("theta").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+        let rho = greeks_obj
+            .get("rho")
+            .and_then(Value::as_f64)
+            .or_else(|| obj_map.get("rho").and_then(Value::as_f64))
+            .unwrap_or(0.0);
+
+        let greeks = Greeks {
+            delta,
+            gamma,
+            vega,
+            theta,
+            rho,
+        };
+
+        out.push(Position::new(
+            format!("position_{i}"),
+            quantity,
+            greeks,
+            spot,
+            implied_vol,
+        ));
+    }
+
+    Ok(out)
+}
+
+fn parse_profile(value: &Value) -> Result<(Vec<f64>, Vec<f64>), String> {
+    if let Some(obj_map) = value.as_object() {
+        let times = obj_map
+            .get("times")
+            .or_else(|| obj_map.get("tenors"))
+            .and_then(Value::as_array)
+            .ok_or_else(|| "exposure_profile.times must be an array".to_string())?
+            .iter()
+            .map(|v| {
+                v.as_f64()
+                    .ok_or_else(|| "exposure times must be numeric".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let values = obj_map
+            .get("values")
+            .or_else(|| obj_map.get("exposures"))
+            .and_then(Value::as_array)
+            .ok_or_else(|| "exposure_profile.values must be an array".to_string())?
+            .iter()
+            .map(|v| {
+                v.as_f64()
+                    .ok_or_else(|| "exposure values must be numeric".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if times.len() != values.len() {
+            return Err("exposure times/values length mismatch".to_string());
+        }
+
+        return Ok((times, values));
+    }
+
+    if let Some(values_arr) = value.as_array() {
+        let values = values_arr
+            .iter()
+            .map(|v| {
+                v.as_f64()
+                    .ok_or_else(|| "exposure profile values must be numeric".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let times = (1..=values.len()).map(|i| i as f64).collect::<Vec<_>>();
+        return Ok((times, values));
+    }
+
+    Err("exposure_profile must be an object with times/values or a numeric array".to_string())
+}
+
+fn unit_discount_curve(times: &[f64]) -> openferric::rates::YieldCurve {
+    let points = times
+        .iter()
+        .map(|t| (t.max(1.0e-8), 1.0))
+        .collect::<Vec<_>>();
+    openferric::rates::YieldCurve::new(points)
+}

--- a/openferric-mcp/src/tools/vol.rs
+++ b/openferric-mcp/src/tools/vol.rs
@@ -1,0 +1,540 @@
+use openferric::core::OptionType;
+use openferric::vol::arbitrage::ArbitrageViolation;
+use openferric::vol::fengler::FenglerSurface;
+use openferric::vol::forward::{ForwardVarianceCurve, ForwardVarianceSource};
+use openferric::vol::implied::implied_vol;
+use openferric::vol::local_vol::{ImpliedVolSurface as LocalVolSurface, dupire_local_vol};
+use openferric::vol::sabr::fit_sabr;
+use openferric::vol::surface::{SviParams, calibrate_svi};
+use serde_json::{Value, json};
+
+use super::{
+    ToolCallResult, ToolSpec, obj, opt_f64, req_array_f64, req_f64, req_matrix_f64, req_value,
+};
+
+#[derive(Debug, Clone)]
+struct SimpleSurface {
+    forward: f64,
+    strikes: Vec<f64>,
+    expiries: Vec<f64>,
+    vols: Vec<Vec<f64>>,
+}
+
+impl SimpleSurface {
+    fn vol_at(&self, strike: f64, expiry: f64) -> f64 {
+        let (ei0, ei1, ew) = locate_bounds(&self.expiries, expiry);
+        let (si0, si1, sw) = locate_bounds(&self.strikes, strike);
+
+        if ei0 == ei1 && si0 == si1 {
+            return self.vols[ei0][si0];
+        }
+        if ei0 == ei1 {
+            let v0 = self.vols[ei0][si0];
+            let v1 = self.vols[ei0][si1];
+            return v0 + (v1 - v0) * sw;
+        }
+        if si0 == si1 {
+            let v0 = self.vols[ei0][si0];
+            let v1 = self.vols[ei1][si0];
+            return v0 + (v1 - v0) * ew;
+        }
+
+        let v00 = self.vols[ei0][si0];
+        let v01 = self.vols[ei0][si1];
+        let v10 = self.vols[ei1][si0];
+        let v11 = self.vols[ei1][si1];
+
+        let v0 = v00 + (v01 - v00) * sw;
+        let v1 = v10 + (v11 - v10) * sw;
+        v0 + (v1 - v0) * ew
+    }
+}
+
+impl LocalVolSurface for SimpleSurface {
+    fn implied_vol(&self, strike: f64, expiry: f64) -> f64 {
+        self.vol_at(strike, expiry)
+    }
+}
+
+impl ForwardVarianceSource for SimpleSurface {
+    fn implied_vol(&self, strike: f64, expiry: f64) -> f64 {
+        self.vol_at(strike, expiry)
+    }
+
+    fn forward_price(&self, _expiry: f64) -> f64 {
+        self.forward
+    }
+
+    fn expiries(&self) -> &[f64] {
+        &self.expiries
+    }
+}
+
+pub fn specs() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "implied_vol_calc",
+            description: "Compute Black-Scholes implied volatility from option price.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "price": {"type":"number"},
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "rate": {"type":"number"},
+                    "time": {"type":"number"},
+                    "is_call": {"type":"boolean"}
+                },
+                "required": ["price","spot","strike","rate","time","is_call"]
+            }),
+        },
+        ToolSpec {
+            name: "vol_surface_build",
+            description: "Build a volatility surface JSON payload from strike/expiry vol grid.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "expiries": {"type":"array", "items": {"type":"number"}},
+                    "vols": {"type":"array"},
+                    "forward": {"type":"number"}
+                },
+                "required": ["strikes","expiries","vols"]
+            }),
+        },
+        ToolSpec {
+            name: "sabr_calibrate",
+            description: "Calibrate SABR parameters to a strike-vol slice.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "forward": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "vols": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["forward","expiry","strikes","vols"]
+            }),
+        },
+        ToolSpec {
+            name: "svi_calibrate",
+            description: "Calibrate SVI parameters to a strike-vol slice.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "forward": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "strikes": {"type":"array", "items": {"type":"number"}},
+                    "vols": {"type":"array", "items": {"type":"number"}}
+                },
+                "required": ["forward","expiry","strikes","vols"]
+            }),
+        },
+        ToolSpec {
+            name: "local_vol",
+            description: "Compute Dupire local vol from a surface JSON.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "spot": {"type":"number"},
+                    "strike": {"type":"number"},
+                    "expiry": {"type":"number"},
+                    "surface": {"type":"object"}
+                },
+                "required": ["spot","strike","expiry","surface"]
+            }),
+        },
+        ToolSpec {
+            name: "forward_vol",
+            description: "Compute forward vol between two maturities from a surface.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "t1": {"type":"number"},
+                    "t2": {"type":"number"},
+                    "surface": {"type":"object"}
+                },
+                "required": ["t1","t2","surface"]
+            }),
+        },
+        ToolSpec {
+            name: "vol_smile",
+            description: "Extract smile points at a given expiry from a surface.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "expiry": {"type":"number"},
+                    "surface": {"type":"object"}
+                },
+                "required": ["expiry","surface"]
+            }),
+        },
+        ToolSpec {
+            name: "vol_arbitrage_check",
+            description: "Run static-arbitrage diagnostics on a surface.",
+            input_schema: json!({
+                "type":"object",
+                "properties": {
+                    "surface": {"type":"object"}
+                },
+                "required": ["surface"]
+            }),
+        },
+    ]
+}
+
+pub fn call(name: &str, args: &Value) -> Option<ToolCallResult> {
+    match name {
+        "implied_vol_calc" => Some(implied_vol_calc(args)),
+        "vol_surface_build" => Some(vol_surface_build(args)),
+        "sabr_calibrate" => Some(sabr_calibrate(args)),
+        "svi_calibrate" => Some(svi_calibrate(args)),
+        "local_vol" => Some(local_vol_tool(args)),
+        "forward_vol" => Some(forward_vol_tool(args)),
+        "vol_smile" => Some(vol_smile_tool(args)),
+        "vol_arbitrage_check" => Some(vol_arbitrage_check(args)),
+        _ => None,
+    }
+}
+
+fn implied_vol_calc(args: &Value) -> ToolCallResult {
+    let price = req_f64(args, "price")?;
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let rate = req_f64(args, "rate")?;
+    let time = req_f64(args, "time")?;
+    let is_call = super::req_bool(args, "is_call")?;
+
+    let iv = implied_vol(
+        if is_call {
+            OptionType::Call
+        } else {
+            OptionType::Put
+        },
+        spot,
+        strike,
+        rate,
+        time,
+        price,
+        1.0e-10,
+        128,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(json!({ "iv": iv }))
+}
+
+fn vol_surface_build(args: &Value) -> ToolCallResult {
+    let strikes = req_array_f64(args, "strikes")?;
+    let expiries = req_array_f64(args, "expiries")?;
+    let vols = req_matrix_f64(args, "vols")?;
+    let forward = opt_f64(args, "forward", strikes[strikes.len() / 2])?;
+
+    validate_grid(&strikes, &expiries, &vols)?;
+
+    let mut svi_slices = Vec::with_capacity(expiries.len());
+    for (i, t) in expiries.iter().enumerate() {
+        let row = &vols[i];
+        let points = strikes
+            .iter()
+            .zip(row.iter())
+            .map(|(k, v)| ((k / forward).ln(), v * v * t.max(1.0e-10)))
+            .collect::<Vec<_>>();
+
+        let init = SviParams {
+            a: 0.01,
+            b: 0.2,
+            rho: -0.2,
+            m: 0.0,
+            sigma: 0.3,
+        };
+        let fit = calibrate_svi(&points, init, 200, 0.0);
+
+        svi_slices.push(json!({
+            "expiry": t,
+            "a": fit.a,
+            "b": fit.b,
+            "rho": fit.rho,
+            "m": fit.m,
+            "sigma": fit.sigma
+        }));
+    }
+
+    Ok(json!({
+        "surface_json": {
+            "forward": forward,
+            "strikes": strikes,
+            "expiries": expiries,
+            "vols": vols,
+            "svi_slices": svi_slices
+        }
+    }))
+}
+
+fn sabr_calibrate(args: &Value) -> ToolCallResult {
+    let forward = req_f64(args, "forward")?;
+    let expiry = req_f64(args, "expiry")?;
+    let strikes = req_array_f64(args, "strikes")?;
+    let vols = req_array_f64(args, "vols")?;
+
+    if strikes.len() != vols.len() || strikes.is_empty() {
+        return Err("strikes and vols must be non-empty and have equal length".to_string());
+    }
+
+    let params = fit_sabr(forward, &strikes, &vols, expiry, 0.5);
+    let mse = strikes
+        .iter()
+        .zip(vols.iter())
+        .map(|(k, v)| {
+            let e = params.implied_vol(forward, *k, expiry) - *v;
+            e * e
+        })
+        .sum::<f64>()
+        / strikes.len() as f64;
+
+    Ok(json!({
+        "alpha": params.alpha,
+        "beta": params.beta,
+        "rho": params.rho,
+        "nu": params.nu,
+        "fit_error": mse.sqrt()
+    }))
+}
+
+fn svi_calibrate(args: &Value) -> ToolCallResult {
+    let forward = req_f64(args, "forward")?;
+    let expiry = req_f64(args, "expiry")?;
+    let strikes = req_array_f64(args, "strikes")?;
+    let vols = req_array_f64(args, "vols")?;
+
+    if strikes.len() != vols.len() || strikes.is_empty() {
+        return Err("strikes and vols must be non-empty and have equal length".to_string());
+    }
+
+    let points = strikes
+        .iter()
+        .zip(vols.iter())
+        .map(|(k, v)| ((k / forward).ln(), v * v * expiry.max(1.0e-10)))
+        .collect::<Vec<_>>();
+
+    let init = SviParams {
+        a: 0.01,
+        b: 0.2,
+        rho: -0.2,
+        m: 0.0,
+        sigma: 0.25,
+    };
+    let fit = calibrate_svi(&points, init, 250, 0.0);
+
+    let mse = points
+        .iter()
+        .map(|(k, w)| {
+            let e = fit.total_variance(*k) - *w;
+            e * e
+        })
+        .sum::<f64>()
+        / points.len() as f64;
+
+    Ok(json!({
+        "a": fit.a,
+        "b": fit.b,
+        "rho": fit.rho,
+        "m": fit.m,
+        "sigma": fit.sigma,
+        "fit_error": mse.sqrt()
+    }))
+}
+
+fn local_vol_tool(args: &Value) -> ToolCallResult {
+    let spot = req_f64(args, "spot")?;
+    let strike = req_f64(args, "strike")?;
+    let expiry = req_f64(args, "expiry")?;
+    let surface = parse_surface(req_value(args, "surface")?, Some(spot))?;
+
+    let lv = dupire_local_vol(surface.clone(), surface.forward.max(1.0e-8), strike, expiry);
+    Ok(json!({ "local_vol": lv }))
+}
+
+fn forward_vol_tool(args: &Value) -> ToolCallResult {
+    let t1 = req_f64(args, "t1")?;
+    let t2 = req_f64(args, "t2")?;
+    let surface = parse_surface(req_value(args, "surface")?, None)?;
+
+    let fvc = ForwardVarianceCurve::from_surface(&surface, &surface.expiries)
+        .map_err(|e| e.to_string())?;
+    let fv = fvc.forward_vol(t1, t2).map_err(|e| e.to_string())?;
+
+    Ok(json!({ "forward_vol": fv }))
+}
+
+fn vol_smile_tool(args: &Value) -> ToolCallResult {
+    let expiry = req_f64(args, "expiry")?;
+    let surface = parse_surface(req_value(args, "surface")?, None)?;
+
+    let vols = surface
+        .strikes
+        .iter()
+        .map(|k| surface.vol_at(*k, expiry))
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "strikes": surface.strikes,
+        "vols": vols
+    }))
+}
+
+fn vol_arbitrage_check(args: &Value) -> ToolCallResult {
+    let surface = parse_surface(req_value(args, "surface")?, None)?;
+
+    let mut quotes = Vec::new();
+    for (ei, t) in surface.expiries.iter().enumerate() {
+        for (si, k) in surface.strikes.iter().enumerate() {
+            quotes.push((*k, *t, surface.vols[ei][si]));
+        }
+    }
+
+    let forwards = surface
+        .expiries
+        .iter()
+        .map(|t| (*t, surface.forward_price(*t)))
+        .collect::<Vec<_>>();
+
+    let fengler = FenglerSurface::new(&quotes, &forwards);
+    let violations = fengler.check_arbitrage();
+
+    let details = violations
+        .iter()
+        .map(arbitrage_violation_to_json)
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "has_arbitrage": !violations.is_empty(),
+        "details": details
+    }))
+}
+
+fn parse_surface(value: &Value, forward_fallback: Option<f64>) -> Result<SimpleSurface, String> {
+    let obj_map = obj(value, "surface")?;
+
+    let strikes = obj_map
+        .get("strikes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.strikes must be an array".to_string())?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| "surface.strikes must be numeric".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let expiries = obj_map
+        .get("expiries")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.expiries must be an array".to_string())?
+        .iter()
+        .map(|v| {
+            v.as_f64()
+                .ok_or_else(|| "surface.expiries must be numeric".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let vols = obj_map
+        .get("vols")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "surface.vols must be a 2D array".to_string())?
+        .iter()
+        .map(|row| {
+            row.as_array()
+                .ok_or_else(|| "surface.vols must be a 2D array".to_string())?
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .ok_or_else(|| "surface.vols entries must be numeric".to_string())
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    validate_grid(&strikes, &expiries, &vols)?;
+
+    let forward = obj_map
+        .get("forward")
+        .and_then(Value::as_f64)
+        .or(forward_fallback)
+        .unwrap_or_else(|| strikes[strikes.len() / 2]);
+
+    Ok(SimpleSurface {
+        forward: forward.max(1.0e-8),
+        strikes,
+        expiries,
+        vols,
+    })
+}
+
+fn validate_grid(strikes: &[f64], expiries: &[f64], vols: &[Vec<f64>]) -> Result<(), String> {
+    if strikes.is_empty() || expiries.is_empty() {
+        return Err("surface strike/expiry grids cannot be empty".to_string());
+    }
+    if strikes.windows(2).any(|w| w[1] <= w[0]) {
+        return Err("surface strikes must be strictly increasing".to_string());
+    }
+    if expiries.windows(2).any(|w| w[1] <= w[0]) {
+        return Err("surface expiries must be strictly increasing".to_string());
+    }
+    if vols.len() != expiries.len() {
+        return Err("surface vols row count must match expiries".to_string());
+    }
+    if vols.iter().any(|row| row.len() != strikes.len()) {
+        return Err("surface vol row length must match strikes".to_string());
+    }
+    Ok(())
+}
+
+fn locate_bounds(grid: &[f64], x: f64) -> (usize, usize, f64) {
+    if x <= grid[0] {
+        return (0, 0, 0.0);
+    }
+    let last = grid.len() - 1;
+    if x >= grid[last] {
+        return (last, last, 0.0);
+    }
+
+    let mut lo = 0usize;
+    for i in 0..last {
+        if x >= grid[i] && x <= grid[i + 1] {
+            lo = i;
+            break;
+        }
+    }
+
+    let hi = lo + 1;
+    let w = (x - grid[lo]) / (grid[hi] - grid[lo]);
+    (lo, hi, w)
+}
+
+fn arbitrage_violation_to_json(v: &ArbitrageViolation) -> Value {
+    match v {
+        ArbitrageViolation::Butterfly {
+            strike,
+            expiry,
+            density,
+        } => json!({
+            "type": "butterfly",
+            "strike": strike,
+            "expiry": expiry,
+            "metric": density
+        }),
+        ArbitrageViolation::Calendar {
+            strike,
+            t1,
+            t2,
+            dw_dt,
+        } => json!({
+            "type": "calendar",
+            "strike": strike,
+            "t1": t1,
+            "t2": t2,
+            "metric": dw_dt
+        }),
+    }
+}


### PR DESCRIPTION
Comprehensive MCP server covering the entire OpenFerric library: DSL, pricing, rates, credit, vol, calibration, risk/XVA, models, live market data, math. +4,598 lines, 12 source files. Closes #113.