### PR TITLE
[codex] refresh README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
 
       - name: Build Python wheel
         run: maturin build --release -m python/Cargo.toml
+        env:
+          RUSTFLAGS: ""
 
       - name: Install wheel
         run: pip install target/wheels/*.whl

--- a/README.md
+++ b/README.md
@@ -1,24 +1,81 @@
 # OpenFerric
 
-**High-performance quantitative finance in Rust.** Derivatives pricing and risk analytics.
+**High-performance quantitative finance in Rust.** Derivatives pricing, funding and rates analytics, credit, risk, structured products, and tooling built around a shared Rust core.
 
 [![Crates.io](https://img.shields.io/crates/v/openferric.svg)](https://crates.io/crates/openferric)
 [![docs.rs](https://docs.rs/openferric/badge.svg)](https://docs.rs/openferric)
 [![Rust](https://img.shields.io/badge/Rust-stable-blue?logo=rust)](https://www.rust-lang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-501%20passing-brightgreen)](#testing)
 [![Coverage](https://codecov.io/gh/rosssaunders/openferric/graph/badge.svg)](https://codecov.io/gh/rosssaunders/openferric)
 
----
+OpenFerric is a Rust library first, but this repository also ships Python bindings, WebAssembly bindings, an Excel add-in, a VS Code extension and LSP for the OpenFerric DSL, and an MCP server for tool-driven integrations.
 
 ## Highlights
 
-- **366 tests** — validated against QuantLib, Haug, Alan Lewis, and Fabozzi reference values
-- **Trait-based architecture**: `Instrument` + `PricingEngine` — composable, extensible
-- **SIMD-accelerated**: AVX2 vectorized Black-Scholes (69M options/sec)
-- **FFT pricing**: Carr-Madan for entire strike grids in O(N log N)
-- **Python bindings**: Optional PyO3 module for research integration
-- **SQL integration**: Designed as extension for [OpenAssay](https://github.com/rosssaunders/openassay)
+- **Trait-based pricing core** built around `Instrument + Market + PricingEngine -> PricingResult`.
+- **Broad product coverage** across equity, FX, rates, credit, volatility, structured products, and portfolio risk.
+- **Funding-rate analytics** for Boros/Pendle-style swaps, including multi-venue curves, rolling stats, liquidation and margin simulation, and piecewise-linear or piecewise-constant interpolation.
+- **Structured product DSL** with `.of` examples, a VS Code pricing dashboard, and an LSP-backed editing experience.
+- **Multiple delivery surfaces** from one Rust core: crate, Python package, WebAssembly, Excel add-in, and MCP server.
+- **Performance-oriented execution** with SIMD, parallel Monte Carlo, optional WebGPU, and optional Cranelift JIT support.
+- **Reference-validated tests** against QuantLib, Haug, Alan Lewis, Fabozzi, and other external sources.
+
+## Demo and Examples
+
+- Example hosted demo: [openferric.netlify.app](https://openferric.netlify.app/) (example only, not the primary supported distribution surface)
+- Rust examples: [`examples/`](examples) and [docs/EXAMPLES.md](docs/EXAMPLES.md)
+- Python funding walkthrough: [examples/boros_funding_swap.py](examples/boros_funding_swap.py)
+- DSL guide: [docs/dsl.md](docs/dsl.md)
+- DSL sample products: [`examples/dsl/`](examples/dsl)
+
+## Quick Start
+
+```bash
+cargo add openferric
+```
+
+```rust
+use openferric::core::PricingEngine;
+use openferric::engines::analytic::BlackScholesEngine;
+use openferric::instruments::VanillaOption;
+use openferric::market::Market;
+
+let market = Market::builder()
+    .spot(100.0)
+    .rate(0.05)
+    .dividend_yield(0.0)
+    .flat_vol(0.20)
+    .build()?;
+
+let option = VanillaOption::european_call(100.0, 1.0);
+let result = BlackScholesEngine::new().price(&option, &market)?;
+
+println!("price = {:.4}", result.price);
+println!("delta = {:.4}", result.greeks.delta);
+```
+
+## Repo Components
+
+| Component | Purpose |
+|---|---|
+| `src/` | Core Rust library for pricing, rates, credit, volatility, calibration, models, DSL, and risk |
+| `python/` | PyO3 bindings for Python workflows and notebooks |
+| `wasm/` | `wasm-bindgen` bindings for browser and WebAssembly consumers |
+| `excel-addin/` | Excel add-in powered by the WASM build |
+| `vscode-ext/` + `lsp/` | VS Code extension and language server for `.of` DSL files with a pricing dashboard |
+| `mcp/` | MCP server exposing OpenFerric functionality as callable tools |
+
+## Coverage
+
+Full coverage notes live in [docs/COVERAGE.md](docs/COVERAGE.md). The current repo covers:
+
+- **Equity and FX**: Black-Scholes, barriers, digitals, Asians, lookbacks, spreads, baskets, rainbows, power options, convertibles, employee stock options, and more.
+- **Volatility and calibration**: Heston, SABR, SVI, local vol, Andreasen-Huge, Fengler, vanna-volga, forward variance, mixture models, and implied vol tooling.
+- **Rates and funding**: yield curves, bonds, swaps, FRAs, caps/floors, swaptions, OIS, inflation, CMS, cross-currency products, funding-rate curves, and funding-rate swaps.
+- **Credit and XVA**: survival curves, CDS, CDS options, CDS indices, nth-to-default baskets, CDO tranches, Gaussian copula, and XVA analytics.
+- **Structured products and DSL**: autocallables, phoenix notes, range accruals, TARFs, MBS pass-throughs, IO/PO strips, and a dedicated product DSL.
+- **Risk and scenarios**: VaR, Expected Shortfall, SA-CCR, portfolio aggregation, margin simulation, liquidation simulation, and stress workflows.
+- **Numerical engines**: analytic pricers, trees, PDEs, Monte Carlo, FFT, SIMD paths, GPU support, and optional JIT-backed DSL execution.
 
 ## Performance
 
@@ -33,103 +90,78 @@
 | Monte Carlo 100K paths | **406 ms** |
 | Vol surface recalibration | **< 50 ms** (20 expiry slices) |
 
-## Quick Start
-
-```rust
-use openferric::core::PricingEngine;
-use openferric::engines::analytic::BlackScholesEngine;
-use openferric::instruments::VanillaOption;
-use openferric::market::Market;
-
-let market = Market::builder()
-    .spot(100.0).rate(0.05).dividend_yield(0.0).flat_vol(0.20)
-    .build()?;
-
-let option = VanillaOption::european_call(100.0, 1.0);
-let result = BlackScholesEngine::new().price(&option, &market)?;
-println!("price = {:.4}, delta = {:.4}", result.price, result.greeks.delta);
-```
-
-See [docs/EXAMPLES.md](docs/EXAMPLES.md) for more — Heston FFT, CDS pricing, vol surface calibration.
-
-## Coverage
-
-Full coverage details in [docs/COVERAGE.md](docs/COVERAGE.md). Summary:
-
-**Equity & FX** — Black-Scholes, barriers, Asians, lookbacks, digitals, double barriers, rainbows, power options, compound/chooser/quanto, cliquets, variance swaps, convertibles, spread options, employee stock options
-
-**Volatility** — Heston, SABR, local vol (Dupire), SVI, Andreasen-Huge (arb-free), Fengler, vanna-volga, mixture of lognormals, Jäckel implied vol
-
-**Rates & Fixed Income** — Yield curves, bonds, swaps, FRAs, caps/floors, swaptions, cross-currency, OIS, inflation, CMS, multi-curve OIS framework
-
-**Credit** — CDS, survival curves, hazard rate bootstrap, ISDA model, CDS index, nth-to-default, CDO tranches, CDS options
-
-**Structured Products** — TARFs, range accruals, autocallables, MBS pass-throughs (PSA/CPR), IO/PO strips
-
-**Risk** — VaR, Expected Shortfall, CVA/DVA/FVA/MVA/KVA, wrong-way risk, SA-CCR, portfolio Greeks
-
-**Stochastic Models** — GBM, Heston, SABR, Hull-White, Vasicek, CIR, HJM, LMM/BGM, Variance Gamma, CGMY, NIG, rBergomi, stochastic local vol
-
-**Numerical Engines** — Analytic (15+), binomial/trinomial trees, explicit/implicit/Crank-Nicolson/Hopscotch FD, Longstaff-Schwartz, Monte Carlo (antithetic, control variate, SIMD, parallel), FFT (Carr-Madan, FRFT), generalized & two-asset trees
-
-## Architecture
-
-```
-Instruments ─→ Engines ─→ Market ─→ PricingResult
-                 │
-    ┌────────────┼────────────┐
-    │            │            │
- Analytic    Tree/PDE     Monte Carlo
- (closed)   (numerical)   (simulation)
-    │            │            │
-    └────────────┼────────────┘
-                 │
-            FFT / SIMD
-          (acceleration)
-```
-
 ## Feature Flags
 
 | Feature | Description |
 |---|---|
-| `python` | PyO3 bindings for Python integration |
-| `parallel` | Rayon-parallelized Monte Carlo |
+| `parallel` | Rayon-parallel Monte Carlo and parallel-enabled benchmark/test paths |
+| `simd` | SIMD code paths for AVX2 and NEON-enabled workloads |
+| `gpu` | WebGPU support for GPU-accelerated pricing paths |
+| `jit` | Cranelift-backed JIT support for DSL execution |
 
-## Testing
+## Build and Validation
 
-Test vectors are externally validated — not self-generated. The reference suite includes:
-
-- **43 European option cases** from Haug's *Option Pricing Formulas*
-- **10 Heston model cases** from Alan Lewis's 12-digit precision reference prices
-- **72 barrier option cases** from Haug
-- **4 Heston cached regression cases** from QuantLib
-
-QuantLib's C++ test suite is included as a git submodule at `vendor/QuantLib/` for reproducibility.
+Core Rust workflow:
 
 ```bash
-cargo test                              # all 366 tests
-cargo test --test quantlib_reference    # reference suite only
-cargo test --features parallel          # include parallel MC tests
-cargo llvm-cov --workspace --features parallel --summary-only  # local coverage metric
-cargo bench                             # Criterion benchmarks
+cargo build
+cargo build --release
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --features parallel,simd
+cargo test --workspace --features parallel,simd
+cargo bench
 ```
 
-## References
+TypeScript and Python linting:
 
-See [docs/REFERENCES.md](docs/REFERENCES.md) for the full list. Key sources:
+```bash
+npm ci
+npm run typecheck
+npm run lint
+ruff check python/ examples/
+ruff format --check python/ examples/
+```
 
-- Hull — *Options, Futures, and Other Derivatives*
-- Haug — *The Complete Guide to Option Pricing Formulas*
-- Gatheral — *The Volatility Surface*
-- Carr & Madan — *Option Valuation Using the FFT*
-- Hagan et al. — *Managing Smile Risk* (SABR)
+Python package:
 
-## Acknowledgements
+```bash
+maturin build --release -m python/Cargo.toml
+pip install target/wheels/*.whl
+pytest python/tests/ -v
+```
 
-- **[QuantLib](https://www.quantlib.org/)** — Reference test vectors (BSD-3-Clause). Included as submodule at `vendor/QuantLib/`.
-- **Alan Lewis** — High-precision Heston reference prices.
-- **E.G. Haug** — Extensive option pricing test cases.
-- **F.J. Fabozzi** — MBS/ABS reference values.
+WASM build:
+
+```bash
+wasm-pack build wasm --target web --out-dir ../www/pkg
+```
+
+Coverage helpers:
+
+```bash
+make install-coverage
+make coverage-test
+make coverage-bench
+make coverage-bench-parallel
+make coverage-all
+make coverage-lcov
+```
+
+## Testing and References
+
+OpenFerric uses externally validated references rather than self-generated assertions wherever practical.
+
+- QuantLib is vendored as a git submodule at [`vendor/QuantLib/`](vendor/QuantLib) for reproducible cross-checks.
+- The test suite includes reference cases from Haug, Alan Lewis, Fabozzi, and other published sources.
+- Integration tests live in [`tests/`](tests), while module-level unit tests stay close to implementation code.
+
+See [docs/REFERENCES.md](docs/REFERENCES.md) for source material and [docs/EXAMPLES.md](docs/EXAMPLES.md) for end-to-end usage examples.
+
+## Related Surfaces
+
+- [Python bindings README](python/README.md)
+- [Excel add-in README](excel-addin/README.md)
+- [OpenAssay](https://github.com/rosssaunders/openassay) for SQL-oriented integration work
 
 ## License
 


### PR DESCRIPTION
## What changed
- refresh `README.md` to reflect the current repository layout and supported surfaces
- document the Rust core alongside the Python bindings, WASM build, Excel add-in, VS Code extension/LSP, and MCP server
- update the feature flag section to match the current crate features (`parallel`, `simd`, `gpu`, `jit`)
- refresh build, lint, test, and coverage commands to match current CI and workspace tooling
- add the hosted Netlify app as an example/demo link
- clear `RUSTFLAGS` for the `maturin build --release -m python/Cargo.toml` CI step so GitHub runners do not inherit local `target-cpu=native` settings

## Why
The previous README had drifted behind the repository. It still used brittle test counts, omitted newer surfaces like `lsp` and `mcp`, and did not mention recent funding-rate and DSL positioning.

While merging the README update, CI exposed an existing workflow gap: the Python wheel build step still inherited `target-cpu=native` from `.cargo/config.toml`, which caused `rustc` to crash with `SIGILL` on the GitHub runner during the release build. The workflow now clears `RUSTFLAGS` for that step, consistent with the other CI Rust steps.

## Impact
- the top-level project documentation better matches the current repository
- new users can find the main delivery surfaces and example/demo entry points more easily
- setup and validation instructions are closer to the commands the repo actually uses
- the protected `Test` job no longer relies on runner-specific CPU features when building the Python wheel

## Validation
- `git diff --check`
- repository pre-commit hook during `git commit` (`cargo fmt --check`, `cargo clippy`, `eslint`, `tsc`, `ruff check`, `ruff format --check`)
- `RUSTFLAGS='' maturin build --release -m python/Cargo.toml`

## Notes
- the original CI failure was unrelated to the README content itself; it was triggered by the branch running the existing Python wheel build path