### PR TITLE
Optimize DSL Monte Carlo runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ name = "mc_bench"
 harness = false
 
 [[bench]]
+name = "dsl_bench"
+harness = false
+
+[[bench]]
 name = "interpolation_bench"
 harness = false
 

--- a/benches/dsl_bench.rs
+++ b/benches/dsl_bench.rs
@@ -1,0 +1,103 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use openferric::dsl::{AssetMarketData, DslMonteCarloEngine, MultiAssetMarket, parse_and_compile};
+use std::fs;
+use std::hint::black_box;
+use std::path::PathBuf;
+
+fn load_example(name: &str) -> String {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = root.join("examples").join("dsl").join(name);
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+}
+
+fn single_asset_market() -> MultiAssetMarket {
+    MultiAssetMarket::single(100.0, 0.20, 0.05, 0.02)
+}
+
+fn three_asset_market() -> MultiAssetMarket {
+    MultiAssetMarket {
+        assets: vec![
+            AssetMarketData::Equity {
+                spot: 100.0,
+                vol: 0.20,
+                dividend_yield: 0.02,
+            },
+            AssetMarketData::Equity {
+                spot: 100.0,
+                vol: 0.22,
+                dividend_yield: 0.03,
+            },
+            AssetMarketData::Equity {
+                spot: 100.0,
+                vol: 0.25,
+                dividend_yield: 0.01,
+            },
+        ],
+        correlation: vec![
+            vec![1.0, 0.7, 0.5],
+            vec![0.7, 1.0, 0.6],
+            vec![0.5, 0.6, 1.0],
+        ],
+        rate: 0.03,
+    }
+}
+
+fn bench_dsl_parse_compile(c: &mut Criterion) {
+    let zero_coupon = load_example("01_zero_coupon.of");
+    let autocall = load_example("06_autocallable_worst_of.of");
+    let mut group = c.benchmark_group("dsl_parse_compile");
+
+    for (name, source) in [
+        ("zero_coupon", zero_coupon.as_str()),
+        ("worst_of_autocall", autocall.as_str()),
+    ] {
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let product =
+                    parse_and_compile(black_box(source)).expect("DSL parse/compile should succeed");
+                black_box(product.schedules.len())
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_dsl_price(c: &mut Criterion) {
+    let zero_coupon =
+        parse_and_compile(&load_example("01_zero_coupon.of")).expect("zero coupon should compile");
+    let autocall = parse_and_compile(&load_example("06_autocallable_worst_of.of"))
+        .expect("autocall should compile");
+    let single_market = single_asset_market();
+    let basket_market = three_asset_market();
+    let mut group = c.benchmark_group("dsl_price");
+    group.sample_size(10);
+
+    for (name, product, market, paths, steps) in [
+        (
+            "zero_coupon",
+            &zero_coupon,
+            &single_market,
+            20_000usize,
+            100usize,
+        ),
+        ("autocall", &autocall, &basket_market, 20_000usize, 100usize),
+        ("autocall", &autocall, &basket_market, 50_000usize, 252usize),
+    ] {
+        let engine = DslMonteCarloEngine::new(paths, steps, 42);
+        let case = format!("{paths}p_{steps}s");
+        group.bench_with_input(BenchmarkId::new(name, case), &engine, |b, engine| {
+            b.iter(|| {
+                let result = engine
+                    .price_multi_asset(black_box(product), black_box(market))
+                    .expect("DSL pricing should succeed");
+                black_box(result.price)
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(dsl_benches, bench_dsl_parse_compile, bench_dsl_price);
+criterion_main!(dsl_benches);

--- a/src/dsl/engine.rs
+++ b/src/dsl/engine.rs
@@ -5,14 +5,22 @@
 use crate::core::{
     DiagKey, Diagnostics, Greeks, Instrument, PricingEngine, PricingError, PricingResult,
 };
-use crate::dsl::eval::evaluate_product;
-use crate::dsl::ir::CompiledProduct;
+use crate::dsl::eval::{
+    ProductExecutionPlan, build_execution_plan, evaluate_product_with_plan_in_place,
+};
+use crate::dsl::ir::{CompiledProduct, Value};
 use crate::dsl::market::{AssetMarketData, MultiAssetMarket};
 use crate::engines::monte_carlo::correlated_mc::{
-    cholesky_for_correlation, sample_correlated_normals_cholesky,
+    cholesky_for_correlation, sample_correlated_normals_cholesky_with_scratch,
 };
 use crate::market::Market;
 use crate::math::fast_rng::{FastRng, FastRngKind};
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+use crate::math::simd_math::{fast_exp_f64x4, ln_f64x4, load_f64x4, store_f64x4};
+#[cfg(all(feature = "simd", target_arch = "aarch64"))]
+use crate::math::simd_neon::{load_f64x2, simd_exp_f64x2, simd_ln_f64x2, store_f64x2};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 /// Per-asset stepping strategy for path generation.
 ///
@@ -61,12 +69,7 @@ impl AssetStepper {
                     diffusion: vol * sqrt_dt,
                 }
             }
-            AssetMarketData::Commodity {
-                vol,
-                kappa,
-                mu,
-                ..
-            } => Self::SchwartzOneF {
+            AssetMarketData::Commodity { vol, kappa, mu, .. } => Self::SchwartzOneF {
                 long_run_log_mean: *mu,
                 exp_neg_kappa_dt: (-kappa * dt).exp(),
                 vol_step: vol * sqrt_dt,
@@ -96,9 +99,9 @@ impl AssetStepper {
             } => {
                 // Schwartz 1-factor: d(ln S) = κ(μ - ln S) dt + σ dW
                 let log_prev = prev.ln();
-                let log_next =
-                    long_run_log_mean + exp_neg_kappa_dt * (log_prev - long_run_log_mean)
-                        + vol_step * z;
+                let log_next = long_run_log_mean
+                    + exp_neg_kappa_dt * (log_prev - long_run_log_mean)
+                    + vol_step * z;
                 log_next.exp()
             }
             Self::Vasicek {
@@ -110,6 +113,100 @@ impl AssetStepper {
                 long_run_mean + exp_neg_a_dt * (prev - long_run_mean) + vol_step * z
             }
         }
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,fma")]
+    unsafe fn step_batch_x86(self, prev: &[f64; 4], z: &[f64; 4], next: &mut [f64; 4]) {
+        use std::arch::x86_64::*;
+
+        let prev_v = unsafe { load_f64x4(prev, 0) };
+        let z_v = unsafe { _mm256_loadu_pd(z.as_ptr()) };
+
+        let next_v = unsafe {
+            match self {
+                Self::Gbm { drift, diffusion } => {
+                    let drift_v = _mm256_set1_pd(drift);
+                    let diffusion_v = _mm256_set1_pd(diffusion);
+                    let exponent = _mm256_fmadd_pd(diffusion_v, z_v, drift_v);
+                    let growth = fast_exp_f64x4(exponent);
+                    _mm256_mul_pd(prev_v, growth)
+                }
+                Self::SchwartzOneF {
+                    long_run_log_mean,
+                    exp_neg_kappa_dt,
+                    vol_step,
+                } => {
+                    let mean_v = _mm256_set1_pd(long_run_log_mean);
+                    let revert_v = _mm256_set1_pd(exp_neg_kappa_dt);
+                    let vol_v = _mm256_set1_pd(vol_step);
+                    let log_prev = ln_f64x4(prev_v);
+                    let reverted =
+                        _mm256_fmadd_pd(revert_v, _mm256_sub_pd(log_prev, mean_v), mean_v);
+                    let log_next = _mm256_fmadd_pd(vol_v, z_v, reverted);
+                    fast_exp_f64x4(log_next)
+                }
+                Self::Vasicek {
+                    long_run_mean,
+                    exp_neg_a_dt,
+                    vol_step,
+                } => {
+                    let mean_v = _mm256_set1_pd(long_run_mean);
+                    let revert_v = _mm256_set1_pd(exp_neg_a_dt);
+                    let vol_v = _mm256_set1_pd(vol_step);
+                    let reverted = _mm256_fmadd_pd(revert_v, _mm256_sub_pd(prev_v, mean_v), mean_v);
+                    _mm256_fmadd_pd(vol_v, z_v, reverted)
+                }
+            }
+        };
+
+        unsafe { store_f64x4(next, 0, next_v) };
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+    unsafe fn step_batch_neon(self, prev: &[f64; 2], z: &[f64; 2], next: &mut [f64; 2]) {
+        use std::arch::aarch64::*;
+
+        let prev_v = unsafe { load_f64x2(prev, 0) };
+        let z_v = unsafe { vld1q_f64(z.as_ptr()) };
+
+        let next_v = unsafe {
+            match self {
+                Self::Gbm { drift, diffusion } => {
+                    let drift_v = vdupq_n_f64(drift);
+                    let diffusion_v = vdupq_n_f64(diffusion);
+                    let exponent = vfmaq_f64(drift_v, diffusion_v, z_v);
+                    let growth = simd_exp_f64x2(exponent);
+                    vmulq_f64(prev_v, growth)
+                }
+                Self::SchwartzOneF {
+                    long_run_log_mean,
+                    exp_neg_kappa_dt,
+                    vol_step,
+                } => {
+                    let mean_v = vdupq_n_f64(long_run_log_mean);
+                    let revert_v = vdupq_n_f64(exp_neg_kappa_dt);
+                    let vol_v = vdupq_n_f64(vol_step);
+                    let log_prev = simd_ln_f64x2(prev_v);
+                    let reverted = vfmaq_f64(mean_v, revert_v, vsubq_f64(log_prev, mean_v));
+                    let log_next = vfmaq_f64(reverted, vol_v, z_v);
+                    simd_exp_f64x2(log_next)
+                }
+                Self::Vasicek {
+                    long_run_mean,
+                    exp_neg_a_dt,
+                    vol_step,
+                } => {
+                    let mean_v = vdupq_n_f64(long_run_mean);
+                    let revert_v = vdupq_n_f64(exp_neg_a_dt);
+                    let vol_v = vdupq_n_f64(vol_step);
+                    let reverted = vfmaq_f64(mean_v, revert_v, vsubq_f64(prev_v, mean_v));
+                    vfmaq_f64(reverted, vol_v, z_v)
+                }
+            }
+        };
+
+        unsafe { store_f64x2(next, 0, next_v) };
     }
 }
 
@@ -174,7 +271,6 @@ impl DslMonteCarloEngine {
             ));
         }
 
-        let n_assets = market.assets.len();
         let n_steps = self.num_steps;
         let dt = product.maturity / n_steps as f64;
 
@@ -182,6 +278,9 @@ impl DslMonteCarloEngine {
         let (chol, _) = cholesky_for_correlation(&market.correlation)?;
 
         let initial_spots = market.initial_spots();
+        let num_locals = product.max_local_slots();
+        let execution_plan = build_execution_plan(product, n_steps, market.rate)
+            .map_err(|e| PricingError::NumericalError(e.to_string()))?;
 
         // Build per-asset steppers.
         let steppers: Vec<AssetStepper> = market
@@ -190,41 +289,44 @@ impl DslMonteCarloEngine {
             .map(|a| AssetStepper::from_asset(a, market.rate, dt))
             .collect();
 
-        let mut rng = FastRng::from_seed(self.rng_kind, self.seed);
-        let mut sum_pv = 0.0;
-        let mut sum_pv_sq = 0.0;
-        let mut corr_normals = vec![0.0; n_assets];
+        #[cfg(feature = "parallel")]
+        let chunk_stats = if should_parallelize_paths(self.num_paths) {
+            self.price_path_chunks_parallel(
+                product,
+                &initial_spots,
+                &execution_plan,
+                &chol,
+                &steppers,
+                num_locals,
+            )?
+        } else {
+            self.price_path_chunk(
+                self.num_paths,
+                self.seed,
+                product,
+                &initial_spots,
+                &execution_plan,
+                &chol,
+                &steppers,
+                num_locals,
+            )?
+        };
+        #[cfg(not(feature = "parallel"))]
+        let chunk_stats = self.price_path_chunk(
+            self.num_paths,
+            self.seed,
+            product,
+            &initial_spots,
+            &execution_plan,
+            &chol,
+            &steppers,
+            num_locals,
+        )?;
 
-        for _ in 0..self.num_paths {
-            // Generate correlated multi-asset path.
-            // path_spots[step][asset]
-            let mut path_spots = vec![vec![0.0; n_assets]; n_steps + 1];
-            for (i, &s0) in initial_spots.iter().enumerate() {
-                path_spots[0][i] = s0;
-            }
-
-            for step in 0..n_steps {
-                sample_correlated_normals_cholesky(&chol, &mut rng, &mut corr_normals)?;
-
-                for asset in 0..n_assets {
-                    let prev = path_spots[step][asset];
-                    let z = corr_normals[asset];
-                    path_spots[step + 1][asset] = steppers[asset].step(prev, z);
-                }
-            }
-
-            // Evaluate product on this path.
-            let pv = evaluate_product(product, &path_spots, &initial_spots, n_steps, market.rate)
-                .map_err(|e| PricingError::NumericalError(e.to_string()))?;
-
-            sum_pv += pv;
-            sum_pv_sq += pv * pv;
-        }
-
-        let n = self.num_paths as f64;
-        let mean = sum_pv / n;
-        let variance = if self.num_paths > 1 {
-            (sum_pv_sq - sum_pv * sum_pv / n) / (n - 1.0)
+        let n = chunk_stats.num_paths as f64;
+        let mean = chunk_stats.sum_pv / n;
+        let variance = if chunk_stats.num_paths > 1 {
+            (chunk_stats.sum_pv_sq - chunk_stats.sum_pv * chunk_stats.sum_pv / n) / (n - 1.0)
         } else {
             0.0
         };
@@ -233,6 +335,10 @@ impl DslMonteCarloEngine {
         let mut diagnostics = Diagnostics::new();
         diagnostics.insert_key(DiagKey::NumPaths, n);
         diagnostics.insert_key(DiagKey::NumSteps, n_steps as f64);
+        #[cfg(feature = "parallel")]
+        if should_parallelize_paths(self.num_paths) {
+            diagnostics.insert_key(DiagKey::NumThreads, rayon::current_num_threads() as f64);
+        }
 
         Ok(PricingResult {
             price: mean,
@@ -240,6 +346,439 @@ impl DslMonteCarloEngine {
             greeks: None,
             diagnostics,
         })
+    }
+
+    fn price_path_chunk(
+        &self,
+        num_paths: usize,
+        seed: u64,
+        product: &CompiledProduct,
+        initial_spots: &[f64],
+        plan: &ProductExecutionPlan,
+        chol: &[Vec<f64>],
+        steppers: &[AssetStepper],
+        num_locals: usize,
+    ) -> Result<ChunkStats, PricingError> {
+        #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+        if should_simd_path_batch(num_paths, SIMD_X86_PATH_LANES)
+            && is_x86_feature_detected!("avx2")
+            && is_x86_feature_detected!("fma")
+        {
+            // SAFETY: Guarded by runtime AVX2+FMA detection.
+            return unsafe {
+                self.price_path_chunk_simd_x86(
+                    num_paths,
+                    seed,
+                    product,
+                    initial_spots,
+                    plan,
+                    chol,
+                    steppers,
+                    num_locals,
+                )
+            };
+        }
+        #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+        if should_simd_path_batch(num_paths, SIMD_NEON_PATH_LANES) {
+            return unsafe {
+                self.price_path_chunk_simd_neon(
+                    num_paths,
+                    seed,
+                    product,
+                    initial_spots,
+                    plan,
+                    chol,
+                    steppers,
+                    num_locals,
+                )
+            };
+        }
+
+        self.price_path_chunk_scalar(
+            num_paths,
+            seed,
+            product,
+            initial_spots,
+            plan,
+            chol,
+            steppers,
+            num_locals,
+        )
+    }
+
+    fn price_path_chunk_scalar(
+        &self,
+        num_paths: usize,
+        seed: u64,
+        product: &CompiledProduct,
+        initial_spots: &[f64],
+        plan: &ProductExecutionPlan,
+        chol: &[Vec<f64>],
+        steppers: &[AssetStepper],
+        num_locals: usize,
+    ) -> Result<ChunkStats, PricingError> {
+        if plan.snapshot_count() == 0 {
+            return Ok(ChunkStats {
+                sum_pv: 0.0,
+                sum_pv_sq: 0.0,
+                num_paths,
+            });
+        }
+
+        let n_assets = initial_spots.len();
+        let n_steps = self.num_steps;
+        let mut rng = FastRng::from_seed(self.rng_kind, seed);
+        let mut sum_pv = 0.0;
+        let mut sum_pv_sq = 0.0;
+        let mut corr_normals = vec![0.0; n_assets];
+        let mut indep_normals = vec![0.0; n_assets];
+        let mut current_spots = initial_spots.to_vec();
+        let mut next_spots = vec![0.0; n_assets];
+        let mut observation_spots = vec![vec![0.0; n_assets]; plan.snapshot_count()];
+        let mut locals = vec![Value::F64(0.0); num_locals];
+        let mut state = vec![Value::F64(0.0); product.state_vars.len()];
+        let mut stack = vec![Value::F64(0.0); plan.max_stack()];
+
+        for _ in 0..num_paths {
+            current_spots.copy_from_slice(initial_spots);
+            if let Some(snapshot_index) = plan.snapshot_index_for_step(0) {
+                observation_spots[snapshot_index].copy_from_slice(initial_spots);
+            }
+
+            for step in 0..n_steps {
+                sample_correlated_normals_cholesky_with_scratch(
+                    chol,
+                    &mut rng,
+                    &mut indep_normals,
+                    &mut corr_normals,
+                )?;
+
+                for asset in 0..n_assets {
+                    let prev = current_spots[asset];
+                    let z = corr_normals[asset];
+                    next_spots[asset] = steppers[asset].step(prev, z);
+                }
+
+                if let Some(snapshot_index) = plan.snapshot_index_for_step(step + 1) {
+                    observation_spots[snapshot_index].copy_from_slice(&next_spots);
+                }
+
+                std::mem::swap(&mut current_spots, &mut next_spots);
+            }
+
+            let pv = evaluate_product_with_plan_in_place(
+                product,
+                plan,
+                &observation_spots,
+                initial_spots,
+                &mut locals,
+                &mut state,
+                &mut stack,
+            )
+            .map_err(|e| PricingError::NumericalError(e.to_string()))?;
+
+            sum_pv += pv;
+            sum_pv_sq += pv * pv;
+        }
+
+        Ok(ChunkStats {
+            sum_pv,
+            sum_pv_sq,
+            num_paths,
+        })
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,fma")]
+    unsafe fn price_path_chunk_simd_x86(
+        &self,
+        num_paths: usize,
+        seed: u64,
+        product: &CompiledProduct,
+        initial_spots: &[f64],
+        plan: &ProductExecutionPlan,
+        chol: &[Vec<f64>],
+        steppers: &[AssetStepper],
+        num_locals: usize,
+    ) -> Result<ChunkStats, PricingError> {
+        const LANES: usize = SIMD_X86_PATH_LANES;
+
+        if plan.snapshot_count() == 0 {
+            return Ok(ChunkStats {
+                sum_pv: 0.0,
+                sum_pv_sq: 0.0,
+                num_paths,
+            });
+        }
+
+        let n_assets = initial_spots.len();
+        let n_steps = self.num_steps;
+        let n_state = product.state_vars.len();
+        let n_snapshots = plan.snapshot_count();
+        let mut rng = FastRng::from_seed(self.rng_kind, seed);
+        let mut sum_pv = 0.0;
+        let mut sum_pv_sq = 0.0;
+        let mut corr_normals = vec![vec![0.0; n_assets]; LANES];
+        let mut indep_normals = vec![vec![0.0; n_assets]; LANES];
+        let mut current_spots = vec![[0.0; LANES]; n_assets];
+        let mut next_spots = vec![[0.0; LANES]; n_assets];
+        let mut observation_spots = vec![vec![vec![0.0; n_assets]; n_snapshots]; LANES];
+        let mut locals = vec![vec![Value::F64(0.0); num_locals]; LANES];
+        let mut state = vec![vec![Value::F64(0.0); n_state]; LANES];
+        let mut stack = vec![vec![Value::F64(0.0); plan.max_stack()]; LANES];
+
+        let simd_paths = num_paths / LANES * LANES;
+        let mut processed = 0usize;
+        while processed < simd_paths {
+            for (asset, &spot0) in initial_spots.iter().enumerate() {
+                current_spots[asset].fill(spot0);
+            }
+            if let Some(snapshot_index) = plan.snapshot_index_for_step(0) {
+                for lane in 0..LANES {
+                    observation_spots[lane][snapshot_index].copy_from_slice(initial_spots);
+                }
+            }
+
+            for step in 0..n_steps {
+                for lane in 0..LANES {
+                    sample_correlated_normals_cholesky_with_scratch(
+                        chol,
+                        &mut rng,
+                        &mut indep_normals[lane],
+                        &mut corr_normals[lane],
+                    )?;
+                }
+
+                for asset in 0..n_assets {
+                    let z = [
+                        corr_normals[0][asset],
+                        corr_normals[1][asset],
+                        corr_normals[2][asset],
+                        corr_normals[3][asset],
+                    ];
+                    unsafe {
+                        steppers[asset].step_batch_x86(
+                            &current_spots[asset],
+                            &z,
+                            &mut next_spots[asset],
+                        )
+                    };
+                }
+
+                if let Some(snapshot_index) = plan.snapshot_index_for_step(step + 1) {
+                    for lane in 0..LANES {
+                        for asset in 0..n_assets {
+                            observation_spots[lane][snapshot_index][asset] =
+                                next_spots[asset][lane];
+                        }
+                    }
+                }
+
+                std::mem::swap(&mut current_spots, &mut next_spots);
+            }
+
+            for lane in 0..LANES {
+                let pv = evaluate_product_with_plan_in_place(
+                    product,
+                    plan,
+                    &observation_spots[lane],
+                    initial_spots,
+                    &mut locals[lane],
+                    &mut state[lane],
+                    &mut stack[lane],
+                )
+                .map_err(|e| PricingError::NumericalError(e.to_string()))?;
+                sum_pv += pv;
+                sum_pv_sq += pv * pv;
+            }
+
+            processed += LANES;
+        }
+
+        if simd_paths < num_paths {
+            let tail = self.price_path_chunk_scalar(
+                num_paths - simd_paths,
+                seed.wrapping_add(0x9E37_79B9_7F4A_7C15),
+                product,
+                initial_spots,
+                plan,
+                chol,
+                steppers,
+                num_locals,
+            )?;
+            sum_pv += tail.sum_pv;
+            sum_pv_sq += tail.sum_pv_sq;
+        }
+
+        Ok(ChunkStats {
+            sum_pv,
+            sum_pv_sq,
+            num_paths,
+        })
+    }
+
+    #[cfg(all(feature = "simd", target_arch = "aarch64"))]
+    unsafe fn price_path_chunk_simd_neon(
+        &self,
+        num_paths: usize,
+        seed: u64,
+        product: &CompiledProduct,
+        initial_spots: &[f64],
+        plan: &ProductExecutionPlan,
+        chol: &[Vec<f64>],
+        steppers: &[AssetStepper],
+        num_locals: usize,
+    ) -> Result<ChunkStats, PricingError> {
+        const LANES: usize = SIMD_NEON_PATH_LANES;
+
+        if plan.snapshot_count() == 0 {
+            return Ok(ChunkStats {
+                sum_pv: 0.0,
+                sum_pv_sq: 0.0,
+                num_paths,
+            });
+        }
+
+        let n_assets = initial_spots.len();
+        let n_steps = self.num_steps;
+        let n_state = product.state_vars.len();
+        let n_snapshots = plan.snapshot_count();
+        let mut rng = FastRng::from_seed(self.rng_kind, seed);
+        let mut sum_pv = 0.0;
+        let mut sum_pv_sq = 0.0;
+        let mut corr_normals = vec![vec![0.0; n_assets]; LANES];
+        let mut indep_normals = vec![vec![0.0; n_assets]; LANES];
+        let mut current_spots = vec![[0.0; LANES]; n_assets];
+        let mut next_spots = vec![[0.0; LANES]; n_assets];
+        let mut observation_spots = vec![vec![vec![0.0; n_assets]; n_snapshots]; LANES];
+        let mut locals = vec![vec![Value::F64(0.0); num_locals]; LANES];
+        let mut state = vec![vec![Value::F64(0.0); n_state]; LANES];
+        let mut stack = vec![vec![Value::F64(0.0); plan.max_stack()]; LANES];
+
+        let simd_paths = num_paths / LANES * LANES;
+        let mut processed = 0usize;
+        while processed < simd_paths {
+            for (asset, &spot0) in initial_spots.iter().enumerate() {
+                current_spots[asset].fill(spot0);
+            }
+            if let Some(snapshot_index) = plan.snapshot_index_for_step(0) {
+                for lane in 0..LANES {
+                    observation_spots[lane][snapshot_index].copy_from_slice(initial_spots);
+                }
+            }
+
+            for step in 0..n_steps {
+                for lane in 0..LANES {
+                    sample_correlated_normals_cholesky_with_scratch(
+                        chol,
+                        &mut rng,
+                        &mut indep_normals[lane],
+                        &mut corr_normals[lane],
+                    )?;
+                }
+
+                for asset in 0..n_assets {
+                    let z = [corr_normals[0][asset], corr_normals[1][asset]];
+                    unsafe {
+                        steppers[asset].step_batch_neon(
+                            &current_spots[asset],
+                            &z,
+                            &mut next_spots[asset],
+                        )
+                    };
+                }
+
+                if let Some(snapshot_index) = plan.snapshot_index_for_step(step + 1) {
+                    for lane in 0..LANES {
+                        for asset in 0..n_assets {
+                            observation_spots[lane][snapshot_index][asset] =
+                                next_spots[asset][lane];
+                        }
+                    }
+                }
+
+                std::mem::swap(&mut current_spots, &mut next_spots);
+            }
+
+            for lane in 0..LANES {
+                let pv = evaluate_product_with_plan_in_place(
+                    product,
+                    plan,
+                    &observation_spots[lane],
+                    initial_spots,
+                    &mut locals[lane],
+                    &mut state[lane],
+                    &mut stack[lane],
+                )
+                .map_err(|e| PricingError::NumericalError(e.to_string()))?;
+                sum_pv += pv;
+                sum_pv_sq += pv * pv;
+            }
+
+            processed += LANES;
+        }
+
+        if simd_paths < num_paths {
+            let tail = self.price_path_chunk_scalar(
+                num_paths - simd_paths,
+                seed.wrapping_add(0x9E37_79B9_7F4A_7C15),
+                product,
+                initial_spots,
+                plan,
+                chol,
+                steppers,
+                num_locals,
+            )?;
+            sum_pv += tail.sum_pv;
+            sum_pv_sq += tail.sum_pv_sq;
+        }
+
+        Ok(ChunkStats {
+            sum_pv,
+            sum_pv_sq,
+            num_paths,
+        })
+    }
+
+    #[cfg(feature = "parallel")]
+    fn price_path_chunks_parallel(
+        &self,
+        product: &CompiledProduct,
+        initial_spots: &[f64],
+        plan: &ProductExecutionPlan,
+        chol: &[Vec<f64>],
+        steppers: &[AssetStepper],
+        num_locals: usize,
+    ) -> Result<ChunkStats, PricingError> {
+        let chunk_sizes = split_path_chunks(self.num_paths, rayon::current_num_threads());
+        let chunk_results: Vec<Result<ChunkStats, PricingError>> = chunk_sizes
+            .par_iter()
+            .enumerate()
+            .map(|(i, &chunk_paths)| {
+                let chunk_seed = self
+                    .seed
+                    .wrapping_add((i as u64).wrapping_mul(6_364_136_223_846_793_005));
+                self.price_path_chunk(
+                    chunk_paths,
+                    chunk_seed,
+                    product,
+                    initial_spots,
+                    plan,
+                    chol,
+                    steppers,
+                    num_locals,
+                )
+            })
+            .collect();
+
+        let mut total = ChunkStats::default();
+        for result in chunk_results {
+            let chunk = result?;
+            total.sum_pv += chunk.sum_pv;
+            total.sum_pv_sq += chunk.sum_pv_sq;
+            total.num_paths += chunk.num_paths;
+        }
+        Ok(total)
     }
 
     /// Compute Greeks via bump-and-reprice.
@@ -346,13 +885,15 @@ impl DslMonteCarloEngine {
         let p_up_up = self.price_multi_asset(product, &m_up_up)?.price;
 
         let mut m_up_down = market.clone();
-        m_up_down.assets[asset_index] =
-            asset_data.with_spot_bump(spot_bump).with_vol_bump(-vol_bump);
+        m_up_down.assets[asset_index] = asset_data
+            .with_spot_bump(spot_bump)
+            .with_vol_bump(-vol_bump);
         let p_up_down = self.price_multi_asset(product, &m_up_down)?.price;
 
         let mut m_down_up = market.clone();
-        m_down_up.assets[asset_index] =
-            asset_data.with_spot_bump(-spot_bump).with_vol_bump(vol_bump);
+        m_down_up.assets[asset_index] = asset_data
+            .with_spot_bump(-spot_bump)
+            .with_vol_bump(vol_bump);
         let p_down_up = self.price_multi_asset(product, &m_down_up)?.price;
 
         let mut m_down_down = market.clone();
@@ -445,6 +986,48 @@ impl DslMonteCarloEngine {
             corr_sens,
         })
     }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ChunkStats {
+    sum_pv: f64,
+    sum_pv_sq: f64,
+    num_paths: usize,
+}
+
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+const SIMD_X86_PATH_LANES: usize = 4;
+#[cfg(all(feature = "simd", target_arch = "aarch64"))]
+const SIMD_NEON_PATH_LANES: usize = 2;
+
+#[cfg(feature = "simd")]
+#[inline]
+fn should_simd_path_batch(num_paths: usize, lanes: usize) -> bool {
+    num_paths >= lanes * 4
+}
+
+#[cfg(feature = "parallel")]
+const MIN_PARALLEL_PATHS: usize = 8_192;
+#[cfg(feature = "parallel")]
+const PATH_CHUNK_SIZE: usize = 4_096;
+
+#[cfg(feature = "parallel")]
+#[inline]
+fn should_parallelize_paths(num_paths: usize) -> bool {
+    num_paths >= MIN_PARALLEL_PATHS && rayon::current_num_threads() > 1
+}
+
+#[cfg(feature = "parallel")]
+fn split_path_chunks(num_paths: usize, threads: usize) -> Vec<usize> {
+    let chunk_size = PATH_CHUNK_SIZE.max(num_paths / threads.max(1));
+    let mut remaining = num_paths;
+    let mut chunks = Vec::new();
+    while remaining > 0 {
+        let chunk = remaining.min(chunk_size);
+        chunks.push(chunk);
+        remaining -= chunk;
+    }
+    chunks
 }
 
 /// Extended per-asset greeks including higher-order sensitivities.
@@ -647,7 +1230,7 @@ mod tests {
     fn schwartz_stepper_mean_reverts() {
         // Schwartz one-factor: commodity price should mean-revert toward exp(mu).
         let stepper = AssetStepper::SchwartzOneF {
-            long_run_log_mean: (100.0_f64).ln(), // mu = ln(100)
+            long_run_log_mean: (100.0_f64).ln(),       // mu = ln(100)
             exp_neg_kappa_dt: (-2.0 * 0.01_f64).exp(), // kappa=2, dt=0.01
             vol_step: 0.30 * (0.01_f64).sqrt(),
         };

--- a/src/dsl/eval.rs
+++ b/src/dsl/eval.rs
@@ -4,9 +4,7 @@
 //! accumulating discounted cashflows and handling early termination.
 
 use crate::dsl::error::DslError;
-use crate::dsl::ir::{
-    BinOp, BuiltinFn, CompiledProduct, Expr, Schedule, Statement, UnaryOp, Value,
-};
+use crate::dsl::ir::{BinOp, BuiltinFn, CompiledProduct, Expr, Statement, UnaryOp, Value};
 
 /// Per-path evaluation context.
 struct EvalContext<'a> {
@@ -20,6 +18,8 @@ struct EvalContext<'a> {
     observation_date: f64,
     /// Whether this is the final observation in the schedule.
     is_final: bool,
+    /// Discount factor for the current observation date.
+    discount_factor: f64,
     /// Local variable slots.
     locals: &'a mut [Value],
     /// State variable slots (mutable across observations).
@@ -44,13 +44,206 @@ pub struct Cashflow {
     pub amount: f64,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ProductExecutionPlan {
+    step_to_snapshot: Vec<usize>,
+    schedules: Vec<ScheduleExecutionPlan>,
+    snapshot_count: usize,
+    max_stack: usize,
+}
+
+impl ProductExecutionPlan {
+    #[inline]
+    pub(crate) fn snapshot_count(&self) -> usize {
+        self.snapshot_count
+    }
+
+    #[inline]
+    pub(crate) fn snapshot_index_for_step(&self, step: usize) -> Option<usize> {
+        let idx = *self.step_to_snapshot.get(step)?;
+        (idx != usize::MAX).then_some(idx)
+    }
+
+    #[inline]
+    pub(crate) fn max_stack(&self) -> usize {
+        self.max_stack
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScheduleExecutionPlan {
+    observations: Vec<ObservationPoint>,
+    program: Vec<ExecOp>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ObservationPoint {
+    snapshot_index: usize,
+    observation_date: f64,
+    discount_factor: f64,
+    is_final: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ExecOp {
+    PushLiteral(Value),
+    PushLocal(usize),
+    PushState(usize),
+    PushNotional,
+    PushObservationDate,
+    PushIsFinal,
+    ApplyBinOp(BinOp),
+    ApplyUnaryOp(UnaryOp),
+    WorstOfPerformances,
+    BestOfPerformances,
+    WorstOf(usize),
+    BestOf(usize),
+    Price,
+    Min,
+    Max,
+    Abs,
+    Exp,
+    Log,
+    StoreLocal(usize),
+    StoreState(usize),
+    Pay,
+    Redeem,
+    JumpIfFalse(usize),
+    Jump(usize),
+    Skip,
+}
+
+#[derive(Debug, Default)]
+struct ProgramBuilder {
+    program: Vec<ExecOp>,
+    stack_depth: usize,
+    max_stack: usize,
+}
+
+impl ProgramBuilder {
+    fn emit(&mut self, op: ExecOp, stack_delta: isize) -> usize {
+        let idx = self.program.len();
+        self.program.push(op);
+        self.adjust_stack(stack_delta);
+        idx
+    }
+
+    fn patch_jump(&mut self, idx: usize, target: usize) {
+        match &mut self.program[idx] {
+            ExecOp::JumpIfFalse(dst) | ExecOp::Jump(dst) => *dst = target,
+            _ => unreachable!("attempted to patch non-jump opcode"),
+        }
+    }
+
+    fn adjust_stack(&mut self, delta: isize) {
+        if delta < 0 {
+            self.stack_depth -= (-delta) as usize;
+        } else {
+            self.stack_depth += delta as usize;
+            self.max_stack = self.max_stack.max(self.stack_depth);
+        }
+    }
+}
+
+struct ValueStack<'a> {
+    values: &'a mut [Value],
+    len: usize,
+}
+
+impl<'a> ValueStack<'a> {
+    fn new(values: &'a mut [Value]) -> Self {
+        Self { values, len: 0 }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    #[inline]
+    fn push(&mut self, value: Value) {
+        debug_assert!(self.len < self.values.len());
+        self.values[self.len] = value;
+        self.len += 1;
+    }
+
+    #[inline]
+    fn pop(&mut self) -> Value {
+        debug_assert!(self.len > 0);
+        self.len -= 1;
+        self.values[self.len]
+    }
+}
+
+pub(crate) fn build_execution_plan(
+    product: &CompiledProduct,
+    num_steps: usize,
+    rate: f64,
+) -> Result<ProductExecutionPlan, DslError> {
+    let maturity = product.maturity;
+    let step_scale = if maturity > 0.0 {
+        num_steps as f64 / maturity
+    } else {
+        0.0
+    };
+    let mut step_to_snapshot = vec![usize::MAX; num_steps + 1];
+    let mut schedules = Vec::with_capacity(product.schedules.len());
+    let mut snapshot_count = 0usize;
+    let mut max_stack = 0usize;
+
+    for schedule in &product.schedules {
+        let num_dates = schedule.dates.len();
+        let mut observations = Vec::with_capacity(num_dates);
+        for (date_idx, &obs_date) in schedule.dates.iter().enumerate() {
+            let mut step_idx = if maturity > 0.0 {
+                (obs_date * step_scale).round() as usize
+            } else {
+                0
+            };
+            step_idx = step_idx.min(num_steps);
+
+            let snapshot_index = if step_to_snapshot[step_idx] == usize::MAX {
+                let idx = snapshot_count;
+                step_to_snapshot[step_idx] = idx;
+                snapshot_count += 1;
+                idx
+            } else {
+                step_to_snapshot[step_idx]
+            };
+
+            observations.push(ObservationPoint {
+                snapshot_index,
+                observation_date: obs_date,
+                discount_factor: (-rate * obs_date).exp(),
+                is_final: date_idx + 1 == num_dates,
+            });
+        }
+
+        let mut builder = ProgramBuilder::default();
+        compile_statement_block(&schedule.body, &mut builder)?;
+        debug_assert_eq!(builder.stack_depth, 0);
+        max_stack = max_stack.max(builder.max_stack);
+        schedules.push(ScheduleExecutionPlan {
+            observations,
+            program: builder.program,
+        });
+    }
+
+    Ok(ProductExecutionPlan {
+        step_to_snapshot,
+        schedules,
+        snapshot_count,
+        max_stack,
+    })
+}
+
 /// Evaluate a compiled product on a single MC path.
 ///
 /// `path_spots[t][asset]` gives the spot price of each underlying at each
 /// time step. The first index is the time step (0 = initial), the second
 /// is the asset index.
 ///
-/// Returns the vector of cashflows generated on this path.
+/// Returns the present value generated on this path.
 pub fn evaluate_product(
     product: &CompiledProduct,
     path_spots: &[Vec<f64>],
@@ -58,22 +251,89 @@ pub fn evaluate_product(
     num_steps: usize,
     rate: f64,
 ) -> Result<f64, DslError> {
+    let plan = build_execution_plan(product, num_steps, rate)?;
     let num_locals = product.max_local_slots();
     let mut locals = vec![Value::F64(0.0); num_locals];
-    let mut state: Vec<Value> = product.state_vars.iter().map(|sv| sv.initial).collect();
+    let mut state = vec![Value::F64(0.0); product.state_vars.len()];
+    let mut stack = vec![Value::F64(0.0); plan.max_stack()];
+
+    evaluate_product_in_place(
+        product,
+        &plan,
+        path_spots,
+        initial_spots,
+        &mut locals,
+        &mut state,
+        &mut stack,
+    )
+}
+
+pub(crate) fn evaluate_product_in_place(
+    product: &CompiledProduct,
+    plan: &ProductExecutionPlan,
+    path_spots: &[Vec<f64>],
+    initial_spots: &[f64],
+    locals: &mut [Value],
+    state: &mut [Value],
+    stack: &mut [Value],
+) -> Result<f64, DslError> {
+    let mut observation_spots = vec![Vec::new(); plan.snapshot_count()];
+    for (step_idx, spots) in path_spots.iter().enumerate() {
+        if let Some(snapshot_index) = plan.snapshot_index_for_step(step_idx) {
+            observation_spots[snapshot_index] = spots.clone();
+        }
+    }
+
+    evaluate_product_with_plan_in_place(
+        product,
+        plan,
+        &observation_spots,
+        initial_spots,
+        locals,
+        state,
+        stack,
+    )
+}
+
+pub(crate) fn evaluate_product_with_plan_in_place(
+    product: &CompiledProduct,
+    plan: &ProductExecutionPlan,
+    observation_spots: &[Vec<f64>],
+    initial_spots: &[f64],
+    locals: &mut [Value],
+    state: &mut [Value],
+    stack: &mut [Value],
+) -> Result<f64, DslError> {
+    if state.len() != product.state_vars.len() {
+        return Err(DslError::EvalError(format!(
+            "state scratch length {} does not match product state count {}",
+            state.len(),
+            product.state_vars.len()
+        )));
+    }
+    if stack.len() < plan.max_stack() {
+        return Err(DslError::EvalError(format!(
+            "stack scratch length {} is smaller than required stack {}",
+            stack.len(),
+            plan.max_stack()
+        )));
+    }
+    for (dst, sv) in state.iter_mut().zip(product.state_vars.iter()) {
+        *dst = sv.initial;
+    }
 
     let mut pv = 0.0;
+    let mut value_stack = ValueStack::new(stack);
 
-    for schedule in &product.schedules {
-        let outcome = evaluate_schedule(
+    for schedule_plan in &plan.schedules {
+        let outcome = execute_schedule(
             product,
-            schedule,
-            path_spots,
+            schedule_plan,
+            observation_spots,
             initial_spots,
-            num_steps,
-            rate,
-            &mut locals,
-            &mut state,
+            locals,
+            state,
+            &mut value_stack,
             &mut pv,
         )?;
         if matches!(
@@ -87,55 +347,40 @@ pub fn evaluate_product(
     Ok(pv)
 }
 
-fn evaluate_schedule(
+fn execute_schedule(
     product: &CompiledProduct,
-    schedule: &Schedule,
-    path_spots: &[Vec<f64>],
+    plan: &ScheduleExecutionPlan,
+    observation_spots: &[Vec<f64>],
     initial_spots: &[f64],
-    num_steps: usize,
-    rate: f64,
     locals: &mut [Value],
     state: &mut [Value],
+    stack: &mut ValueStack<'_>,
     pv: &mut f64,
 ) -> Result<ObservationResult, DslError> {
-    let maturity = product.maturity;
-    let num_dates = schedule.dates.len();
-
-    for (date_idx, &obs_date) in schedule.dates.iter().enumerate() {
-        let is_final = date_idx == num_dates - 1;
-
-        // Map observation date to path step index.
-        let step_idx = if maturity > 0.0 {
-            ((obs_date / maturity) * num_steps as f64).round() as usize
-        } else {
-            0
-        };
-        let step_idx = step_idx.min(path_spots.len() - 1);
-
-        let spots = &path_spots[step_idx];
+    for observation in &plan.observations {
+        let spots = observation_spots
+            .get(observation.snapshot_index)
+            .ok_or_else(|| {
+                DslError::EvalError(format!(
+                    "missing observation snapshot {}",
+                    observation.snapshot_index
+                ))
+            })?;
         // Reset locals for each observation date.
-        for local in locals.iter_mut() {
-            *local = Value::F64(0.0);
-        }
+        locals.fill(Value::F64(0.0));
 
         let mut ctx = EvalContext {
             spots,
             initial_spots,
             notional: product.notional,
-            observation_date: obs_date,
-            is_final,
+            observation_date: observation.observation_date,
+            is_final: observation.is_final,
+            discount_factor: observation.discount_factor,
             locals,
             state,
         };
 
-        let mut cashflows = Vec::new();
-        let result = execute_statements(&schedule.body, &mut ctx, &mut cashflows)?;
-
-        // Discount and accumulate cashflows.
-        for cf in &cashflows {
-            let cf_df = (-rate * cf.time).exp();
-            *pv += cf.amount * cf_df;
-        }
+        let result = execute_program(&plan.program, &mut ctx, stack, pv)?;
 
         match result {
             ObservationResult::Redeemed | ObservationResult::Skipped => return Ok(result),
@@ -146,89 +391,318 @@ fn evaluate_schedule(
     Ok(ObservationResult::Continue)
 }
 
-fn execute_statements(
+fn compile_statement_block(
     stmts: &[Statement],
-    ctx: &mut EvalContext<'_>,
-    cashflows: &mut Vec<Cashflow>,
-) -> Result<ObservationResult, DslError> {
+    builder: &mut ProgramBuilder,
+) -> Result<(), DslError> {
     for stmt in stmts {
-        let result = execute_statement(stmt, ctx, cashflows)?;
-        match result {
-            ObservationResult::Continue => {}
-            other => return Ok(other),
-        }
+        compile_statement(stmt, builder)?;
     }
-    Ok(ObservationResult::Continue)
+    Ok(())
 }
 
-fn execute_statement(
-    stmt: &Statement,
-    ctx: &mut EvalContext<'_>,
-    cashflows: &mut Vec<Cashflow>,
-) -> Result<ObservationResult, DslError> {
+fn compile_statement(stmt: &Statement, builder: &mut ProgramBuilder) -> Result<(), DslError> {
+    let entry_stack = builder.stack_depth;
+
     match stmt {
         Statement::Let { slot, expr } => {
-            let val = eval_expr(expr, ctx)?;
-            ctx.locals[*slot] = val;
-            Ok(ObservationResult::Continue)
+            compile_expr(expr, builder)?;
+            builder.emit(ExecOp::StoreLocal(*slot), -1);
         }
         Statement::If {
             condition,
             then_body,
             else_body,
         } => {
-            let cond = eval_expr(condition, ctx)?;
-            if cond.as_bool() {
-                execute_statements(then_body, ctx, cashflows)
+            compile_expr(condition, builder)?;
+            let jump_if_false = builder.emit(ExecOp::JumpIfFalse(usize::MAX), -1);
+            compile_statement_block(then_body, builder)?;
+            if else_body.is_empty() {
+                builder.patch_jump(jump_if_false, builder.program.len());
             } else {
-                execute_statements(else_body, ctx, cashflows)
+                let jump_end = builder.emit(ExecOp::Jump(usize::MAX), 0);
+                let else_start = builder.program.len();
+                builder.patch_jump(jump_if_false, else_start);
+                compile_statement_block(else_body, builder)?;
+                builder.patch_jump(jump_end, builder.program.len());
             }
         }
         Statement::Pay { amount } => {
-            let val = eval_expr(amount, ctx)?.as_f64();
-            cashflows.push(Cashflow {
-                time: ctx.observation_date,
-                amount: val,
-            });
-            Ok(ObservationResult::Continue)
+            compile_expr(amount, builder)?;
+            builder.emit(ExecOp::Pay, -1);
         }
         Statement::Redeem { amount } => {
-            let val = eval_expr(amount, ctx)?.as_f64();
-            cashflows.push(Cashflow {
-                time: ctx.observation_date,
-                amount: val,
-            });
-            Ok(ObservationResult::Redeemed)
+            compile_expr(amount, builder)?;
+            builder.emit(ExecOp::Redeem, -1);
         }
         Statement::SetState { slot, expr } => {
-            let val = eval_expr(expr, ctx)?;
-            ctx.state[*slot] = val;
-            Ok(ObservationResult::Continue)
+            compile_expr(expr, builder)?;
+            builder.emit(ExecOp::StoreState(*slot), -1);
         }
-        Statement::Skip => Ok(ObservationResult::Skipped),
+        Statement::Skip => {
+            builder.emit(ExecOp::Skip, 0);
+        }
     }
+
+    debug_assert_eq!(builder.stack_depth, entry_stack);
+    Ok(())
 }
 
-#[inline]
-fn eval_expr(expr: &Expr, ctx: &mut EvalContext<'_>) -> Result<Value, DslError> {
+fn compile_expr(expr: &Expr, builder: &mut ProgramBuilder) -> Result<(), DslError> {
     match expr {
-        Expr::Literal(v) => Ok(*v),
-        Expr::LocalVar(slot) => Ok(ctx.locals[*slot]),
-        Expr::StateVar(slot) => Ok(ctx.state[*slot]),
-        Expr::Notional => Ok(Value::F64(ctx.notional)),
-        Expr::ObservationDate => Ok(Value::F64(ctx.observation_date)),
-        Expr::IsFinal => Ok(Value::Bool(ctx.is_final)),
+        Expr::Literal(v) => {
+            builder.emit(ExecOp::PushLiteral(*v), 1);
+        }
+        Expr::LocalVar(slot) => {
+            builder.emit(ExecOp::PushLocal(*slot), 1);
+        }
+        Expr::StateVar(slot) => {
+            builder.emit(ExecOp::PushState(*slot), 1);
+        }
+        Expr::Notional => {
+            builder.emit(ExecOp::PushNotional, 1);
+        }
+        Expr::ObservationDate => {
+            builder.emit(ExecOp::PushObservationDate, 1);
+        }
+        Expr::IsFinal => {
+            builder.emit(ExecOp::PushIsFinal, 1);
+        }
         Expr::BinOp { op, lhs, rhs } => {
-            let l = eval_expr(lhs, ctx)?;
-            let r = eval_expr(rhs, ctx)?;
-            Ok(eval_binop(*op, l, r))
+            compile_expr(lhs, builder)?;
+            compile_expr(rhs, builder)?;
+            builder.emit(ExecOp::ApplyBinOp(*op), -1);
         }
         Expr::UnaryOp { op, operand } => {
-            let v = eval_expr(operand, ctx)?;
-            Ok(eval_unaryop(*op, v))
+            compile_expr(operand, builder)?;
+            builder.emit(ExecOp::ApplyUnaryOp(*op), 0);
         }
-        Expr::Call { func, args } => eval_builtin(*func, args, ctx),
+        Expr::Call { func, args } => compile_builtin(*func, args, builder)?,
     }
+
+    Ok(())
+}
+
+fn compile_builtin(
+    func: BuiltinFn,
+    args: &[Expr],
+    builder: &mut ProgramBuilder,
+) -> Result<(), DslError> {
+    match func {
+        BuiltinFn::Performances => {
+            return Err(DslError::EvalError(
+                "performances() cannot be used standalone; wrap in worst_of() or best_of()"
+                    .to_string(),
+            ));
+        }
+        BuiltinFn::WorstOf => {
+            if args.len() == 1
+                && matches!(
+                    &args[0],
+                    Expr::Call {
+                        func: BuiltinFn::Performances,
+                        ..
+                    }
+                )
+            {
+                builder.emit(ExecOp::WorstOfPerformances, 1);
+            } else {
+                for arg in args {
+                    compile_expr(arg, builder)?;
+                }
+                builder.emit(ExecOp::WorstOf(args.len()), 1 - args.len() as isize);
+            }
+        }
+        BuiltinFn::BestOf => {
+            if args.len() == 1
+                && matches!(
+                    &args[0],
+                    Expr::Call {
+                        func: BuiltinFn::Performances,
+                        ..
+                    }
+                )
+            {
+                builder.emit(ExecOp::BestOfPerformances, 1);
+            } else {
+                for arg in args {
+                    compile_expr(arg, builder)?;
+                }
+                builder.emit(ExecOp::BestOf(args.len()), 1 - args.len() as isize);
+            }
+        }
+        BuiltinFn::Price => {
+            if args.len() != 1 {
+                return Err(DslError::EvalError(
+                    "price() requires an asset index".to_string(),
+                ));
+            }
+            compile_expr(&args[0], builder)?;
+            builder.emit(ExecOp::Price, 0);
+        }
+        BuiltinFn::Min => {
+            if args.len() != 2 {
+                return Err(DslError::EvalError(
+                    "min() requires 2 arguments".to_string(),
+                ));
+            }
+            compile_expr(&args[0], builder)?;
+            compile_expr(&args[1], builder)?;
+            builder.emit(ExecOp::Min, -1);
+        }
+        BuiltinFn::Max => {
+            if args.len() != 2 {
+                return Err(DslError::EvalError(
+                    "max() requires 2 arguments".to_string(),
+                ));
+            }
+            compile_expr(&args[0], builder)?;
+            compile_expr(&args[1], builder)?;
+            builder.emit(ExecOp::Max, -1);
+        }
+        BuiltinFn::Abs => {
+            if args.len() != 1 {
+                return Err(DslError::EvalError("abs() requires 1 argument".to_string()));
+            }
+            compile_expr(&args[0], builder)?;
+            builder.emit(ExecOp::Abs, 0);
+        }
+        BuiltinFn::Exp => {
+            if args.len() != 1 {
+                return Err(DslError::EvalError("exp() requires 1 argument".to_string()));
+            }
+            compile_expr(&args[0], builder)?;
+            builder.emit(ExecOp::Exp, 0);
+        }
+        BuiltinFn::Log => {
+            if args.len() != 1 {
+                return Err(DslError::EvalError("log() requires 1 argument".to_string()));
+            }
+            compile_expr(&args[0], builder)?;
+            builder.emit(ExecOp::Log, 0);
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_program(
+    program: &[ExecOp],
+    ctx: &mut EvalContext<'_>,
+    stack: &mut ValueStack<'_>,
+    pv: &mut f64,
+) -> Result<ObservationResult, DslError> {
+    stack.clear();
+    let mut pc = 0usize;
+
+    while pc < program.len() {
+        match program[pc] {
+            ExecOp::PushLiteral(value) => stack.push(value),
+            ExecOp::PushLocal(slot) => stack.push(ctx.locals[slot]),
+            ExecOp::PushState(slot) => stack.push(ctx.state[slot]),
+            ExecOp::PushNotional => stack.push(Value::F64(ctx.notional)),
+            ExecOp::PushObservationDate => stack.push(Value::F64(ctx.observation_date)),
+            ExecOp::PushIsFinal => stack.push(Value::Bool(ctx.is_final)),
+            ExecOp::ApplyBinOp(op) => {
+                let rhs = stack.pop();
+                let lhs = stack.pop();
+                stack.push(eval_binop(op, lhs, rhs));
+            }
+            ExecOp::ApplyUnaryOp(op) => {
+                let value = stack.pop();
+                stack.push(eval_unaryop(op, value));
+            }
+            ExecOp::WorstOfPerformances => {
+                stack.push(Value::F64(compute_worst_of_performance(ctx)));
+            }
+            ExecOp::BestOfPerformances => {
+                stack.push(Value::F64(compute_best_of_performance(ctx)));
+            }
+            ExecOp::WorstOf(arg_count) => {
+                let mut min_val = f64::INFINITY;
+                for _ in 0..arg_count {
+                    let value = stack.pop().as_f64();
+                    if value < min_val {
+                        min_val = value;
+                    }
+                }
+                stack.push(Value::F64(min_val));
+            }
+            ExecOp::BestOf(arg_count) => {
+                let mut max_val = f64::NEG_INFINITY;
+                for _ in 0..arg_count {
+                    let value = stack.pop().as_f64();
+                    if value > max_val {
+                        max_val = value;
+                    }
+                }
+                stack.push(Value::F64(max_val));
+            }
+            ExecOp::Price => {
+                let idx = stack.pop().as_f64() as usize;
+                if idx >= ctx.spots.len() {
+                    return Err(DslError::EvalError(format!(
+                        "asset index {idx} out of range (have {} assets)",
+                        ctx.spots.len()
+                    )));
+                }
+                stack.push(Value::F64(ctx.spots[idx]));
+            }
+            ExecOp::Min => {
+                let rhs = stack.pop().as_f64();
+                let lhs = stack.pop().as_f64();
+                stack.push(Value::F64(lhs.min(rhs)));
+            }
+            ExecOp::Max => {
+                let rhs = stack.pop().as_f64();
+                let lhs = stack.pop().as_f64();
+                stack.push(Value::F64(lhs.max(rhs)));
+            }
+            ExecOp::Abs => {
+                let value = stack.pop().as_f64();
+                stack.push(Value::F64(value.abs()));
+            }
+            ExecOp::Exp => {
+                let value = stack.pop().as_f64();
+                stack.push(Value::F64(value.exp()));
+            }
+            ExecOp::Log => {
+                let value = stack.pop().as_f64();
+                stack.push(Value::F64(value.ln()));
+            }
+            ExecOp::StoreLocal(slot) => {
+                ctx.locals[slot] = stack.pop();
+            }
+            ExecOp::StoreState(slot) => {
+                ctx.state[slot] = stack.pop();
+            }
+            ExecOp::Pay => {
+                let value = stack.pop().as_f64();
+                *pv += value * ctx.discount_factor;
+            }
+            ExecOp::Redeem => {
+                let value = stack.pop().as_f64();
+                *pv += value * ctx.discount_factor;
+                return Ok(ObservationResult::Redeemed);
+            }
+            ExecOp::JumpIfFalse(target) => {
+                if !stack.pop().as_bool() {
+                    pc = target;
+                    continue;
+                }
+            }
+            ExecOp::Jump(target) => {
+                pc = target;
+                continue;
+            }
+            ExecOp::Skip => return Ok(ObservationResult::Skipped),
+        }
+
+        pc += 1;
+    }
+
+    debug_assert_eq!(stack.len, 0);
+    Ok(ObservationResult::Continue)
 }
 
 #[inline]
@@ -256,126 +730,6 @@ fn eval_unaryop(op: UnaryOp, val: Value) -> Value {
     match op {
         UnaryOp::Neg => Value::F64(-val.as_f64()),
         UnaryOp::Not => Value::Bool(!val.as_bool()),
-    }
-}
-
-fn eval_builtin(
-    func: BuiltinFn,
-    args: &[Expr],
-    ctx: &mut EvalContext<'_>,
-) -> Result<Value, DslError> {
-    match func {
-        BuiltinFn::Performances => {
-            // Returns a pseudo-value; only meaningful as argument to worst_of/best_of.
-            // We encode the performance vector as the first performance value.
-            // This is handled specially by worst_of/best_of.
-            Err(DslError::EvalError(
-                "performances() cannot be used standalone; wrap in worst_of() or best_of()"
-                    .to_string(),
-            ))
-        }
-        BuiltinFn::WorstOf => {
-            // If the argument is performances(), compute worst-of performance.
-            if args.len() == 1
-                && matches!(
-                    &args[0],
-                    Expr::Call {
-                        func: BuiltinFn::Performances,
-                        ..
-                    }
-                )
-            {
-                let wof = compute_worst_of_performance(ctx);
-                return Ok(Value::F64(wof));
-            }
-            // Otherwise, evaluate all args and take min.
-            let mut min_val = f64::INFINITY;
-            for arg in args {
-                let v = eval_expr(arg, ctx)?.as_f64();
-                if v < min_val {
-                    min_val = v;
-                }
-            }
-            Ok(Value::F64(min_val))
-        }
-        BuiltinFn::BestOf => {
-            if args.len() == 1
-                && matches!(
-                    &args[0],
-                    Expr::Call {
-                        func: BuiltinFn::Performances,
-                        ..
-                    }
-                )
-            {
-                let bof = compute_best_of_performance(ctx);
-                return Ok(Value::F64(bof));
-            }
-            let mut max_val = f64::NEG_INFINITY;
-            for arg in args {
-                let v = eval_expr(arg, ctx)?.as_f64();
-                if v > max_val {
-                    max_val = v;
-                }
-            }
-            Ok(Value::F64(max_val))
-        }
-        BuiltinFn::Price => {
-            if args.is_empty() {
-                return Err(DslError::EvalError(
-                    "price() requires an asset index".to_string(),
-                ));
-            }
-            let idx = eval_expr(&args[0], ctx)?.as_f64() as usize;
-            if idx >= ctx.spots.len() {
-                return Err(DslError::EvalError(format!(
-                    "asset index {idx} out of range (have {} assets)",
-                    ctx.spots.len()
-                )));
-            }
-            Ok(Value::F64(ctx.spots[idx]))
-        }
-        BuiltinFn::Min => {
-            if args.len() != 2 {
-                return Err(DslError::EvalError(
-                    "min() requires 2 arguments".to_string(),
-                ));
-            }
-            let a = eval_expr(&args[0], ctx)?.as_f64();
-            let b = eval_expr(&args[1], ctx)?.as_f64();
-            Ok(Value::F64(a.min(b)))
-        }
-        BuiltinFn::Max => {
-            if args.len() != 2 {
-                return Err(DslError::EvalError(
-                    "max() requires 2 arguments".to_string(),
-                ));
-            }
-            let a = eval_expr(&args[0], ctx)?.as_f64();
-            let b = eval_expr(&args[1], ctx)?.as_f64();
-            Ok(Value::F64(a.max(b)))
-        }
-        BuiltinFn::Abs => {
-            if args.len() != 1 {
-                return Err(DslError::EvalError("abs() requires 1 argument".to_string()));
-            }
-            let v = eval_expr(&args[0], ctx)?.as_f64();
-            Ok(Value::F64(v.abs()))
-        }
-        BuiltinFn::Exp => {
-            if args.len() != 1 {
-                return Err(DslError::EvalError("exp() requires 1 argument".to_string()));
-            }
-            let v = eval_expr(&args[0], ctx)?.as_f64();
-            Ok(Value::F64(v.exp()))
-        }
-        BuiltinFn::Log => {
-            if args.len() != 1 {
-                return Err(DslError::EvalError("log() requires 1 argument".to_string()));
-            }
-            let v = eval_expr(&args[0], ctx)?.as_f64();
-            Ok(Value::F64(v.ln()))
-        }
     }
 }
 

--- a/src/engines/monte_carlo/correlated_mc.rs
+++ b/src/engines/monte_carlo/correlated_mc.rs
@@ -37,18 +37,33 @@ pub fn sample_correlated_normals_cholesky(
     rng: &mut FastRng,
     out: &mut [f64],
 ) -> Result<(), PricingError> {
+    let mut indep = vec![0.0; chol.len()];
+    sample_correlated_normals_cholesky_with_scratch(chol, rng, &mut indep, out)
+}
+
+/// Samples one vector of correlated normals using caller-provided scratch space.
+pub fn sample_correlated_normals_cholesky_with_scratch(
+    chol: &[Vec<f64>],
+    rng: &mut FastRng,
+    indep: &mut [f64],
+    out: &mut [f64],
+) -> Result<(), PricingError> {
     if chol.is_empty() || out.len() != chol.len() {
         return Err(PricingError::InvalidInput(
             "output length must match cholesky dimension".to_string(),
         ));
     }
+    if indep.len() != chol.len() {
+        return Err(PricingError::InvalidInput(
+            "scratch length must match cholesky dimension".to_string(),
+        ));
+    }
 
-    let mut indep = vec![0.0; chol.len()];
-    for z in &mut indep {
+    for z in indep.iter_mut() {
         *z = sample_standard_normal(rng);
     }
 
-    correlate_normals(chol, &indep, out);
+    correlate_normals(chol, indep, out);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated DSL benchmark harness
- reuse hot-path scratch buffers and observation snapshots in the DSL engine
- add parallel chunk pricing and SIMD path batching for DSL Monte Carlo

## Verification
- cargo test --release --features simd --test dsl_examples -- --nocapture
- cargo test --release --features "parallel simd" --test dsl_examples -- --nocapture
- cargo test --release --features "parallel simd" end_to_end_ -- --nocapture
- cargo bench --features simd --bench dsl_bench dsl_price -- --noplot
- cargo bench --features "parallel simd" --bench dsl_bench dsl_price -- --noplot