### PR TITLE
Review follow-up: final four performance items

### DIFF
--- a/src/rates/funding_rate.rs
+++ b/src/rates/funding_rate.rs
@@ -113,7 +113,7 @@ pub struct FundingRateCurve {
     anchor_timestamp: Option<DateTime<Utc>>,
     nodes: Vec<(f64, f64)>,
     interpolation_mode: FundingRateInterpolation,
-    interpolator: Option<Box<dyn Interpolator + Send + Sync>>,
+    interpolator: Option<std::sync::Arc<dyn Interpolator + Send + Sync>>,
 }
 
 impl std::fmt::Debug for FundingRateCurve {
@@ -130,7 +130,16 @@ impl std::fmt::Debug for FundingRateCurve {
 
 impl Clone for FundingRateCurve {
     fn clone(&self) -> Self {
-        Self::new_with_interpolation(self.snapshots.clone(), self.interpolation_mode)
+        // All fields are immutable after construction; the interpolator is
+        // shared via Arc rather than rebuilt (clones sit on bump-and-reprice
+        // paths such as parallel_shifted/volatility_shifted).
+        Self {
+            snapshots: self.snapshots.clone(),
+            anchor_timestamp: self.anchor_timestamp,
+            nodes: self.nodes.clone(),
+            interpolation_mode: self.interpolation_mode,
+            interpolator: self.interpolator.clone(),
+        }
     }
 }
 
@@ -440,7 +449,7 @@ fn build_nodes(
 fn build_interpolator(
     nodes: &[(f64, f64)],
     mode: FundingRateInterpolation,
-) -> Option<Box<dyn Interpolator + Send + Sync>> {
+) -> Option<std::sync::Arc<dyn Interpolator + Send + Sync>> {
     if nodes.len() < 2 {
         return None;
     }
@@ -450,11 +459,11 @@ fn build_interpolator(
     match mode {
         FundingRateInterpolation::Linear => LinearInterpolator::new(x, y, ExtrapolationMode::Flat)
             .ok()
-            .map(|i| Box::new(i) as Box<dyn Interpolator + Send + Sync>),
+            .map(|i| std::sync::Arc::new(i) as std::sync::Arc<dyn Interpolator + Send + Sync>),
         FundingRateInterpolation::PiecewiseConstant => {
             PiecewiseConstantInterpolator::new(x, y, ExtrapolationMode::Flat)
                 .ok()
-                .map(|i| Box::new(i) as Box<dyn Interpolator + Send + Sync>)
+                .map(|i| std::sync::Arc::new(i) as std::sync::Arc<dyn Interpolator + Send + Sync>)
         }
     }
 }

--- a/src/risk/sensitivities.rs
+++ b/src/risk/sensitivities.rs
@@ -310,14 +310,9 @@ fn locate_bounds(grid: &[f64], x: f64) -> (usize, usize, f64) {
         return (last, last, 0.0);
     }
 
-    let mut lo = 0usize;
-    for i in 0..last {
-        if x >= grid[i] && x <= grid[i + 1] {
-            lo = i;
-            break;
-        }
-    }
-    let hi = lo + 1;
+    // grid[0] < x < grid[last]: first index with grid[hi] >= x is in [1, last].
+    let hi = grid.partition_point(|&g| g < x);
+    let lo = hi - 1;
     let w = (x - grid[lo]) / (grid[hi] - grid[lo]);
     (lo, hi, w)
 }
@@ -344,6 +339,7 @@ fn derivative(base: f64, up: f64, down: Option<f64>, h: f64, scheme: Differencin
 
 fn second_derivative<F>(
     mut eval: F,
+    base_price: f64,
     base_state: &[f64],
     idx: usize,
     h: f64,
@@ -359,10 +355,9 @@ where
             let mut dn = base_state.to_vec();
             dn[idx] -= h;
 
-            let p0 = eval(base_state);
             let p_up = eval(&up);
             let p_dn = eval(&dn);
-            (p_up - 2.0 * p0 + p_dn) / (h * h)
+            (p_up - 2.0 * base_price + p_dn) / (h * h)
         }
         DifferencingScheme::Forward => {
             let mut up = base_state.to_vec();
@@ -370,10 +365,9 @@ where
             let mut up2 = base_state.to_vec();
             up2[idx] += 2.0 * h;
 
-            let p0 = eval(base_state);
             let p_up = eval(&up);
             let p_up2 = eval(&up2);
-            (p_up2 - 2.0 * p_up + p0) / (h * h)
+            (p_up2 - 2.0 * p_up + base_price) / (h * h)
         }
     }
 }
@@ -596,6 +590,8 @@ where
     P: Fn(&YieldCurve) -> f64,
 {
     let state = curve_state(curve, config.mode);
+    // The unbumped price is pillar-independent; price it once for the ladder.
+    let base_price = pricer(curve);
 
     curve
         .tenors
@@ -608,6 +604,7 @@ where
                     let c = curve_from_state(curve, config.mode, x);
                     pricer(&c)
                 },
+                base_price,
                 &state,
                 idx,
                 h,

--- a/src/risk/var.rs
+++ b/src/risk/var.rs
@@ -226,9 +226,16 @@ pub fn rolling_historical_var_from_prices(
         "window must be < number of returns for out-of-sample backtest"
     );
 
+    // Reuse one loss buffer and select the two quantile ranks per window
+    // (O(n*w)) instead of allocating and fully sorting every window
+    // (O(n*w*log w)). Matches historical_var's interpolated quantile exactly.
+    let mut losses = vec![0.0; window];
     let mut forecasts = Vec::with_capacity(returns.len() - window);
     for i in window..returns.len() {
-        forecasts.push(historical_var(&returns[(i - window)..i], confidence));
+        for (loss, r) in losses.iter_mut().zip(&returns[(i - window)..i]) {
+            *loss = -r;
+        }
+        forecasts.push(empirical_quantile_select(&mut losses, confidence).max(0.0));
     }
     forecasts
 }
@@ -277,6 +284,33 @@ fn validate_params(confidence: f64, annual_volatility: f64, horizon_days: f64) {
         horizon_days.is_finite() && horizon_days > 0.0,
         "horizon_days must be finite and > 0"
     );
+}
+
+/// Interpolated empirical quantile via selection instead of a full sort;
+/// identical to `empirical_quantile` for any input.
+fn empirical_quantile_select(sample: &mut [f64], p: f64) -> f64 {
+    let n = sample.len();
+    if n == 1 {
+        return sample[0];
+    }
+
+    let rank = p * (n as f64 - 1.0);
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    let (_, lo_val, above) = sample.select_nth_unstable_by(lo, |a, b| a.total_cmp(b));
+    let lo_val = *lo_val;
+    if lo == hi {
+        return lo_val;
+    }
+
+    // sorted[lo + 1] is the minimum of the partition above the lo-th element.
+    let hi_val = above
+        .iter()
+        .copied()
+        .min_by(|a, b| a.total_cmp(b))
+        .expect("hi rank exists when lo < hi");
+    let w = rank - lo as f64;
+    lo_val + w * (hi_val - lo_val)
 }
 
 fn empirical_quantile(sample: &mut [f64], p: f64) -> f64 {
@@ -330,6 +364,34 @@ fn sample_moments(values: &[f64]) -> (f64, f64, f64, f64) {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn quantile_select_matches_full_sort_quantile() {
+        // Deterministic LCG sample with ties and negatives.
+        let mut state = 0x2545_f491_4f6c_dd1d_u64;
+        let mut sample: Vec<f64> = (0..257)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (((state >> 33) % 1000) as f64 - 500.0) / 100.0
+            })
+            .collect();
+        for p in [0.0, 0.01, 0.25, 0.5, 0.95, 0.99, 0.999] {
+            let mut a = sample.clone();
+            let mut b = sample.clone();
+            let q_sort = super::empirical_quantile(&mut a, p);
+            let q_sel = super::empirical_quantile_select(&mut b, p);
+            assert_eq!(q_sort, q_sel, "p={p}");
+        }
+        sample.truncate(1);
+        let mut a = sample.clone();
+        let mut b = sample;
+        assert_eq!(
+            super::empirical_quantile(&mut a, 0.5),
+            super::empirical_quantile_select(&mut b, 0.5)
+        );
+    }
+
     use approx::assert_relative_eq;
     use rand::SeedableRng;
     use rand::rngs::StdRng;


### PR DESCRIPTION
Follow-up to #183 (merged): closes out the last four performance findings from the library review that hadn't been assigned in the main fix waves.

- **`risk/sensitivities.rs`**: `gamma_ladder` prices the unbumped curve once for the whole ladder instead of once per pillar (saves n full revaluations); `locate_bounds` uses `partition_point` instead of a linear scan.
- **`risk/var.rs`**: rolling historical VaR reuses one loss buffer and selects the two interpolation ranks per window — O(n·w) instead of O(n·w·log w) with a fresh allocation and full sort per window. Exact equivalence with the sort-based quantile is tested.
- **`rates/funding_rate.rs`**: the interpolator is shared via `Arc`, so `Clone` (used on `parallel_shifted`/`volatility_shifted` bump paths) is a refcount bump instead of re-running sanitize/sort/interpolator construction.

With this, every bug and every ranked performance item from `docs/reviews/2026-06-09-full-library-review.md` is addressed.

Validation: risk (56) and rates (38) lib tests green, fmt clean, workspace clippy zero errors.

https://claude.ai/code/session_01FAx1FjfzYunS5ZmSzywFjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAx1FjfzYunS5ZmSzywFjv)_