### PR TITLE
Verification infrastructure: cross-engine consistency, property invariants, hot-path benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,10 @@ harness = false
 name = "interpolation_bench"
 harness = false
 
+[[bench]]
+name = "hot_paths_bench"
+harness = false
+
 [[example]]
 name = "boros_funding_swap"
 

--- a/benches/hot_paths_bench.rs
+++ b/benches/hot_paths_bench.rs
@@ -1,0 +1,393 @@
+//! Benchmarks for recently optimized hot paths.
+//!
+//! Covers, in order:
+//! - SVI vol-surface queries (total-variance interpolation across expiries),
+//! - analytic Black-Scholes price + Greeks (baseline reference),
+//! - Monte Carlo European pricing: standard engine and the SoA SIMD path,
+//! - ADI Heston PDE pricing on a moderate grid,
+//! - Longstaff-Schwartz American put,
+//! - autocallable price-only vs price-with-Greeks (the ~9x split),
+//! - CDS survival-curve bootstrap (5 pillars),
+//! - bounded Levenberg-Marquardt Heston calibration (1 LM iteration),
+//! - rolling historical VaR (5k returns, window 250),
+//! - gamma ladder on a 10-pillar yield curve.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use openferric::calibration::{Calibrator, HestonCalibrator, LmOptions, OptionVolQuote};
+use openferric::core::PricingEngine;
+use openferric::credit::bootstrap_survival_curve_from_cds_spreads;
+use openferric::engines::analytic::BlackScholesEngine;
+use openferric::engines::lsm::LongstaffSchwartzEngine;
+use openferric::engines::monte_carlo::{
+    MonteCarloPricingEngine, mc_european_call_soa, mc_european_call_soa_scalar,
+};
+use openferric::engines::pde::{AdiHestonEngine, AdiScheme};
+use openferric::instruments::{Autocallable, VanillaOption};
+use openferric::market::Market;
+use openferric::models::stochastic::Heston;
+use openferric::pricing::autocallable::{price_autocallable, price_autocallable_with_greeks};
+use openferric::rates::YieldCurve;
+use openferric::risk::sensitivities::{CurveBumpConfig, gamma_ladder};
+use openferric::risk::var::rolling_historical_var_from_prices;
+use openferric::vol::surface::{SviParams, VolSurface};
+use std::hint::black_box;
+
+fn benchmark_market() -> Market {
+    Market::builder()
+        .spot(100.0)
+        .rate(0.05)
+        .dividend_yield(0.0)
+        .flat_vol(0.20)
+        .build()
+        .expect("benchmark market should be valid")
+}
+
+/// Multi-expiry SVI surface; queries exercise the total-variance
+/// interpolation path between expiry knots.
+fn benchmark_vol_surface() -> VolSurface {
+    let expiries = [0.1, 0.25, 0.5, 1.0, 2.0];
+    let slices: Vec<(f64, SviParams)> = expiries
+        .iter()
+        .enumerate()
+        .map(|(i, &t)| {
+            let scale = 1.0 + 0.1 * i as f64;
+            (
+                t,
+                SviParams {
+                    a: 0.015 * t * scale,
+                    b: 0.10 * scale,
+                    rho: -0.3 - 0.05 * i as f64,
+                    m: 0.01 * i as f64,
+                    sigma: 0.25 + 0.02 * i as f64,
+                },
+            )
+        })
+        .collect();
+    VolSurface::new(slices, 100.0).expect("benchmark surface should be valid")
+}
+
+fn bench_vol_surface_query(c: &mut Criterion) {
+    let surface = benchmark_vol_surface();
+
+    // Strided (K, T) grid: strikes 60..140, expiries deliberately off the
+    // knot grid so every query interpolates between two SVI slices.
+    let strikes: Vec<f64> = (0..16).map(|i| 60.0 + i as f64 * 5.0).collect();
+    let times: Vec<f64> = (0..8).map(|j| 0.15 + j as f64 * 0.22).collect();
+
+    c.bench_function("vol_surface_query_128", |b| {
+        b.iter(|| {
+            let mut acc = 0.0;
+            for &t in &times {
+                for &k in &strikes {
+                    acc += surface.vol(black_box(k), black_box(t));
+                }
+            }
+            black_box(acc)
+        })
+    });
+}
+
+fn bench_black_scholes_price_greeks(c: &mut Criterion) {
+    let market = benchmark_market();
+    let option = VanillaOption::european_call(100.0, 1.0);
+    let engine = BlackScholesEngine::new();
+
+    // Analytic BS returns price + full Greeks in one call; this is the
+    // reference baseline for the other engines below.
+    c.bench_function("bs_analytic_price_greeks", |b| {
+        b.iter(|| {
+            let result = engine
+                .price(black_box(&option), black_box(&market))
+                .expect("pricing should succeed");
+            black_box((result.price, result.greeks))
+        })
+    });
+}
+
+fn bench_mc_european_50k(c: &mut Criterion) {
+    let market = benchmark_market();
+    let option = VanillaOption::european_call(100.0, 1.0);
+
+    let mut group = c.benchmark_group("mc_european_50k");
+    group.sample_size(10);
+
+    let engine = MonteCarloPricingEngine::new(50_000, 64, 42);
+    group.bench_function("standard_engine", |b| {
+        b.iter(|| {
+            let px = engine
+                .price(black_box(&option), black_box(&market))
+                .expect("pricing should succeed")
+                .price;
+            black_box(px)
+        })
+    });
+
+    // SoA scalar reference path.
+    group.bench_function("soa_scalar", |b| {
+        b.iter(|| {
+            black_box(mc_european_call_soa_scalar(
+                100.0, 100.0, 0.05, 0.0, 0.20, 1.0, 50_000, 64, 42,
+            ))
+        })
+    });
+
+    // Runtime-dispatched SoA path; uses AVX2/NEON when built with the
+    // `simd` feature and supported by the host.
+    #[cfg(feature = "simd")]
+    group.bench_function("soa_simd_dispatch", |b| {
+        b.iter(|| {
+            black_box(mc_european_call_soa(
+                100.0, 100.0, 0.05, 0.0, 0.20, 1.0, 50_000, 64, 42,
+            ))
+        })
+    });
+    #[cfg(not(feature = "simd"))]
+    let _ = mc_european_call_soa;
+
+    group.finish();
+}
+
+fn bench_adi_heston_pde(c: &mut Criterion) {
+    let market = benchmark_market();
+    let option = VanillaOption::european_call(100.0, 1.0);
+    let model = Heston {
+        mu: 0.05,
+        kappa: 2.0,
+        theta: 0.04,
+        xi: 0.3,
+        rho: -0.7,
+        v0: 0.04,
+    };
+    // Moderate grid: 50 time steps on a 100 x 50 (S, v) mesh.
+    let engine = AdiHestonEngine::new(model, 50, 100, 50).with_scheme(AdiScheme::CraigSneyd);
+
+    let mut group = c.benchmark_group("adi_heston_pde");
+    group.sample_size(20);
+    group.bench_function("craig_sneyd_50x100x50", |b| {
+        b.iter(|| {
+            let px = engine
+                .price(black_box(&option), black_box(&market))
+                .expect("pricing should succeed")
+                .price;
+            black_box(px)
+        })
+    });
+    group.finish();
+}
+
+fn bench_lsm_american_put(c: &mut Criterion) {
+    let market = benchmark_market();
+    let option = VanillaOption::american_put(100.0, 1.0);
+    let engine = LongstaffSchwartzEngine::new(20_000, 50, 42);
+
+    let mut group = c.benchmark_group("lsm_american_put");
+    group.sample_size(10);
+    group.bench_function("paths_20k_steps_50", |b| {
+        b.iter(|| {
+            let px = engine
+                .price(black_box(&option), black_box(&market))
+                .expect("pricing should succeed")
+                .price;
+            black_box(px)
+        })
+    });
+    group.finish();
+}
+
+fn benchmark_autocallable() -> Autocallable {
+    Autocallable {
+        underlyings: vec![0, 1],
+        notional: 100.0,
+        autocall_dates: vec![0.5, 1.0, 1.5, 2.0],
+        autocall_barrier: 1.0,
+        coupon_rate: 0.08,
+        ki_barrier: 0.6,
+        ki_strike: 1.0,
+        maturity: 2.0,
+    }
+}
+
+fn bench_autocallable_price_vs_greeks(c: &mut Criterion) {
+    let autocall = benchmark_autocallable();
+    let spots = [100.0, 95.0];
+    let vols = [0.25, 0.30];
+    let corr = vec![vec![1.0, 0.5], vec![0.5, 1.0]];
+    let (n_paths, n_steps) = (10_000usize, 100usize);
+
+    let mut group = c.benchmark_group("autocallable");
+    group.sample_size(10);
+
+    // Price-only path: no bump-and-reprice ladder.
+    group.bench_function("price_only", |b| {
+        b.iter(|| {
+            let result = price_autocallable(
+                black_box(&autocall),
+                black_box(&spots),
+                black_box(&vols),
+                black_box(&corr),
+                0.03,
+                0.0,
+                n_paths,
+                n_steps,
+            );
+            black_box(result.price)
+        })
+    });
+
+    // Bump-and-reprice Greeks ladder: roughly 9x the price-only cost.
+    group.bench_function("price_with_greeks", |b| {
+        b.iter(|| {
+            let result = price_autocallable_with_greeks(
+                black_box(&autocall),
+                black_box(&spots),
+                black_box(&vols),
+                black_box(&corr),
+                0.03,
+                0.0,
+                n_paths,
+                n_steps,
+            );
+            black_box((result.price, result.greeks))
+        })
+    });
+
+    group.finish();
+}
+
+fn benchmark_discount_curve() -> YieldCurve {
+    // Flat 2% continuously compounded zero curve on 6 nodes.
+    let tenors: Vec<(f64, f64)> = [0.5_f64, 1.0, 2.0, 3.0, 5.0, 10.0]
+        .iter()
+        .map(|&t| (t, (-0.02 * t).exp()))
+        .collect();
+    YieldCurve::new(tenors)
+}
+
+fn bench_cds_bootstrap(c: &mut Criterion) {
+    let discount_curve = benchmark_discount_curve();
+    let spreads = [
+        (1.0, 0.008),
+        (3.0, 0.011),
+        (5.0, 0.014),
+        (7.0, 0.016),
+        (10.0, 0.018),
+    ];
+
+    c.bench_function("cds_bootstrap_5_pillars", |b| {
+        b.iter(|| {
+            let curve = bootstrap_survival_curve_from_cds_spreads(
+                black_box(&spreads),
+                0.40,
+                4,
+                black_box(&discount_curve),
+            );
+            black_box(curve.survival_prob(10.0))
+        })
+    });
+}
+
+fn bench_heston_lm_calibration_one_iter(c: &mut Criterion) {
+    // Small single-expiry quote set with LM capped at one iteration: this
+    // bounds the bench to the residual + finite-difference Jacobian cost
+    // (the dominant per-iteration work) without a full calibration run.
+    let cal = HestonCalibrator {
+        lm_options: LmOptions {
+            max_iterations: 1,
+            max_stagnation: 1,
+            ..LmOptions::default()
+        },
+        ..HestonCalibrator::default()
+    };
+
+    let strikes = [80.0, 90.0, 95.0, 100.0, 105.0, 110.0, 120.0];
+    let vols = [0.25, 0.23, 0.215, 0.205, 0.20, 0.205, 0.22];
+    let quotes: Vec<OptionVolQuote> = strikes
+        .iter()
+        .zip(vols.iter())
+        .enumerate()
+        .map(|(i, (&k, &v))| OptionVolQuote::new(format!("Q{i}"), k, 1.0, v))
+        .collect();
+
+    let mut group = c.benchmark_group("heston_lm_calibration");
+    group.sample_size(10);
+    group.bench_function("one_iteration_7_quotes", |b| {
+        b.iter(|| {
+            let result = cal
+                .calibrate(black_box(&quotes))
+                .expect("bounded calibration should succeed");
+            black_box(result.objective)
+        })
+    });
+    group.finish();
+}
+
+/// Deterministic pseudo-random price series (xorshift; no external RNG dep).
+fn benchmark_price_series(n: usize) -> Vec<f64> {
+    let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+    let mut prices = Vec::with_capacity(n);
+    let mut p = 100.0_f64;
+    for _ in 0..n {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        // Uniform in [-1, 1), scaled to ~1% daily moves.
+        let u = (state >> 11) as f64 / (1u64 << 53) as f64;
+        p *= 1.0 + 0.01 * (2.0 * u - 1.0);
+        prices.push(p);
+    }
+    prices
+}
+
+fn bench_rolling_historical_var(c: &mut Criterion) {
+    // 5001 prices -> 5000 returns; 250-day window -> 4750 forecasts.
+    let prices = benchmark_price_series(5_001);
+
+    let mut group = c.benchmark_group("rolling_historical_var");
+    group.sample_size(20);
+    group.bench_function("returns_5k_window_250", |b| {
+        b.iter(|| {
+            let forecasts = rolling_historical_var_from_prices(black_box(&prices), 250, 0.99, true);
+            black_box(forecasts)
+        })
+    });
+    group.finish();
+}
+
+fn bench_gamma_ladder(c: &mut Criterion) {
+    // 10-pillar curve; pricer values a 20-cashflow annuity off the curve.
+    let tenors: Vec<(f64, f64)> = (1..=10)
+        .map(|i| {
+            let t = i as f64;
+            (t, (-0.02 * t).exp())
+        })
+        .collect();
+    let curve = YieldCurve::new(tenors);
+    let cashflow_times: Vec<f64> = (1..=20).map(|i| i as f64 * 0.5).collect();
+
+    c.bench_function("gamma_ladder_10_pillars", |b| {
+        b.iter(|| {
+            let ladder = gamma_ladder(black_box(&curve), CurveBumpConfig::default(), |c| {
+                cashflow_times
+                    .iter()
+                    .map(|&t| 2.5 * c.discount_factor(t))
+                    .sum::<f64>()
+            });
+            black_box(ladder)
+        })
+    });
+}
+
+criterion_group!(
+    hot_path_benches,
+    bench_vol_surface_query,
+    bench_black_scholes_price_greeks,
+    bench_mc_european_50k,
+    bench_adi_heston_pde,
+    bench_lsm_american_put,
+    bench_autocallable_price_vs_greeks,
+    bench_cds_bootstrap,
+    bench_heston_lm_calibration_one_iter,
+    bench_rolling_historical_var,
+    bench_gamma_ladder
+);
+criterion_main!(hot_path_benches);

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -1,0 +1,794 @@
+//! Cross-engine consistency tests.
+//!
+//! Every test in this file prices the SAME instrument through several
+//! independent engines and asserts agreement. This catches sign/convention
+//! bugs, drift/discounting mistakes, and payoff wiring errors that no
+//! single-engine reference test can see.
+//!
+//! Engine pairs covered:
+//! 1. European vanillas: Black-Scholes analytic vs CRR binomial tree vs
+//!    trinomial tree vs Crank-Nicolson PDE vs Monte Carlo vs Carr-Madan FFT
+//!    (exact Black-Scholes characteristic function, puts via put-call parity).
+//! 2. American puts: CRR binomial vs `AmericanBinomialEngine` vs trinomial vs
+//!    Crank-Nicolson PDE vs Longstaff-Schwartz LSM. American calls with q = 0
+//!    and r >= 0 must equal European calls (no early exercise).
+//! 3. Barriers: Reiner-Rubinstein analytic vs discretely-monitored MC using
+//!    the Broadie-Glasserman-Kou barrier shift, one-sided discrete-vs-
+//!    continuous ordering, and in + out = vanilla parity inside each engine.
+//! 4. Asians: geometric discrete closed form vs MC geometric payoff.
+//! 5. Digitals: cash-or-nothing analytic vs an exact-terminal-GBM MC.
+//!
+//! Tolerances:
+//! - Deterministic engines (tree/PDE/FFT): documented per test, generally
+//!   relative 2e-3 plus a small absolute floor for deep out-of-the-money
+//!   points whose prices are ~1e-12 (relative error is meaningless there).
+//! - Monte Carlo: |mc - reference| <= 4 * stderr + 5e-7. The absolute floor
+//!   covers deep-OTM points below Monte Carlo resolution: when the exercise
+//!   probability is ~1e-7, 60k paths produce zero payoffs (stderr exactly 0)
+//!   while the analytic price is a positive number of that magnitude.
+//!
+//! All Monte Carlo engines use fixed seeds; the suite is fully deterministic
+//! and uses no external data.
+
+use openferric::core::types::AsianSpec;
+use openferric::core::{Averaging, OptionType, PricingEngine, StrikeType};
+use openferric::engines::analytic::{
+    BarrierAnalyticEngine, BlackScholesEngine, DigitalAnalyticEngine, GeometricAsianEngine,
+};
+use openferric::engines::fft::{BlackScholesCharFn, CarrMadanParams, carr_madan_price_at_strikes};
+use openferric::engines::lsm::LongstaffSchwartzEngine;
+use openferric::engines::monte_carlo::MonteCarloPricingEngine;
+use openferric::engines::numerical::AmericanBinomialEngine;
+use openferric::engines::pde::CrankNicolsonEngine;
+use openferric::engines::tree::{BinomialTreeEngine, TrinomialTreeEngine};
+use openferric::instruments::{AsianOption, BarrierOption, CashOrNothingOption, VanillaOption};
+use openferric::market::Market;
+use openferric::math::fast_norm::beasley_springer_moro_inv_cdf;
+use openferric::math::fast_rng::{Xoshiro256PlusPlus, uniform_open01};
+
+/// Common strike for the moneyness grid (S/K is varied through the spot).
+const STRIKE: f64 = 100.0;
+
+/// One point of the European consistency grid.
+#[derive(Debug, Clone, Copy)]
+struct GridPoint {
+    option_type: OptionType,
+    spot: f64,
+    vol: f64,
+    rate: f64,
+    div: f64,
+    expiry: f64,
+}
+
+impl GridPoint {
+    fn market(&self) -> Market {
+        Market::builder()
+            .spot(self.spot)
+            .rate(self.rate)
+            .dividend_yield(self.div)
+            .flat_vol(self.vol)
+            .build()
+            .expect("valid market")
+    }
+
+    fn european(&self) -> VanillaOption {
+        match self.option_type {
+            OptionType::Call => VanillaOption::european_call(STRIKE, self.expiry),
+            OptionType::Put => VanillaOption::european_put(STRIKE, self.expiry),
+        }
+    }
+
+    fn label(&self) -> String {
+        format!(
+            "{:?} S={} K={} vol={} r={} q={} T={}",
+            self.option_type, self.spot, STRIKE, self.vol, self.rate, self.div, self.expiry
+        )
+    }
+}
+
+/// Full 96-point European grid:
+/// moneyness S/K in {0.7, 1.0, 1.3} x vol in {0.1, 0.4} x r in {-0.01, 0.05}
+/// x q in {0.0, 0.03} x T in {0.25, 2.0} x {Call, Put}.
+fn european_grid() -> Vec<GridPoint> {
+    let mut points = Vec::with_capacity(96);
+    for option_type in [OptionType::Call, OptionType::Put] {
+        for spot in [70.0, 100.0, 130.0] {
+            for vol in [0.1, 0.4] {
+                for rate in [-0.01, 0.05] {
+                    for div in [0.0, 0.03] {
+                        for expiry in [0.25, 2.0] {
+                            points.push(GridPoint {
+                                option_type,
+                                spot,
+                                vol,
+                                rate,
+                                div,
+                                expiry,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    points
+}
+
+/// Runs `check(point, black_scholes_reference_price)` over the whole grid.
+fn for_each_european_point(check: impl Fn(&GridPoint, f64)) {
+    let analytic = BlackScholesEngine::new();
+    for point in european_grid() {
+        let reference = analytic
+            .price(&point.european(), &point.market())
+            .expect("analytic pricing succeeds")
+            .price;
+        check(&point, reference);
+    }
+}
+
+/// Asserts `|value - reference| <= abs_tol + rel_tol * |reference|` with a
+/// failure message carrying every grid parameter.
+fn assert_close(engine: &str, label: &str, value: f64, reference: f64, rel_tol: f64, abs_tol: f64) {
+    let err = (value - reference).abs();
+    let tol = abs_tol + rel_tol * reference.abs();
+    assert!(
+        value.is_finite() && err <= tol,
+        "{engine} disagrees at [{label}]: value={value} reference={reference} err={err:.3e} tol={tol:.3e}"
+    );
+}
+
+/// Asserts an MC estimate agrees with a reference within 4 standard errors
+/// (plus a tiny absolute floor for zero-variance deep-OTM points whose
+/// analytic price is below Monte Carlo resolution; see module docs).
+fn assert_mc_close(engine: &str, label: &str, value: f64, stderr: f64, reference: f64) {
+    let err = (value - reference).abs();
+    let tol = 4.0 * stderr + 5e-7;
+    assert!(
+        value.is_finite() && err <= tol,
+        "{engine} disagrees at [{label}]: value={value} reference={reference} stderr={stderr} err={err:.3e} tol=4*stderr+5e-7={tol:.3e}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. European vanillas across analytic / tree / PDE / MC / FFT engines.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn european_binomial_tree_matches_black_scholes() {
+    // CRR converges ~O(1/n) with odd/even oscillation; 1000 steps puts the
+    // discretization error comfortably inside relative 2e-3 (+ small absolute
+    // floor for prices ~1e-12 where relative error is meaningless).
+    let engine = BinomialTreeEngine::new(1000);
+    for_each_european_point(|point, reference| {
+        let price = engine
+            .price(&point.european(), &point.market())
+            .expect("binomial pricing succeeds")
+            .price;
+        assert_close(
+            "CRR binomial(1000)",
+            &point.label(),
+            price,
+            reference,
+            2e-3,
+            2e-3,
+        );
+    });
+}
+
+#[test]
+fn european_trinomial_tree_matches_black_scholes() {
+    let engine = TrinomialTreeEngine::new(800);
+    for_each_european_point(|point, reference| {
+        let price = engine
+            .price(&point.european(), &point.market())
+            .expect("trinomial pricing succeeds")
+            .price;
+        assert_close(
+            "trinomial(800)",
+            &point.label(),
+            price,
+            reference,
+            2e-3,
+            2e-3,
+        );
+    });
+}
+
+/// Vol-adaptive Crank-Nicolson grid. A fixed S_max = 5K wastes most of the
+/// 400 space nodes when vol*sqrt(T) is small (dS becomes coarse relative to
+/// the narrow gamma region around the strike and the ATM error blows past
+/// 2e-3), while high-vol long-dated points need S_max several stddevs above
+/// spot to control truncation. Put S_max ~3.5 lognormal stddevs above
+/// max(spot, K); the call upper boundary is the exact asymptote, so modest
+/// truncation distances are safe.
+fn crank_nicolson_for(point: &GridPoint) -> CrankNicolsonEngine {
+    let sigma_sqrt_t = point.vol * point.expiry.sqrt();
+    let multiplier = ((point.spot / STRIKE).max(1.0) * (3.5 * sigma_sqrt_t).exp()).clamp(1.5, 8.0);
+    CrankNicolsonEngine::new(400, 400).with_s_max_multiplier(multiplier)
+}
+
+#[test]
+fn european_crank_nicolson_matches_black_scholes() {
+    for_each_european_point(|point, reference| {
+        let price = crank_nicolson_for(point)
+            .price(&point.european(), &point.market())
+            .expect("crank-nicolson pricing succeeds")
+            .price;
+        assert_close(
+            "Crank-Nicolson(400x400)",
+            &point.label(),
+            price,
+            reference,
+            2e-3,
+            2e-3,
+        );
+    });
+}
+
+#[test]
+fn european_monte_carlo_matches_black_scholes_within_4_stderr() {
+    // GBM path generation uses exact log-Euler increments, so one time step
+    // samples the terminal distribution exactly; only sampling error remains.
+    let engine = MonteCarloPricingEngine::new(60_000, 1, 20_240_607);
+    for_each_european_point(|point, reference| {
+        let result = engine
+            .price(&point.european(), &point.market())
+            .expect("monte carlo pricing succeeds");
+        let stderr = result.stderr.expect("monte carlo reports stderr");
+        assert_mc_close("MC(60k,1)", &point.label(), result.price, stderr, reference);
+    });
+}
+
+#[test]
+fn european_carr_madan_fft_matches_black_scholes() {
+    // Exact Black-Scholes characteristic function through the Carr-Madan
+    // pricer (no Heston proxy needed). FFT gives calls; puts via put-call
+    // parity: P = C - S e^{-qT} + K e^{-rT}. Default grid (n=4096, eta=0.25,
+    // alpha=1.5) resolves vanillas to ~1e-4 absolute; tolerance 1e-3 + 1e-4.
+    let params = CarrMadanParams::default();
+    for_each_european_point(|point, reference| {
+        let cf =
+            BlackScholesCharFn::new(point.spot, point.rate, point.div, point.vol, point.expiry);
+        let prices = carr_madan_price_at_strikes(
+            &cf,
+            point.rate,
+            point.expiry,
+            point.spot,
+            &[STRIKE],
+            params,
+        )
+        .expect("carr-madan pricing succeeds");
+        let call = prices[0].1;
+        let price = match point.option_type {
+            OptionType::Call => call,
+            OptionType::Put => {
+                call - point.spot * (-point.div * point.expiry).exp()
+                    + STRIKE * (-point.rate * point.expiry).exp()
+            }
+        };
+        assert_close(
+            "Carr-Madan FFT",
+            &point.label(),
+            price,
+            reference,
+            1e-4,
+            1e-3,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 2. American exercise: trees vs PDE vs LSM, and the q=0 call no-early-
+//    exercise identity.
+// ---------------------------------------------------------------------------
+
+/// Smaller American grid: S in {90, 100, 110} x vol in {0.2, 0.4} x
+/// q in {0.0, 0.03}, with r = 0.05 and T = 1.
+fn american_put_grid() -> Vec<GridPoint> {
+    let mut points = Vec::new();
+    for spot in [90.0, 100.0, 110.0] {
+        for vol in [0.2, 0.4] {
+            for div in [0.0, 0.03] {
+                points.push(GridPoint {
+                    option_type: OptionType::Put,
+                    spot,
+                    vol,
+                    rate: 0.05,
+                    div,
+                    expiry: 1.0,
+                });
+            }
+        }
+    }
+    points
+}
+
+#[test]
+fn american_put_tree_pde_lsm_agree() {
+    let reference_tree = BinomialTreeEngine::new(2000);
+    let american_binomial = AmericanBinomialEngine::new(2000);
+    let trinomial = TrinomialTreeEngine::new(800);
+    let pde = CrankNicolsonEngine::new(400, 400).with_s_max_multiplier(5.0);
+    let lsm = LongstaffSchwartzEngine::new(40_000, 50, 7_771);
+
+    for point in american_put_grid() {
+        let option = VanillaOption::american_put(STRIKE, point.expiry);
+        let market = point.market();
+        let label = format!("American {}", point.label());
+
+        let reference = reference_tree
+            .price(&option, &market)
+            .expect("binomial american pricing succeeds")
+            .price;
+
+        // Independent CRR implementation: same lattice parameterization, so
+        // agreement should be near machine accuracy.
+        let alt = american_binomial
+            .price(&option, &market)
+            .expect("american binomial pricing succeeds")
+            .price;
+        assert_close(
+            "AmericanBinomial(2000) vs CRR(2000)",
+            &label,
+            alt,
+            reference,
+            1e-9,
+            1e-9,
+        );
+
+        let tri = trinomial
+            .price(&option, &market)
+            .expect("trinomial american pricing succeeds")
+            .price;
+        assert_close("trinomial(800)", &label, tri, reference, 2e-3, 2e-3);
+
+        let cn = pde
+            .price(&option, &market)
+            .expect("crank-nicolson american pricing succeeds")
+            .price;
+        assert_close("Crank-Nicolson(400x400)", &label, cn, reference, 2e-3, 2e-3);
+
+        // LSM carries both Monte Carlo noise and a small low-side regression
+        // bias (quadratic basis, 50 exercise dates), so allow 4*stderr plus
+        // 0.5% relative for the bias.
+        let lsm_result = lsm
+            .price(&option, &market)
+            .expect("lsm american pricing succeeds");
+        let lsm_stderr = lsm_result.stderr.expect("lsm reports stderr");
+        let err = (lsm_result.price - reference).abs();
+        let tol = 4.0 * lsm_stderr + 5e-3 * reference;
+        assert!(
+            err <= tol,
+            "LSM(40k,50) disagrees at [{label}]: value={} reference={reference} stderr={lsm_stderr} err={err:.3e} tol={tol:.3e}",
+            lsm_result.price
+        );
+    }
+}
+
+#[test]
+fn american_call_without_dividends_equals_european_call() {
+    // With q = 0 and r >= 0 early exercise of a call is never optimal, so the
+    // American price must collapse to the European one in every engine.
+    // (Deliberately excludes r < 0, where early exercise can be optimal.)
+    let analytic = BlackScholesEngine::new();
+    let tree = BinomialTreeEngine::new(2000);
+    let pde = CrankNicolsonEngine::new(400, 400).with_s_max_multiplier(5.0);
+    let lsm = LongstaffSchwartzEngine::new(40_000, 50, 7_772);
+
+    for spot in [80.0, 100.0, 125.0] {
+        for vol in [0.2, 0.4] {
+            let point = GridPoint {
+                option_type: OptionType::Call,
+                spot,
+                vol,
+                rate: 0.05,
+                div: 0.0,
+                expiry: 1.0,
+            };
+            let market = point.market();
+            let american = VanillaOption::american_call(STRIKE, point.expiry);
+            let european = VanillaOption::european_call(STRIKE, point.expiry);
+            let label = format!("American-call-q0 {}", point.label());
+
+            let euro_reference = analytic
+                .price(&european, &market)
+                .expect("analytic pricing succeeds")
+                .price;
+
+            // Within one engine the American and European backward inductions
+            // must coincide exactly when intrinsic never beats continuation.
+            let tree_am = tree.price(&american, &market).expect("tree am").price;
+            let tree_eu = tree.price(&european, &market).expect("tree eu").price;
+            assert_close(
+                "CRR American==European",
+                &label,
+                tree_am,
+                tree_eu,
+                0.0,
+                1e-9,
+            );
+            assert_close(
+                "CRR(2000) vs analytic",
+                &label,
+                tree_am,
+                euro_reference,
+                2e-3,
+                2e-3,
+            );
+
+            let cn_am = pde.price(&american, &market).expect("pde am").price;
+            assert_close(
+                "Crank-Nicolson American",
+                &label,
+                cn_am,
+                euro_reference,
+                2e-3,
+                2e-3,
+            );
+
+            let lsm_result = lsm.price(&american, &market).expect("lsm am");
+            let lsm_stderr = lsm_result.stderr.expect("lsm reports stderr");
+            let err = (lsm_result.price - euro_reference).abs();
+            // 4*stderr plus 0.5% relative headroom for LSM regression bias
+            // (spurious early exercise adds a small high-side bias here).
+            let tol = 4.0 * lsm_stderr + 5e-3 * euro_reference;
+            assert!(
+                err <= tol,
+                "LSM American call disagrees at [{label}]: value={} reference={euro_reference} stderr={lsm_stderr} err={err:.3e} tol={tol:.3e}",
+                lsm_result.price
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Barrier options: analytic (continuous monitoring) vs MC (discrete).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+enum BarrierKind {
+    UpOut,
+    UpIn,
+    DownOut,
+    DownIn,
+}
+
+fn barrier_option(
+    kind: BarrierKind,
+    level: f64,
+    option_type: OptionType,
+    expiry: f64,
+) -> BarrierOption {
+    let builder = match option_type {
+        OptionType::Call => BarrierOption::builder().call(),
+        OptionType::Put => BarrierOption::builder().put(),
+    };
+    let builder = builder.strike(STRIKE).expiry(expiry).rebate(0.0);
+    let builder = match kind {
+        BarrierKind::UpOut => builder.up_and_out(level),
+        BarrierKind::UpIn => builder.up_and_in(level),
+        BarrierKind::DownOut => builder.down_and_out(level),
+        BarrierKind::DownIn => builder.down_and_in(level),
+    };
+    builder.build().expect("valid barrier option")
+}
+
+#[test]
+fn barrier_in_out_parity_analytic_and_mc() {
+    // With zero rebate, in + out = vanilla must hold exactly within each
+    // engine. For MC the same seed/steps reproduce identical paths across the
+    // three pricings, so the identity holds per path and the only slack is
+    // floating-point summation order (tolerance 1e-9).
+    let spot = 100.0;
+    let market = Market::builder()
+        .spot(spot)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+    let expiry = 1.0;
+
+    let analytic = BarrierAnalyticEngine::new();
+    let bs = BlackScholesEngine::new();
+    let mc = MonteCarloPricingEngine::new(30_000, 400, 4_242);
+
+    for (in_kind, out_kind, option_type, level) in [
+        (
+            BarrierKind::UpIn,
+            BarrierKind::UpOut,
+            OptionType::Call,
+            130.0,
+        ),
+        (
+            BarrierKind::UpIn,
+            BarrierKind::UpOut,
+            OptionType::Put,
+            130.0,
+        ),
+        (
+            BarrierKind::DownIn,
+            BarrierKind::DownOut,
+            OptionType::Call,
+            70.0,
+        ),
+        (
+            BarrierKind::DownIn,
+            BarrierKind::DownOut,
+            OptionType::Put,
+            70.0,
+        ),
+    ] {
+        let label = format!(
+            "{option_type:?} barrier={level} S={spot} K={STRIKE} vol=0.25 r=0.03 q=0.01 T={expiry}"
+        );
+        let knock_in = barrier_option(in_kind, level, option_type, expiry);
+        let knock_out = barrier_option(out_kind, level, option_type, expiry);
+        let vanilla = match option_type {
+            OptionType::Call => VanillaOption::european_call(STRIKE, expiry),
+            OptionType::Put => VanillaOption::european_put(STRIKE, expiry),
+        };
+
+        // Analytic parity: exact identity of the Reiner-Rubinstein formulas.
+        let a_in = analytic
+            .price(&knock_in, &market)
+            .expect("analytic in")
+            .price;
+        let a_out = analytic
+            .price(&knock_out, &market)
+            .expect("analytic out")
+            .price;
+        let a_vanilla = bs.price(&vanilla, &market).expect("analytic vanilla").price;
+        assert_close(
+            "analytic in+out parity",
+            &label,
+            a_in + a_out,
+            a_vanilla,
+            1e-9,
+            1e-9,
+        );
+
+        // MC parity with common paths (same seed, steps, maturity, model).
+        let m_in = mc.price(&knock_in, &market).expect("mc in").price;
+        let m_out = mc.price(&knock_out, &market).expect("mc out").price;
+        let m_vanilla = mc.price(&vanilla, &market).expect("mc vanilla").price;
+        assert_close(
+            "mc in+out parity (common seed)",
+            &label,
+            m_in + m_out,
+            m_vanilla,
+            1e-9,
+            1e-9,
+        );
+    }
+}
+
+#[test]
+fn barrier_mc_matches_analytic_with_bgk_barrier_shift() {
+    // The MC engine monitors the barrier discretely on the path grid while
+    // the Reiner-Rubinstein engine assumes continuous monitoring. Comparing
+    // them directly is biased, so we use the Broadie-Glasserman-Kou
+    // continuity correction: a discretely monitored barrier at H prices like
+    // a continuous barrier at H * exp(+/- beta * sigma * sqrt(dt)) with
+    // beta = 0.5826 (+ for up barriers, - for down barriers).
+    //
+    // Tolerances: 4 * stderr for MC noise plus 0.5% relative for the O(1/n)
+    // residual of the BGK approximation at 400 monitoring steps.
+    //
+    // We also assert the one-sided ordering: discrete monitoring makes a
+    // knock-out strictly MORE valuable (fewer knock-outs) and a knock-in
+    // LESS valuable than continuous monitoring.
+    const BGK_BETA: f64 = 0.5826;
+    let spot = 100.0;
+    let vol = 0.25;
+    let expiry = 1.0;
+    let steps = 400usize;
+    let market = Market::builder()
+        .spot(spot)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .flat_vol(vol)
+        .build()
+        .expect("valid market");
+
+    let analytic = BarrierAnalyticEngine::new();
+    let mc = MonteCarloPricingEngine::new(30_000, steps, 9_001);
+    let dt = expiry / steps as f64;
+    let shift = (BGK_BETA * vol * dt.sqrt()).exp();
+
+    for (kind, option_type, level, is_up, is_out) in [
+        (BarrierKind::UpOut, OptionType::Call, 130.0, true, true),
+        (BarrierKind::UpIn, OptionType::Call, 130.0, true, false),
+        (BarrierKind::DownOut, OptionType::Put, 70.0, false, true),
+        (BarrierKind::DownIn, OptionType::Put, 70.0, false, false),
+    ] {
+        let label = format!(
+            "{kind:?} {option_type:?} barrier={level} S={spot} K={STRIKE} vol={vol} r=0.03 q=0.01 T={expiry} steps={steps}"
+        );
+        let option = barrier_option(kind, level, option_type, expiry);
+
+        let continuous = analytic
+            .price(&option, &market)
+            .expect("analytic barrier")
+            .price;
+
+        let mc_result = mc.price(&option, &market).expect("mc barrier");
+        let mc_stderr = mc_result.stderr.expect("mc reports stderr");
+
+        // BGK-adjusted continuous price approximating discrete monitoring:
+        // move the barrier AWAY from the spot.
+        let adjusted_level = if is_up { level * shift } else { level / shift };
+        let adjusted = barrier_option(kind, adjusted_level, option_type, expiry);
+        let adjusted_price = analytic
+            .price(&adjusted, &market)
+            .expect("analytic adjusted")
+            .price;
+
+        let err = (mc_result.price - adjusted_price).abs();
+        let tol = 4.0 * mc_stderr + 5e-3 * adjusted_price.abs();
+        assert!(
+            err <= tol,
+            "MC vs BGK-adjusted analytic disagrees at [{label}]: mc={} adjusted_analytic={adjusted_price} continuous_analytic={continuous} stderr={mc_stderr} err={err:.3e} tol={tol:.3e}",
+            mc_result.price
+        );
+
+        // One-sided discrete-vs-continuous ordering (within MC noise):
+        // discrete KO >= continuous KO, discrete KI <= continuous KI.
+        let slack = 4.0 * mc_stderr;
+        if is_out {
+            assert!(
+                mc_result.price >= continuous - slack,
+                "discrete knock-out should not be cheaper than continuous at [{label}]: mc={} continuous={continuous} slack={slack:.3e}",
+                mc_result.price
+            );
+        } else {
+            assert!(
+                mc_result.price <= continuous + slack,
+                "discrete knock-in should not be dearer than continuous at [{label}]: mc={} continuous={continuous} slack={slack:.3e}",
+                mc_result.price
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Asian options: geometric discrete closed form vs MC geometric payoff.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn geometric_asian_closed_form_matches_monte_carlo() {
+    // 12 monthly observations on a 12-step path: every observation time maps
+    // exactly onto a path grid point, so the MC payoff prices precisely the
+    // contract the discrete closed form values; remaining error is sampling.
+    let expiry = 1.0;
+    let observations: Vec<f64> = (1..=12).map(|i| expiry * i as f64 / 12.0).collect();
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.01)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+
+    let analytic = GeometricAsianEngine::new();
+    let mc = MonteCarloPricingEngine::new(100_000, 12, 5_555);
+
+    for option_type in [OptionType::Call, OptionType::Put] {
+        for strike in [90.0, 100.0, 110.0] {
+            let option = AsianOption::new(
+                option_type,
+                strike,
+                expiry,
+                AsianSpec {
+                    averaging: Averaging::Geometric,
+                    strike_type: StrikeType::Fixed,
+                    observation_times: observations.clone(),
+                },
+            );
+            let label = format!(
+                "geometric Asian {option_type:?} S=100 K={strike} vol=0.25 r=0.03 q=0.01 T={expiry} obs=12"
+            );
+
+            let reference = analytic.price(&option, &market).expect("closed form").price;
+            let mc_result = mc.price(&option, &market).expect("mc asian");
+            let stderr = mc_result.stderr.expect("mc reports stderr");
+            assert_mc_close(
+                "Asian MC(100k,12)",
+                &label,
+                mc_result.price,
+                stderr,
+                reference,
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Digital cash-or-nothing: analytic vs Monte Carlo.
+// ---------------------------------------------------------------------------
+
+/// Exact-terminal-distribution GBM Monte Carlo for a cash-or-nothing digital.
+/// The library's generic MC engine has no digital instrument, so this uses
+/// the crate's own deterministic RNG and inverse-CDF sampler directly:
+/// S_T = S0 * exp((r - q - sigma^2/2) T + sigma sqrt(T) Z). Returns
+/// (discounted price, standard error).
+fn mc_cash_or_nothing(
+    option_type: OptionType,
+    spot: f64,
+    strike: f64,
+    cash: f64,
+    rate: f64,
+    div: f64,
+    vol: f64,
+    expiry: f64,
+    paths: usize,
+    seed: u64,
+) -> (f64, f64) {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(seed);
+    let drift = (rate - div - 0.5 * vol * vol) * expiry;
+    let diffusion = vol * expiry.sqrt();
+    let discount = (-rate * expiry).exp();
+
+    let mut sum = 0.0_f64;
+    let mut sum_sq = 0.0_f64;
+    for _ in 0..paths {
+        let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
+        let terminal = spot * (drift + diffusion * z).exp();
+        let pays = match option_type {
+            OptionType::Call => terminal > strike,
+            OptionType::Put => terminal < strike,
+        };
+        let payoff = if pays { cash } else { 0.0 };
+        sum += payoff;
+        sum_sq += payoff * payoff;
+    }
+    let n = paths as f64;
+    let mean = sum / n;
+    let var = (sum_sq - sum * sum / n).max(0.0) / (n - 1.0);
+    (discount * mean, discount * (var / n).sqrt())
+}
+
+#[test]
+fn digital_cash_or_nothing_analytic_matches_monte_carlo() {
+    let spot = 100.0;
+    let rate = 0.03;
+    let div = 0.01;
+    let vol = 0.25;
+    let expiry = 1.0;
+    let cash = 10.0;
+    let market = Market::builder()
+        .spot(spot)
+        .rate(rate)
+        .dividend_yield(div)
+        .flat_vol(vol)
+        .build()
+        .expect("valid market");
+    let analytic = DigitalAnalyticEngine::new();
+
+    for option_type in [OptionType::Call, OptionType::Put] {
+        for strike in [90.0, 100.0, 110.0] {
+            let option = CashOrNothingOption::new(option_type, strike, cash, expiry);
+            let label = format!(
+                "cash-or-nothing {option_type:?} S={spot} K={strike} cash={cash} vol={vol} r={rate} q={div} T={expiry}"
+            );
+
+            let reference = analytic
+                .price(&option, &market)
+                .expect("digital analytic")
+                .price;
+            let (mc_price, mc_stderr) = mc_cash_or_nothing(
+                option_type,
+                spot,
+                strike,
+                cash,
+                rate,
+                div,
+                vol,
+                expiry,
+                200_000,
+                31_337,
+            );
+            assert_mc_close("digital MC(200k)", &label, mc_price, mc_stderr, reference);
+        }
+    }
+}

--- a/tests/property_invariants.rs
+++ b/tests/property_invariants.rs
@@ -1,0 +1,962 @@
+//! Property-based no-arbitrage and structural invariants.
+//!
+//! Deterministic parameter sweeps (seeded `Xoshiro256PlusPlus`, no proptest
+//! dependency) asserting model-free identities and structural properties:
+//!
+//! 1. Put-call parity (Black-Scholes, Black-76, Garman-Kohlhagen, digitals).
+//! 2. Monotonicity and bounds of Black-Scholes prices and Greeks.
+//! 3. Convexity of the call price in strike (butterfly spreads).
+//! 4. Barrier in/out parity and knock-out structural bounds.
+//! 5. Vol surface no-arbitrage (calendar monotonicity, Fengler butterfly check).
+//! 6. Yield curve bootstrap invariants and par-swap repricing.
+//! 7. CDS survival-curve invariants and par-spread repricing.
+//! 8. Analytic Greeks vs central finite differences of the analytic price.
+//!
+//! Every assertion message carries the full parameter set so a failure is
+//! immediately reproducible.
+
+use openferric::core::{OptionType, PricingEngine, PricingResult};
+use openferric::credit::{Cds, bootstrap_survival_curve_from_cds_spreads};
+use openferric::engines::analytic::digital::DigitalAnalyticEngine;
+use openferric::engines::analytic::{
+    BarrierAnalyticEngine, Black76Engine, BlackScholesEngine, GarmanKohlhagenEngine,
+};
+use openferric::instruments::digital::{AssetOrNothingOption, CashOrNothingOption};
+use openferric::instruments::{BarrierOption, FuturesOption, FxOption, VanillaOption};
+use openferric::market::Market;
+use openferric::math::fast_rng::Xoshiro256PlusPlus;
+use openferric::rates::{YieldCurve, YieldCurveBuilder};
+use openferric::vol::fengler::FenglerSurface;
+use openferric::vol::surface::{SviParams, VolSurface};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Deterministic uniform sample in `[lo, hi)`.
+fn uniform(rng: &mut Xoshiro256PlusPlus, lo: f64, hi: f64) -> f64 {
+    lo + (hi - lo) * rng.next_f64()
+}
+
+/// Flat-vol equity market.
+fn make_market(spot: f64, rate: f64, dividend_yield: f64, vol: f64) -> Market {
+    Market::builder()
+        .spot(spot)
+        .rate(rate)
+        .dividend_yield(dividend_yield)
+        .flat_vol(vol)
+        .build()
+        .expect("valid market")
+}
+
+/// Black-Scholes analytic result for a European option.
+fn bs_result(
+    option_type: OptionType,
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+    expiry: f64,
+) -> PricingResult {
+    let option = match option_type {
+        OptionType::Call => VanillaOption::european_call(strike, expiry),
+        OptionType::Put => VanillaOption::european_put(strike, expiry),
+    };
+    let market = make_market(spot, rate, dividend_yield, vol);
+    BlackScholesEngine::new()
+        .price(&option, &market)
+        .expect("BS pricing succeeds")
+}
+
+fn bs_price(
+    option_type: OptionType,
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+    expiry: f64,
+) -> f64 {
+    bs_result(option_type, spot, strike, rate, dividend_yield, vol, expiry).price
+}
+
+/// Random Black-Scholes scenario over a wide but well-posed domain.
+#[derive(Debug, Clone, Copy)]
+struct BsScenario {
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+    expiry: f64,
+}
+
+fn sample_bs(rng: &mut Xoshiro256PlusPlus) -> BsScenario {
+    BsScenario {
+        spot: uniform(rng, 20.0, 300.0),
+        strike: uniform(rng, 20.0, 300.0),
+        rate: uniform(rng, -0.02, 0.10),
+        dividend_yield: uniform(rng, 0.0, 0.06),
+        vol: uniform(rng, 0.05, 0.80),
+        expiry: uniform(rng, 0.05, 3.0),
+    }
+}
+
+/// Flat continuously-compounded discount curve with quarterly nodes.
+fn flat_discount_curve(rate: f64, max_tenor: f64) -> YieldCurve {
+    let n = (max_tenor * 4.0).ceil() as usize;
+    YieldCurve::new(
+        (1..=n)
+            .map(|i| {
+                let t = i as f64 * 0.25;
+                (t, (-rate * t).exp())
+            })
+            .collect(),
+    )
+}
+
+// ============================================================================
+// 1. Put-call parity
+// ============================================================================
+
+#[test]
+fn put_call_parity_black_scholes() {
+    // C - P = S e^{-qT} - K e^{-rT}, model-free for European options.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xA11C_E001);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let call = bs_price(
+            OptionType::Call,
+            s.spot,
+            s.strike,
+            s.rate,
+            s.dividend_yield,
+            s.vol,
+            s.expiry,
+        );
+        let put = bs_price(
+            OptionType::Put,
+            s.spot,
+            s.strike,
+            s.rate,
+            s.dividend_yield,
+            s.vol,
+            s.expiry,
+        );
+        let forward_value =
+            s.spot * (-s.dividend_yield * s.expiry).exp() - s.strike * (-s.rate * s.expiry).exp();
+        let err = (call - put - forward_value).abs();
+        assert!(
+            err <= 1e-10,
+            "BS put-call parity violated at point {i}: {s:?} call={call} put={put} \
+             S e^-qT - K e^-rT = {forward_value} err={err}"
+        );
+    }
+}
+
+#[test]
+fn put_call_parity_black76() {
+    // Forward parity: C - P = e^{-rT} (F - K).
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xA11C_E002);
+    let engine = Black76Engine::new();
+    let dummy = make_market(100.0, 0.0, 0.0, 0.2);
+    for i in 0..200 {
+        let forward = uniform(&mut rng, 20.0, 300.0);
+        let strike = uniform(&mut rng, 20.0, 300.0);
+        let rate = uniform(&mut rng, -0.02, 0.10);
+        let vol = uniform(&mut rng, 0.05, 0.80);
+        let expiry = uniform(&mut rng, 0.05, 3.0);
+
+        let call = engine
+            .price(
+                &FuturesOption::call(forward, strike, vol, rate, expiry),
+                &dummy,
+            )
+            .expect("Black76 call prices")
+            .price;
+        let put = engine
+            .price(
+                &FuturesOption::put(forward, strike, vol, rate, expiry),
+                &dummy,
+            )
+            .expect("Black76 put prices")
+            .price;
+        let parity = (-rate * expiry).exp() * (forward - strike);
+        let err = (call - put - parity).abs();
+        assert!(
+            err <= 1e-10,
+            "Black76 parity violated at point {i}: F={forward} K={strike} r={rate} \
+             vol={vol} T={expiry} call={call} put={put} e^-rT(F-K)={parity} err={err}"
+        );
+    }
+}
+
+#[test]
+fn put_call_parity_garman_kohlhagen() {
+    // FX parity: C - P = S e^{-r_f T} - K e^{-r_d T}.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xA11C_E003);
+    let engine = GarmanKohlhagenEngine::new();
+    let dummy = make_market(100.0, 0.0, 0.0, 0.2);
+    for i in 0..200 {
+        let spot = uniform(&mut rng, 0.5, 2.5);
+        let strike = uniform(&mut rng, 0.5, 2.5);
+        let rd = uniform(&mut rng, -0.01, 0.08);
+        let rf = uniform(&mut rng, -0.01, 0.08);
+        let vol = uniform(&mut rng, 0.05, 0.50);
+        let expiry = uniform(&mut rng, 0.05, 3.0);
+
+        let call = engine
+            .price(
+                &FxOption::new(OptionType::Call, rd, rf, spot, strike, vol, expiry),
+                &dummy,
+            )
+            .expect("GK call prices")
+            .price;
+        let put = engine
+            .price(
+                &FxOption::new(OptionType::Put, rd, rf, spot, strike, vol, expiry),
+                &dummy,
+            )
+            .expect("GK put prices")
+            .price;
+        let parity = spot * (-rf * expiry).exp() - strike * (-rd * expiry).exp();
+        let err = (call - put - parity).abs();
+        assert!(
+            err <= 1e-10,
+            "Garman-Kohlhagen parity violated at point {i}: S={spot} K={strike} rd={rd} \
+             rf={rf} vol={vol} T={expiry} call={call} put={put} parity={parity} err={err}"
+        );
+    }
+}
+
+#[test]
+fn put_call_parity_digitals() {
+    // cash_call + cash_put = cash e^{-rT}; asset_call + asset_put = S e^{-qT}.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xA11C_E004);
+    let engine = DigitalAnalyticEngine::new();
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let cash = uniform(&mut rng, 0.5, 10.0);
+        let market = make_market(s.spot, s.rate, s.dividend_yield, s.vol);
+
+        let cash_call = engine
+            .price(
+                &CashOrNothingOption::new(OptionType::Call, s.strike, cash, s.expiry),
+                &market,
+            )
+            .expect("cash-or-nothing call prices")
+            .price;
+        let cash_put = engine
+            .price(
+                &CashOrNothingOption::new(OptionType::Put, s.strike, cash, s.expiry),
+                &market,
+            )
+            .expect("cash-or-nothing put prices")
+            .price;
+        let cash_parity = cash * (-s.rate * s.expiry).exp();
+        let cash_err = (cash_call + cash_put - cash_parity).abs();
+        assert!(
+            cash_err <= 1e-10,
+            "cash-or-nothing parity violated at point {i}: {s:?} cash={cash} \
+             call={cash_call} put={cash_put} cash e^-rT={cash_parity} err={cash_err}"
+        );
+
+        let asset_call = engine
+            .price(
+                &AssetOrNothingOption::new(OptionType::Call, s.strike, s.expiry),
+                &market,
+            )
+            .expect("asset-or-nothing call prices")
+            .price;
+        let asset_put = engine
+            .price(
+                &AssetOrNothingOption::new(OptionType::Put, s.strike, s.expiry),
+                &market,
+            )
+            .expect("asset-or-nothing put prices")
+            .price;
+        let asset_parity = s.spot * (-s.dividend_yield * s.expiry).exp();
+        let asset_err = (asset_call + asset_put - asset_parity).abs();
+        assert!(
+            asset_err <= 1e-10,
+            "asset-or-nothing parity violated at point {i}: {s:?} call={asset_call} \
+             put={asset_put} S e^-qT={asset_parity} err={asset_err}"
+        );
+    }
+}
+
+// ============================================================================
+// 2. Monotonicity and bounds (Black-Scholes analytic)
+// ============================================================================
+
+#[test]
+fn call_price_non_increasing_in_strike() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0B0B_0001);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let mut prev = f64::INFINITY;
+        for j in 0..21 {
+            let strike = s.spot * (0.4 + 0.08 * j as f64);
+            let price = bs_price(
+                OptionType::Call,
+                s.spot,
+                strike,
+                s.rate,
+                s.dividend_yield,
+                s.vol,
+                s.expiry,
+            );
+            assert!(
+                price <= prev + 1e-12 * (1.0 + prev.min(1e300)),
+                "call not non-increasing in K at scenario {i} step {j}: {s:?} \
+                 K={strike} price={price} prev={prev}"
+            );
+            prev = price;
+        }
+    }
+}
+
+#[test]
+fn call_price_non_decreasing_in_spot_and_vol() {
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0B0B_0002);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+
+        let mut prev = f64::NEG_INFINITY;
+        for j in 0..21 {
+            let spot = s.strike * (0.4 + 0.08 * j as f64);
+            let price = bs_price(
+                OptionType::Call,
+                spot,
+                s.strike,
+                s.rate,
+                s.dividend_yield,
+                s.vol,
+                s.expiry,
+            );
+            assert!(
+                price + 1e-12 * (1.0 + price) >= prev,
+                "call not non-decreasing in S at scenario {i} step {j}: {s:?} \
+                 S={spot} price={price} prev={prev}"
+            );
+            prev = price;
+        }
+
+        let mut prev = f64::NEG_INFINITY;
+        for j in 0..21 {
+            let vol = 0.05 + 0.05 * j as f64;
+            let price = bs_price(
+                OptionType::Call,
+                s.spot,
+                s.strike,
+                s.rate,
+                s.dividend_yield,
+                vol,
+                s.expiry,
+            );
+            assert!(
+                price + 1e-12 * (1.0 + price) >= prev,
+                "call not non-decreasing in vol at scenario {i} step {j}: {s:?} \
+                 vol={vol} price={price} prev={prev}"
+            );
+            prev = price;
+        }
+    }
+}
+
+#[test]
+fn call_price_non_decreasing_in_expiry_without_dividends() {
+    // NOTE: monotonicity of the European call price in T only holds model-free
+    // for q = 0 and r >= 0 (the call is then worth its American counterpart and
+    // longer-dated dominates). With q > 0 (or r < 0) the European call can
+    // legitimately *decrease* in T, so the sweep is restricted to q = 0, r >= 0.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0B0B_0003);
+    for i in 0..200 {
+        let spot = uniform(&mut rng, 20.0, 300.0);
+        let strike = uniform(&mut rng, 20.0, 300.0);
+        let rate = uniform(&mut rng, 0.0, 0.10);
+        let vol = uniform(&mut rng, 0.05, 0.80);
+        let mut prev = f64::NEG_INFINITY;
+        for j in 0..21 {
+            let expiry = 0.05 + 0.15 * j as f64;
+            let price = bs_price(OptionType::Call, spot, strike, rate, 0.0, vol, expiry);
+            assert!(
+                price + 1e-12 * (1.0 + price) >= prev,
+                "call not non-decreasing in T (q=0) at scenario {i} step {j}: \
+                 S={spot} K={strike} r={rate} vol={vol} T={expiry} price={price} prev={prev}"
+            );
+            prev = price;
+        }
+    }
+}
+
+#[test]
+fn call_price_within_no_arbitrage_bounds() {
+    // max(S e^{-qT} - K e^{-rT}, 0) <= C <= S e^{-qT}.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0B0B_0004);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let price = bs_price(
+            OptionType::Call,
+            s.spot,
+            s.strike,
+            s.rate,
+            s.dividend_yield,
+            s.vol,
+            s.expiry,
+        );
+        let lower = (s.spot * (-s.dividend_yield * s.expiry).exp()
+            - s.strike * (-s.rate * s.expiry).exp())
+        .max(0.0);
+        let upper = s.spot * (-s.dividend_yield * s.expiry).exp();
+        assert!(
+            price >= lower - 1e-10 && price <= upper + 1e-10,
+            "call outside no-arbitrage bounds at point {i}: {s:?} price={price} \
+             lower={lower} upper={upper}"
+        );
+    }
+}
+
+#[test]
+fn greeks_within_structural_bounds() {
+    // Call delta in [0, e^{-qT}], put delta in [-e^{-qT}, 0], gamma >= 0, vega >= 0.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x0B0B_0005);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let df_q = (-s.dividend_yield * s.expiry).exp();
+
+        for option_type in [OptionType::Call, OptionType::Put] {
+            let result = bs_result(
+                option_type,
+                s.spot,
+                s.strike,
+                s.rate,
+                s.dividend_yield,
+                s.vol,
+                s.expiry,
+            );
+            let greeks = result.greeks.expect("BS engine returns greeks");
+            match option_type {
+                OptionType::Call => assert!(
+                    (-1e-12..=df_q + 1e-12).contains(&greeks.delta),
+                    "call delta out of [0, e^-qT] at point {i}: {s:?} \
+                     delta={} e^-qT={df_q}",
+                    greeks.delta
+                ),
+                OptionType::Put => assert!(
+                    (-df_q - 1e-12..=1e-12).contains(&greeks.delta),
+                    "put delta out of [-e^-qT, 0] at point {i}: {s:?} \
+                     delta={} e^-qT={df_q}",
+                    greeks.delta
+                ),
+            }
+            assert!(
+                greeks.gamma >= -1e-12,
+                "negative gamma at point {i} ({option_type:?}): {s:?} gamma={}",
+                greeks.gamma
+            );
+            assert!(
+                greeks.vega >= -1e-12,
+                "negative vega at point {i} ({option_type:?}): {s:?} vega={}",
+                greeks.vega
+            );
+        }
+    }
+}
+
+// ============================================================================
+// 3. Convexity in strike (butterfly)
+// ============================================================================
+
+#[test]
+fn call_price_convex_in_strike() {
+    // Butterfly: C(K-h) - 2 C(K) + C(K+h) >= 0 for all K, h > 0.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x00C0_FFEE);
+    for i in 0..200 {
+        let s = sample_bs(&mut rng);
+        let h = s.spot * uniform(&mut rng, 0.01, 0.10);
+        for j in 0..15 {
+            let strike = s.spot * (0.5 + 0.07 * j as f64);
+            let price = |k: f64| {
+                bs_price(
+                    OptionType::Call,
+                    s.spot,
+                    k,
+                    s.rate,
+                    s.dividend_yield,
+                    s.vol,
+                    s.expiry,
+                )
+            };
+            let butterfly = price(strike - h) - 2.0 * price(strike) + price(strike + h);
+            assert!(
+                butterfly >= -1e-12,
+                "butterfly arbitrage at scenario {i} step {j}: {s:?} K={strike} h={h} \
+                 butterfly={butterfly}"
+            );
+        }
+    }
+}
+
+// ============================================================================
+// 4. Barrier parity and bounds
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BarrierDirection {
+    Down,
+    Up,
+}
+
+fn barrier_pair(
+    direction: BarrierDirection,
+    option_type: OptionType,
+    strike: f64,
+    expiry: f64,
+    barrier: f64,
+) -> (BarrierOption, BarrierOption) {
+    let base = || {
+        let b = BarrierOption::builder()
+            .strike(strike)
+            .expiry(expiry)
+            .rebate(0.0);
+        match option_type {
+            OptionType::Call => b.call(),
+            OptionType::Put => b.put(),
+        }
+    };
+    let (knock_in, knock_out) = match direction {
+        BarrierDirection::Down => (
+            base().down_and_in(barrier).build(),
+            base().down_and_out(barrier).build(),
+        ),
+        BarrierDirection::Up => (
+            base().up_and_in(barrier).build(),
+            base().up_and_out(barrier).build(),
+        ),
+    };
+    (
+        knock_in.expect("valid knock-in"),
+        knock_out.expect("valid knock-out"),
+    )
+}
+
+#[test]
+fn barrier_in_out_parity_all_eight_types() {
+    // With zero rebate: knock-in + knock-out = vanilla, for all four barrier
+    // directions x call/put (8 combinations), and knock-out <= vanilla.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xBA22_0001);
+    let barrier_engine = BarrierAnalyticEngine::new();
+    for direction in [BarrierDirection::Down, BarrierDirection::Up] {
+        for option_type in [OptionType::Call, OptionType::Put] {
+            for i in 0..50 {
+                let spot = uniform(&mut rng, 50.0, 200.0);
+                let strike = spot * uniform(&mut rng, 0.6, 1.4);
+                let rate = uniform(&mut rng, 0.0, 0.08);
+                let q = uniform(&mut rng, 0.0, 0.04);
+                let vol = uniform(&mut rng, 0.10, 0.60);
+                let expiry = uniform(&mut rng, 0.1, 2.0);
+                let barrier = match direction {
+                    BarrierDirection::Down => spot * uniform(&mut rng, 0.50, 0.95),
+                    BarrierDirection::Up => spot * uniform(&mut rng, 1.05, 2.00),
+                };
+
+                let market = make_market(spot, rate, q, vol);
+                let (knock_in, knock_out) =
+                    barrier_pair(direction, option_type, strike, expiry, barrier);
+
+                let in_price = barrier_engine
+                    .price(&knock_in, &market)
+                    .expect("knock-in prices")
+                    .price;
+                let out_price = barrier_engine
+                    .price(&knock_out, &market)
+                    .expect("knock-out prices")
+                    .price;
+                let vanilla = bs_price(option_type, spot, strike, rate, q, vol, expiry);
+
+                let err = (in_price + out_price - vanilla).abs();
+                assert!(
+                    err <= 1e-8,
+                    "barrier in/out parity violated ({direction:?} {option_type:?}, point {i}): \
+                     S={spot} K={strike} B={barrier} r={rate} q={q} vol={vol} T={expiry} \
+                     in={in_price} out={out_price} vanilla={vanilla} err={err}"
+                );
+                assert!(
+                    out_price <= vanilla + 1e-10,
+                    "knock-out above vanilla ({direction:?} {option_type:?}, point {i}): \
+                     S={spot} K={strike} B={barrier} r={rate} q={q} vol={vol} T={expiry} \
+                     out={out_price} vanilla={vanilla}"
+                );
+                assert!(
+                    in_price >= -1e-10 && out_price >= -1e-10,
+                    "negative barrier price ({direction:?} {option_type:?}, point {i}): \
+                     S={spot} K={strike} B={barrier} r={rate} q={q} vol={vol} T={expiry} \
+                     in={in_price} out={out_price}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn knock_out_non_increasing_as_barrier_tightens_toward_spot() {
+    // A tighter barrier (closer to spot) removes payoff paths, so the
+    // knock-out value must not increase.
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xBA22_0002);
+    let barrier_engine = BarrierAnalyticEngine::new();
+    for direction in [BarrierDirection::Down, BarrierDirection::Up] {
+        for option_type in [OptionType::Call, OptionType::Put] {
+            for i in 0..25 {
+                let spot = uniform(&mut rng, 50.0, 200.0);
+                let strike = spot * uniform(&mut rng, 0.7, 1.3);
+                let rate = uniform(&mut rng, 0.0, 0.08);
+                let q = uniform(&mut rng, 0.0, 0.04);
+                let vol = uniform(&mut rng, 0.10, 0.60);
+                let expiry = uniform(&mut rng, 0.1, 2.0);
+
+                let mut prev = f64::INFINITY;
+                for j in 0..16 {
+                    let frac = j as f64 / 15.0;
+                    // Barrier marches toward spot as j grows.
+                    let barrier = match direction {
+                        BarrierDirection::Down => spot * (0.50 + (0.97 - 0.50) * frac),
+                        BarrierDirection::Up => spot * (1.95 - (1.95 - 1.03) * frac),
+                    };
+                    let market = make_market(spot, rate, q, vol);
+                    let (_, knock_out) =
+                        barrier_pair(direction, option_type, strike, expiry, barrier);
+                    let out_price = barrier_engine
+                        .price(&knock_out, &market)
+                        .expect("knock-out prices")
+                        .price;
+                    assert!(
+                        out_price <= prev + 1e-10,
+                        "knock-out increased as barrier tightened \
+                         ({direction:?} {option_type:?}, scenario {i} step {j}): \
+                         S={spot} K={strike} B={barrier} r={rate} q={q} vol={vol} \
+                         T={expiry} price={out_price} prev={prev}"
+                    );
+                    prev = out_price;
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// 5. Vol surface no-arbitrage
+// ============================================================================
+
+#[test]
+fn svi_surface_total_variance_non_decreasing_in_expiry() {
+    // Slices share (b, rho, m, sigma) and have strictly increasing `a`, so the
+    // surface is calendar-arbitrage-free by construction; the query layer
+    // (interpolation in T at fixed log-moneyness) must preserve that.
+    let forward = 100.0;
+    let common = |t: f64| SviParams {
+        a: 0.005 + 0.02 * t,
+        b: 0.08,
+        rho: -0.3,
+        m: 0.0,
+        sigma: 0.25,
+    };
+    let expiries = [0.25, 0.5, 1.0, 2.0, 3.0];
+    let surface = VolSurface::new(expiries.iter().map(|&t| (t, common(t))).collect(), forward)
+        .expect("valid SVI surface");
+
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5141_0001);
+    for i in 0..50 {
+        let k = uniform(&mut rng, -1.2, 1.2);
+        let strike = forward * k.exp();
+        let a = uniform(&mut rng, 0.25, 3.0);
+        let b = uniform(&mut rng, 0.25, 3.0);
+        let (t1, t2) = if a <= b { (a, b) } else { (b, a) };
+        let w1 = surface.total_variance(strike, t1);
+        let w2 = surface.total_variance(strike, t2);
+        assert!(
+            w2 >= w1 - 1e-12,
+            "calendar arbitrage in SVI surface at pair {i}: k={k} K={strike} \
+             t1={t1} t2={t2} w1={w1} w2={w2}"
+        );
+    }
+}
+
+#[test]
+fn fengler_surface_from_clean_quotes_has_no_arbitrage() {
+    // Clean synthetic quotes: strike-independent vol with an increasing total
+    // variance term structure. The fitted surface must report no butterfly
+    // (g(k) >= 0) or calendar violations, and stay calendar-monotone when
+    // queried off-grid.
+    let expiries: [f64; 4] = [0.25, 0.5, 1.0, 2.0];
+    let spot_rate = 0.02_f64;
+    let forward_curve: Vec<(f64, f64)> = expiries
+        .iter()
+        .map(|&t| (t, 100.0 * (spot_rate * t).exp()))
+        .collect();
+    let mut quotes = Vec::new();
+    for &t in &expiries {
+        let vol = 0.18 + 0.03 * t.sqrt();
+        for j in 0..11 {
+            let strike = 60.0 + 10.0 * j as f64;
+            quotes.push((strike, t, vol));
+        }
+    }
+    let surface = FenglerSurface::new(&quotes, &forward_curve);
+
+    let violations = surface.check_arbitrage();
+    assert!(
+        violations.is_empty(),
+        "Fengler surface built from clean quotes reports arbitrage: {violations:?}"
+    );
+
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0x5141_0002);
+    for i in 0..50 {
+        let k = uniform(&mut rng, -0.4, 0.4);
+        let a = uniform(&mut rng, 0.25, 2.0);
+        let b = uniform(&mut rng, 0.25, 2.0);
+        let (t1, t2) = if a <= b { (a, b) } else { (b, a) };
+        let w1 = surface.total_variance(k, t1);
+        let w2 = surface.total_variance(k, t2);
+        assert!(
+            w2 >= w1 - 1e-12,
+            "calendar arbitrage in Fengler surface at pair {i}: k={k} t1={t1} t2={t2} \
+             w1={w1} w2={w2}"
+        );
+    }
+}
+
+// ============================================================================
+// 6. Yield curve invariants
+// ============================================================================
+
+#[test]
+fn deposit_curve_discount_factor_invariants() {
+    let deposits: Vec<(f64, f64)> = [
+        (0.25, 0.020),
+        (0.5, 0.022),
+        (1.0, 0.025),
+        (2.0, 0.028),
+        (3.0, 0.030),
+        (5.0, 0.032),
+        (7.0, 0.033),
+        (10.0, 0.034),
+    ]
+    .to_vec();
+    let curve = YieldCurveBuilder::from_deposits(&deposits);
+
+    let df0 = curve.discount_factor(0.0);
+    assert!((df0 - 1.0).abs() <= 1e-14, "DF(0) must equal 1, got {df0}");
+
+    let mut prev = 1.0_f64;
+    for j in 1..=100 {
+        let t = 0.1 * j as f64;
+        let df = curve.discount_factor(t);
+        assert!(
+            df.is_finite() && df > 0.0 && df < 1.0,
+            "DF({t}) out of (0, 1): {df}"
+        );
+        assert!(
+            df < prev,
+            "discount factors not strictly decreasing for positive rates: \
+             DF({t})={df} >= DF({})={prev}",
+            t - 0.1
+        );
+        prev = df;
+    }
+
+    for j in 0..40 {
+        let t1 = 0.25 * j as f64;
+        let t2 = t1 + 0.25;
+        let fwd = curve.forward_rate(t1, t2);
+        assert!(
+            fwd.is_finite(),
+            "forward rate over [{t1}, {t2}] is not finite: {fwd}"
+        );
+    }
+}
+
+#[test]
+fn swap_bootstrap_reprices_input_par_rates() {
+    // Bootstrap contract (see `YieldCurveBuilder::from_swap_rates_with_settings`):
+    // with the default interpolating method each input swap reprices exactly,
+    // i.e. coupon * sum DF(t_i) + DF(T) = 1, equivalently
+    // par = freq * (1 - DF(T)) / sum DF(t_i) equals the input quote.
+    let frequency = 2usize;
+    let quotes: Vec<(f64, f64)> = vec![
+        (1.0, 0.020),
+        (2.0, 0.022),
+        (3.0, 0.024),
+        (5.0, 0.026),
+        (7.0, 0.027),
+        (10.0, 0.028),
+    ];
+    let curve = YieldCurveBuilder::from_swap_rates(&quotes, frequency);
+
+    let df0 = curve.discount_factor(0.0);
+    assert!((df0 - 1.0).abs() <= 1e-14, "DF(0) must equal 1, got {df0}");
+
+    let dt = 1.0 / frequency as f64;
+    for &(tenor, quote) in &quotes {
+        let periods = (tenor * frequency as f64).round() as usize;
+        let annuity: f64 = (1..=periods)
+            .map(|i| curve.discount_factor(i as f64 * dt))
+            .sum();
+        let par = (1.0 - curve.discount_factor(tenor)) / (dt * annuity);
+        let err = (par - quote).abs();
+        assert!(
+            err <= 1e-8,
+            "par swap repricing failed at tenor {tenor}: input={quote} implied par={par} \
+             err={err}"
+        );
+    }
+
+    let mut prev = 1.0_f64;
+    for j in 1..=100 {
+        let t = 0.1 * j as f64;
+        let df = curve.discount_factor(t);
+        assert!(
+            df.is_finite() && df > 0.0 && df < prev,
+            "swap curve DF not strictly decreasing/finite at t={t}: df={df} prev={prev}"
+        );
+        prev = df;
+    }
+}
+
+// ============================================================================
+// 7. CDS invariants
+// ============================================================================
+
+#[test]
+fn cds_bootstrap_survival_and_par_spread_invariants() {
+    let discount_curve = flat_discount_curve(0.03, 12.0);
+    let recovery = 0.4;
+    let payment_freq = 4usize;
+    let quotes: Vec<(f64, f64)> = vec![
+        (1.0, 0.0060),
+        (3.0, 0.0080),
+        (5.0, 0.0100),
+        (7.0, 0.0115),
+        (10.0, 0.0130),
+    ];
+
+    let survival =
+        bootstrap_survival_curve_from_cds_spreads(&quotes, recovery, payment_freq, &discount_curve);
+
+    // Survival probabilities in (0, 1], non-increasing.
+    let mut prev = 1.0_f64;
+    for j in 0..=120 {
+        let t = 0.1 * j as f64;
+        let p = survival.survival_prob(t);
+        assert!(
+            p > 0.0 && p <= 1.0,
+            "survival probability out of (0, 1] at t={t}: {p}"
+        );
+        assert!(
+            p <= prev + 1e-12,
+            "survival probability increased at t={t}: S(t)={p} prev={prev}"
+        );
+        prev = p;
+    }
+
+    // Par-spread repricing of the bootstrap inputs.
+    for &(tenor, spread) in &quotes {
+        let cds = Cds {
+            notional: 1.0,
+            spread,
+            maturity: tenor,
+            recovery_rate: recovery,
+            payment_freq,
+        };
+        let fair = cds.fair_spread(&discount_curve, &survival);
+        let err = (fair - spread).abs();
+        assert!(
+            err <= 1e-8,
+            "CDS par-spread repricing failed at tenor {tenor}: input={spread} fair={fair} \
+             err={err}"
+        );
+        let npv = cds.npv(&discount_curve, &survival);
+        assert!(
+            npv.abs() <= 1e-8,
+            "pillar CDS NPV not ~0 at tenor {tenor}: npv={npv}"
+        );
+    }
+}
+
+// ============================================================================
+// 8. Greeks vs finite differences
+// ============================================================================
+
+#[test]
+fn bs_greeks_match_central_finite_differences() {
+    // Independent of external references: the analytic Greeks must agree with
+    // central finite differences of the engine's own analytic price.
+    // Conventions (from the engine): vega = dP/dvol, rho = dP/dr,
+    // theta = -dP/dT (calendar decay).
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(0xD1FF_0001);
+    // Moderate ranges keep the Greeks well away from machine noise so a pure
+    // relative tolerance is meaningful.
+    for i in 0..50 {
+        let spot = uniform(&mut rng, 50.0, 200.0);
+        let strike = spot * uniform(&mut rng, 0.75, 1.30);
+        let rate = uniform(&mut rng, 0.0, 0.08);
+        let q = uniform(&mut rng, 0.0, 0.04);
+        let vol = uniform(&mut rng, 0.15, 0.50);
+        let expiry = uniform(&mut rng, 0.30, 2.0);
+
+        for option_type in [OptionType::Call, OptionType::Put] {
+            let greeks = bs_result(option_type, spot, strike, rate, q, vol, expiry)
+                .greeks
+                .expect("BS engine returns greeks");
+            let price_at = |s: f64, r: f64, v: f64, t: f64| -> f64 {
+                bs_price(option_type, s, strike, r, q, v, t)
+            };
+
+            let hs = spot * 1e-4;
+            let fd_delta = (price_at(spot + hs, rate, vol, expiry)
+                - price_at(spot - hs, rate, vol, expiry))
+                / (2.0 * hs);
+
+            let hg = spot * 1e-3;
+            let fd_gamma = (price_at(spot + hg, rate, vol, expiry)
+                - 2.0 * price_at(spot, rate, vol, expiry)
+                + price_at(spot - hg, rate, vol, expiry))
+                / (hg * hg);
+
+            let hv = 1e-4;
+            let fd_vega = (price_at(spot, rate, vol + hv, expiry)
+                - price_at(spot, rate, vol - hv, expiry))
+                / (2.0 * hv);
+
+            let hr = 1e-5;
+            let fd_rho = (price_at(spot, rate + hr, vol, expiry)
+                - price_at(spot, rate - hr, vol, expiry))
+                / (2.0 * hr);
+
+            let ht = 1e-5;
+            let fd_theta = -(price_at(spot, rate, vol, expiry + ht)
+                - price_at(spot, rate, vol, expiry - ht))
+                / (2.0 * ht);
+
+            let checks = [
+                ("delta", greeks.delta, fd_delta),
+                ("gamma", greeks.gamma, fd_gamma),
+                ("vega", greeks.vega, fd_vega),
+                ("theta", greeks.theta, fd_theta),
+                ("rho", greeks.rho, fd_rho),
+            ];
+            for (name, analytic, fd) in checks {
+                // Relative 1e-5 with a small absolute floor for near-zero Greeks.
+                let tol = 1e-5 * analytic.abs().max(1e-2);
+                let err = (analytic - fd).abs();
+                assert!(
+                    err <= tol,
+                    "{name} mismatch vs FD at point {i} ({option_type:?}): S={spot} \
+                     K={strike} r={rate} q={q} vol={vol} T={expiry} analytic={analytic} \
+                     fd={fd} err={err} tol={tol}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Durable verification infrastructure following the two review passes (#183/#185): instead of more reading, this PR makes the engine stack check itself.

## `tests/cross_engine_consistency.rs` (11 tests, ~20s debug)
The same instruments priced through every applicable engine with agreement asserted:
- European vanillas over a 96-point grid: BS analytic vs CRR, trinomial, Crank-Nicolson (vol-adaptive S_max so low-vol points are grid-resolved rather than tolerance-excused), Monte Carlo (4σ), and Carr-Madan FFT via the exact BS characteristic function
- American puts across CRR / independent binomial / trinomial / CN / LSM; American call with q=0 ≡ European
- Barriers: in + out = vanilla exactly in analytic and in common-path MC; discrete MC vs analytic at the Broadie–Glasserman–Kou shifted barrier
- Geometric Asians and digitals vs MC

**No genuine inter-engine discrepancies found.** The two independent CRR implementations agree to 1e-9; MC barrier parity holds to float precision.

## `tests/property_invariants.rs` (18 tests, 0.03s)
Seeded-sweep no-arbitrage and structural properties: put-call parity (BS/Black76/GK/digital cash+asset), monotonicity/bounds/delta ranges/gamma–vega positivity, strike convexity, barrier parity and KO monotonicity, SVI calendar + Fengler butterfly checks, curve DF and swap-bootstrap repricing identities, CDS bootstrap repricing, analytic-vs-FD Greeks. **All properties hold at first run.**

## `benches/hot_paths_bench.rs` (12 benchmarks)
Covers every recently optimized hot path so future regressions are measurable. Measured against the pre-review baseline (`da6b4b8`, release, criterion quick medians):

| Path | Baseline | Current | Speedup |
|---|---|---|---|
| Vol-surface query (128 lookups) | 20.1 µs | 3.3 µs | ~6.1x |
| Autocallable single price | 285.6 ms | 31.9 ms | ~8.9x |
| CDS bootstrap (5 pillars) | 1.011 ms | ~75 µs | ~13x |
| Rolling historical VaR (5k, w=250) | 21.7 ms | ~3.4 ms | ~6.4x |
| Gamma ladder (10 pillars) | 33.3 µs | 22.4 µs | ~1.45x |

Validation: both suites green, `cargo bench --no-run --features parallel,simd` compiles, fmt clean, workspace clippy zero errors.

https://claude.ai/code/session_01FAx1FjfzYunS5ZmSzywFjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAx1FjfzYunS5ZmSzywFjv)_