### PR TITLE
[codex] fix NEON SIMD exponent reconstruction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,26 @@ jobs:
       - name: Run Python tests
         run: pytest python/tests/ -v
 
+  arm64-simd:
+    name: ARM64 SIMD
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run NEON SIMD regressions
+        run: |
+          cargo test -p openferric --test simd_test --features simd
+          cargo test -p openferric --lib --features simd commodity_forward_product_mean_reverts
+        env:
+          RUSTFLAGS: ""
+
   wasm:
     name: WASM
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,9 @@ Current CI in `.github/workflows/ci.yml` runs:
 1. `cargo fmt --all --check`
 2. `cargo clippy --workspace --all-targets --features parallel,simd`
 3. `cargo test --workspace --features parallel,simd`
-4. Python wheel build plus `pytest python/tests -v`
-5. `wasm-pack build wasm --target web --out-dir ../www/pkg`
+4. ARM64 NEON SIMD regression tests on `ubuntu-24.04-arm`
+5. Python wheel build plus `pytest python/tests -v`
+6. `wasm-pack build wasm --target web --out-dir ../www/pkg`
 
 Prefer validating the narrowest relevant subset locally, but make sure changes are consistent with the CI commands above before opening a PR.
 

--- a/src/math/simd_neon.rs
+++ b/src/math/simd_neon.rs
@@ -87,14 +87,11 @@ pub unsafe fn simd_exp_f64x2(x: float64x2_t) -> float64x2_t {
     poly = vfmaq_f64(one, poly, r);
     poly = vfmaq_f64(one, poly, r);
 
-    // Reconstruct: exp(x) = poly * 2^n via IEEE 754 exponent manipulation
-    let mut n_lanes = [0_i64; 2];
-    vst1q_f64(n_lanes.as_mut_ptr() as *mut f64, n_f64);
-    let mut exp_lanes = [0_u64; 2];
-    for i in 0..2 {
-        exp_lanes[i] = ((n_lanes[i] + 1023) as u64) << 52;
-    }
-    let two_pow_n: float64x2_t = std::mem::transmute(vld1q_u64(exp_lanes.as_ptr()));
+    // Reconstruct: exp(x) = poly * 2^n via IEEE 754 exponent manipulation.
+    let n_i64 = vcvtq_s64_f64(n_f64);
+    let biased_exponent = vaddq_s64(n_i64, vdupq_n_s64(1023));
+    let exp_bits = vshlq_n_s64(biased_exponent, 52);
+    let two_pow_n = vreinterpretq_f64_s64(exp_bits);
     vmulq_f64(poly, two_pow_n)
 }
 

--- a/tests/simd_test.rs
+++ b/tests/simd_test.rs
@@ -253,7 +253,99 @@ mod neon_tests {
 
     use openferric::core::OptionType;
     use openferric::engines::analytic::bs_price_batch;
+    #[cfg(feature = "simd")]
+    use openferric::math::simd_neon::{load_f64x2, simd_exp_f64x2, simd_ln_f64x2, store_f64x2};
     use openferric::pricing::european::black_scholes_price;
+
+    #[cfg(feature = "simd")]
+    unsafe fn neon_ln_batch(xs: &[f64]) -> Vec<f64> {
+        let mut out = vec![0.0; xs.len()];
+        let mut i = 0usize;
+        while i + 2 <= xs.len() {
+            let x = unsafe { load_f64x2(xs, i) };
+            let y = unsafe { simd_ln_f64x2(x) };
+            unsafe { store_f64x2(&mut out, i, y) };
+            i += 2;
+        }
+        while i < xs.len() {
+            out[i] = xs[i].ln();
+            i += 1;
+        }
+        out
+    }
+
+    #[cfg(feature = "simd")]
+    unsafe fn neon_exp_batch(xs: &[f64]) -> Vec<f64> {
+        let mut out = vec![0.0; xs.len()];
+        let mut i = 0usize;
+        while i + 2 <= xs.len() {
+            let x = unsafe { load_f64x2(xs, i) };
+            let y = unsafe { simd_exp_f64x2(x) };
+            unsafe { store_f64x2(&mut out, i, y) };
+            i += 2;
+        }
+        while i < xs.len() {
+            out[i] = xs[i].exp();
+            i += 1;
+        }
+        out
+    }
+
+    #[cfg(feature = "simd")]
+    #[test]
+    fn neon_ln_matches_scalar() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            return;
+        }
+
+        let mut rng = StdRng::seed_from_u64(7);
+        let n = 32_768usize;
+        let mut xs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let e = rng.random_range(-300.0..300.0);
+            let m = rng.random_range(1.0..10.0);
+            xs.push(m * 10f64.powf(e));
+        }
+
+        let simd = unsafe { neon_ln_batch(&xs) };
+        for (x, y) in xs.iter().zip(simd.iter()) {
+            let expected = x.ln();
+            let abs_err = (*y - expected).abs();
+            assert!(
+                abs_err <= 1e-9,
+                "x={x} neon={y} expected={expected} abs_err={abs_err}"
+            );
+        }
+    }
+
+    #[cfg(feature = "simd")]
+    #[test]
+    fn neon_exp_matches_scalar() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            return;
+        }
+
+        let mut rng = StdRng::seed_from_u64(11);
+        let n = 32_768usize;
+        let mut xs = Vec::with_capacity(n);
+        for _ in 0..n {
+            xs.push(rng.random_range(-700.0..700.0));
+        }
+
+        let simd = unsafe { neon_exp_batch(&xs) };
+        for (x, y) in xs.iter().zip(simd.iter()) {
+            let expected = x.exp();
+            let rel_err = if expected.abs() > 0.0 {
+                ((*y - expected) / expected).abs()
+            } else {
+                (*y - expected).abs()
+            };
+            assert!(
+                rel_err <= 1e-12,
+                "x={x} neon={y} expected={expected} rel_err={rel_err}"
+            );
+        }
+    }
 
     #[test]
     fn neon_bs_price_matches_scalar_within_1e6() {


### PR DESCRIPTION
## Summary
- Fix the ARM64 NEON `simd_exp_f64x2` exponent reconstruction by converting rounded exponent lanes to integers before building IEEE exponent bits.
- Add ARM64 regression coverage for NEON `ln`, `exp`, and Black-Scholes batch pricing.
- Add a GitHub Actions `ubuntu-24.04-arm` job to block future NEON SIMD regressions.
- Update `AGENTS.md` to document the new ARM64 CI baseline.

## Validation
- `cargo test -p openferric --test simd_test --features simd -- --nocapture`
- `cargo test -p openferric --lib --features simd commodity_forward_product_mean_reverts -- --nocapture`
- `cargo fmt --all --check`
- `cargo test --workspace --features parallel,simd`
- `cargo clippy --workspace --all-targets --features parallel,simd`
- `git diff --check`
- pre-commit hook during commit