### PR TITLE
[codex] harden wasm bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,9 @@ jobs:
 
       - name: Build WASM
         run: wasm-pack build wasm --target web --out-dir ../www/pkg
+
+      - name: Test WASM bindings
+        run: wasm-pack test --node wasm
+
+      - name: Check WASM size budget
+        run: test "$(wc -c < www/pkg/openferric_wasm_bg.wasm)" -le 1200000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ pytest python/tests -v
 
 ```bash
 wasm-pack build wasm --target web --out-dir ../www/pkg
+wasm-pack test --node wasm
 ```
 
 ### TypeScript
@@ -83,6 +84,8 @@ Current CI in `.github/workflows/ci.yml` runs:
 4. ARM64 NEON SIMD regression tests on `ubuntu-24.04-arm`
 5. Python wheel build plus `pytest python/tests -v`
 6. `wasm-pack build wasm --target web --out-dir ../www/pkg`
+7. `wasm-pack test --node wasm`
+8. WASM binary size budget check for `www/pkg/openferric_wasm_bg.wasm`
 
 Prefer validating the narrowest relevant subset locally, but make sure changes are consistent with the CI commands above before opening a PR.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1608,6 +1627,7 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -2796,6 +2816,45 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ WASM build:
 
 ```bash
 wasm-pack build wasm --target web --out-dir ../www/pkg
+wasm-pack test --node wasm
 ```
 
 Coverage helpers:

--- a/src/math/correlation.rs
+++ b/src/math/correlation.rs
@@ -726,8 +726,8 @@ mod tests {
         for i in 0..n {
             for j in 0..n {
                 let mut acc = 0.0;
-                for k in 0..n {
-                    acc += l[i][k] * l[j][k];
+                for (&left, &right) in l[i].iter().zip(&l[j]) {
+                    acc += left * right;
                 }
                 assert!(
                     (acc - 1.0).abs() < 1.0e-12,

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -25,5 +25,8 @@ getrandom_0_2 = { package = "getrandom", version = "0.2", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/wasm/src/contract_tests.rs
+++ b/wasm/src/contract_tests.rs
@@ -1,0 +1,58 @@
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn pricing_success_path_returns_values() {
+    let price = crate::pricing::bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true)
+        .expect("valid Black-Scholes input should price");
+    assert!((price - 10.4506).abs() < 0.01);
+
+    let greeks = crate::pricing::bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true)
+        .expect("valid Greeks input should price");
+    assert_eq!(greeks.len(), 7);
+}
+
+#[wasm_bindgen_test]
+fn batch_length_mismatch_returns_js_error() {
+    let result = crate::pricing::bs_price_batch_wasm(
+        &[100.0, 101.0],
+        &[100.0],
+        &[0.05, 0.05],
+        &[0.0, 0.0],
+        &[0.20, 0.20],
+        &[1.0, 1.0],
+        &[1, 0],
+    );
+    assert!(result.is_err());
+}
+
+#[wasm_bindgen_test]
+fn invalid_scalar_inputs_return_js_errors() {
+    assert!(
+        crate::pricing::barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "sideways", true,)
+            .is_err()
+    );
+    assert!(crate::pricing::bond_price(1000.0, 0.05, 10.0, 0.05, 0).is_err());
+    assert!(crate::risk::var_historical(&[], 0.95).is_err());
+    assert!(crate::credit::cds_fair_spread(1_000_000.0, 5.0, 1.2, 0.02, 0.03).is_err());
+}
+
+#[wasm_bindgen_test]
+fn payoff_and_heston_reject_invalid_shapes() {
+    assert!(
+        crate::payoff::strategy_intrinsic_pnl_wasm(
+            &[90.0, 100.0, 110.0],
+            &[100.0, 110.0],
+            &[1.0],
+            &[1, 0],
+            5.0,
+        )
+        .is_err()
+    );
+
+    assert!(
+        crate::heston::heston_price(
+            100.0, 100.0, 0.01, 0.0, 0.04, 4.0, 0.25, 1.0, -1.2, 1.0, true,
+        )
+        .is_err()
+    );
+}

--- a/wasm/src/credit.rs
+++ b/wasm/src/credit.rs
@@ -1,17 +1,25 @@
 use wasm_bindgen::prelude::*;
 
+use crate::error::{require_finite, require_non_negative, require_positive, require_probability};
+
 /// Approximate CDS fair spread from flat hazard rate and flat discount rate.
 #[wasm_bindgen]
 pub fn cds_fair_spread(
-    _notional: f64,
+    notional: f64,
     maturity: f64,
     recovery_rate: f64,
     hazard_rate: f64,
     discount_rate: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     use openferric::credit::Cds;
     use openferric::credit::survival_curve::SurvivalCurve;
     use openferric::rates::YieldCurve;
+
+    require_positive("notional", notional)?;
+    require_positive("maturity", maturity)?;
+    require_probability("recovery_rate", recovery_rate)?;
+    require_non_negative("hazard_rate", hazard_rate)?;
+    require_finite("discount_rate", discount_rate)?;
 
     let tenors: Vec<(f64, f64)> = (1..=((maturity * 4.0).ceil() as u32))
         .map(|i| {
@@ -30,13 +38,13 @@ pub fn cds_fair_spread(
     let survival_curve = SurvivalCurve::new(surv_nodes);
 
     let cds = Cds {
-        notional: 1.0,
+        notional,
         spread: 0.01, // dummy
         maturity,
         recovery_rate,
         payment_freq: 4,
     };
-    cds.fair_spread(&discount_curve, &survival_curve)
+    Ok(cds.fair_spread(&discount_curve, &survival_curve))
 }
 
 #[cfg(test)]
@@ -45,7 +53,7 @@ mod tests {
 
     #[test]
     fn cds_fair_spread_positive() {
-        let spread = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.02, 0.03);
+        let spread = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.02, 0.03).unwrap();
         assert!(spread > 0.0);
     }
 
@@ -54,23 +62,23 @@ mod tests {
         // Fair spread ≈ (1-R)*λ for flat curves
         let hazard = 0.02;
         let recovery = 0.40;
-        let spread = cds_fair_spread(1_000_000.0, 5.0, recovery, hazard, 0.03);
+        let spread = cds_fair_spread(1_000_000.0, 5.0, recovery, hazard, 0.03).unwrap();
         let approx = (1.0 - recovery) * hazard;
         assert!((spread - approx).abs() < 0.005);
     }
 
     #[test]
     fn cds_fair_spread_higher_hazard() {
-        let spread_low = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.01, 0.03);
-        let spread_high = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.05, 0.03);
+        let spread_low = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.01, 0.03).unwrap();
+        let spread_high = cds_fair_spread(1_000_000.0, 5.0, 0.40, 0.05, 0.03).unwrap();
         assert!(spread_high > spread_low);
     }
 
     #[test]
     fn cds_fair_spread_lower_recovery() {
         // Lower recovery → higher spread
-        let spread_high_r = cds_fair_spread(1_000_000.0, 5.0, 0.60, 0.02, 0.03);
-        let spread_low_r = cds_fair_spread(1_000_000.0, 5.0, 0.20, 0.02, 0.03);
+        let spread_high_r = cds_fair_spread(1_000_000.0, 5.0, 0.60, 0.02, 0.03).unwrap();
+        let spread_low_r = cds_fair_spread(1_000_000.0, 5.0, 0.20, 0.02, 0.03).unwrap();
         assert!(spread_low_r > spread_high_r);
     }
 }

--- a/wasm/src/error.rs
+++ b/wasm/src/error.rs
@@ -1,0 +1,97 @@
+use wasm_bindgen::prelude::*;
+
+#[inline]
+pub(crate) fn js_error(message: impl Into<String>) -> JsValue {
+    JsValue::from_str(&message.into())
+}
+
+pub(crate) fn batch_length_error(
+    primary_name: &str,
+    primary_len: usize,
+    others: &[(&str, usize)],
+) -> Result<(), String> {
+    for (name, len) in others {
+        if *len != primary_len {
+            return Err(format!(
+                "batch input length mismatch: `{name}` has {len} entries, expected {primary_len} to match `{primary_name}`"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn check_batch_lengths(
+    primary_name: &str,
+    primary_len: usize,
+    others: &[(&str, usize)],
+) -> Result<(), JsValue> {
+    batch_length_error(primary_name, primary_len, others).map_err(js_error)
+}
+
+#[inline]
+pub(crate) fn require_finite(name: &str, value: f64) -> Result<(), JsValue> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(js_error(format!("`{name}` must be finite")))
+    }
+}
+
+#[inline]
+pub(crate) fn require_positive(name: &str, value: f64) -> Result<(), JsValue> {
+    require_finite(name, value)?;
+    if value > 0.0 {
+        Ok(())
+    } else {
+        Err(js_error(format!("`{name}` must be positive")))
+    }
+}
+
+#[inline]
+pub(crate) fn require_non_negative(name: &str, value: f64) -> Result<(), JsValue> {
+    require_finite(name, value)?;
+    if value >= 0.0 {
+        Ok(())
+    } else {
+        Err(js_error(format!("`{name}` must be non-negative")))
+    }
+}
+
+#[inline]
+pub(crate) fn require_probability(name: &str, value: f64) -> Result<(), JsValue> {
+    require_finite(name, value)?;
+    if (0.0..=1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(js_error(format!("`{name}` must be between 0 and 1")))
+    }
+}
+
+#[inline]
+pub(crate) fn require_open_probability(name: &str, value: f64) -> Result<(), JsValue> {
+    require_finite(name, value)?;
+    if (0.0..1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(js_error(format!(
+            "`{name}` must be greater than 0 and less than 1"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_length_error_reports_mismatched_input() {
+        let err = batch_length_error("spots", 2, &[("strikes", 1)]).unwrap_err();
+        assert!(err.contains("strikes"));
+        assert!(err.contains("spots"));
+    }
+
+    #[test]
+    fn batch_length_error_accepts_matching_inputs() {
+        assert!(batch_length_error("spots", 2, &[("strikes", 2), ("vols", 2)]).is_ok());
+    }
+}

--- a/wasm/src/heston.rs
+++ b/wasm/src/heston.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 
+use crate::error::{js_error, require_finite, require_non_negative, require_positive};
 use crate::helpers::{heston_intrinsic, option_price_from_call};
 
 /// Heston European option price via FFT. Put prices are computed by parity.
@@ -16,9 +17,11 @@ pub fn heston_price(
     rho: f64,
     maturity: f64,
     is_call: bool,
-) -> f64 {
+) -> Result<f64, JsValue> {
+    validate_heston_inputs(spot, &[strike], v0, kappa, theta, sigma_v, rho, maturity)?;
+
     if maturity <= 0.0 {
-        return heston_intrinsic(spot, strike, is_call);
+        return Ok(heston_intrinsic(spot, strike, is_call));
     }
 
     let call_price = heston_fft_prices(
@@ -32,16 +35,18 @@ pub fn heston_price(
         sigma_v,
         rho,
         maturity,
-    )
+    )?
     .into_iter()
     .next()
-    .unwrap_or(f64::NAN);
+    .ok_or_else(|| js_error("Heston FFT returned no prices"))?;
 
     if !call_price.is_finite() {
-        return f64::NAN;
+        return Err(js_error("Heston FFT returned a non-finite price"));
     }
 
-    option_price_from_call(call_price, spot, strike, rate, div_yield, maturity, is_call)
+    Ok(option_price_from_call(
+        call_price, spot, strike, rate, div_yield, maturity, is_call,
+    ))
 }
 
 /// Heston FFT prices for a strike array.
@@ -60,24 +65,27 @@ pub fn heston_fft_prices(
     sigma_v: f64,
     rho: f64,
     maturity: f64,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, JsValue> {
     use openferric::engines::fft::{CarrMadanContext, CarrMadanParams, HestonCharFn};
 
     if strikes.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
+    validate_heston_inputs(spot, strikes, v0, kappa, theta, sigma_v, rho, maturity)?;
+    require_finite("rate", rate)?;
+    require_finite("div_yield", div_yield)?;
 
     let cf = HestonCharFn::new(
         spot, rate, div_yield, maturity, v0, kappa, theta, sigma_v, rho,
     );
     let ctx = match CarrMadanContext::new(&cf, rate, maturity, spot, CarrMadanParams::default()) {
         Ok(ctx) => ctx,
-        Err(_) => return vec![f64::NAN; strikes.len()],
+        Err(e) => return Err(js_error(format!("Heston FFT setup failed: {e}"))),
     };
 
     ctx.price_strikes(strikes)
         .map(|pairs| pairs.into_iter().map(|(_, p)| p).collect())
-        .unwrap_or_else(|_| vec![f64::NAN; strikes.len()])
+        .map_err(|e| js_error(format!("Heston FFT pricing failed: {e}")))
 }
 
 /// Heston FFT price for a single strike (convenience wrapper).
@@ -94,7 +102,7 @@ pub fn heston_fft_price(
     sigma_v: f64,
     rho: f64,
     maturity: f64,
-) -> f64 {
+) -> Result<f64, JsValue> {
     heston_fft_prices(
         spot,
         &[strike],
@@ -106,10 +114,36 @@ pub fn heston_fft_price(
         sigma_v,
         rho,
         maturity,
-    )
+    )?
     .into_iter()
     .next()
-    .unwrap_or(f64::NAN)
+    .ok_or_else(|| js_error("Heston FFT returned no prices"))
+}
+
+fn validate_heston_inputs(
+    spot: f64,
+    strikes: &[f64],
+    v0: f64,
+    kappa: f64,
+    theta: f64,
+    sigma_v: f64,
+    rho: f64,
+    maturity: f64,
+) -> Result<(), JsValue> {
+    require_positive("spot", spot)?;
+    require_non_negative("maturity", maturity)?;
+    require_non_negative("v0", v0)?;
+    require_positive("kappa", kappa)?;
+    require_non_negative("theta", theta)?;
+    require_non_negative("sigma_v", sigma_v)?;
+    require_finite("rho", rho)?;
+    if !(-1.0..=1.0).contains(&rho) {
+        return Err(js_error("`rho` must be between -1 and 1"));
+    }
+    for &strike in strikes {
+        require_positive("strike", strike)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -129,13 +163,13 @@ mod tests {
 
     #[test]
     fn heston_fft_price_reference_k100() {
-        let price = heston_fft_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T);
+        let price = heston_fft_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T).unwrap();
         assert!((price - 16.070154917028834).abs() < 0.05);
     }
 
     #[test]
     fn heston_fft_price_reference_k80() {
-        let price = heston_fft_price(SPOT, 80.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T);
+        let price = heston_fft_price(SPOT, 80.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T).unwrap();
         assert!((price - 26.774758743998854).abs() < 0.05);
     }
 
@@ -152,7 +186,8 @@ mod tests {
             SIGMA_V,
             RHO,
             T,
-        );
+        )
+        .unwrap();
         assert_eq!(prices.len(), 3);
         // Call prices decrease with strike
         assert!(prices[0] > prices[1]);
@@ -161,33 +196,39 @@ mod tests {
 
     #[test]
     fn heston_fft_prices_empty() {
-        let prices = heston_fft_prices(SPOT, &[], R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T);
+        let prices = heston_fft_prices(SPOT, &[], R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T).unwrap();
         assert!(prices.is_empty());
     }
 
     #[test]
     fn heston_fft_price_matches_batch() {
-        let scalar = heston_fft_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T);
-        let batch = heston_fft_prices(SPOT, &[100.0], R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T);
+        let scalar =
+            heston_fft_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T).unwrap();
+        let batch =
+            heston_fft_prices(SPOT, &[100.0], R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T).unwrap();
         assert!((scalar - batch[0]).abs() < 1e-10);
     }
 
     #[test]
     fn heston_price_call_reference() {
-        let price = heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, true);
+        let price =
+            heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, true).unwrap();
         assert!((price - 16.070154917028834).abs() < 0.05);
     }
 
     #[test]
     fn heston_price_put_reference() {
-        let price = heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, false);
+        let price =
+            heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, false).unwrap();
         assert!((price - 17.055_270_961_270_11).abs() < 0.05);
     }
 
     #[test]
     fn heston_price_put_call_parity() {
-        let call = heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, true);
-        let put = heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, false);
+        let call =
+            heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, true).unwrap();
+        let put =
+            heston_price(SPOT, 100.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, T, false).unwrap();
         let fwd = SPOT * (-Q * T).exp();
         let pv_k = 100.0 * (-R * T).exp();
         let parity = call - put - (fwd - pv_k);
@@ -196,11 +237,13 @@ mod tests {
 
     #[test]
     fn heston_price_zero_maturity() {
-        let call = heston_price(SPOT, 90.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, 0.0, true);
+        let call =
+            heston_price(SPOT, 90.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, 0.0, true).unwrap();
         assert!((call - 10.0).abs() < 1e-10); // intrinsic
         let put = heston_price(
             SPOT, 110.0, R, Q, V0, KAPPA, THETA, SIGMA_V, RHO, 0.0, false,
-        );
+        )
+        .unwrap();
         assert!((put - 10.0).abs() < 1e-10); // intrinsic
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,6 +1,7 @@
 mod calibrate;
 mod credit;
 mod dsl;
+mod error;
 mod funding;
 mod gpu;
 mod helpers;
@@ -9,3 +10,6 @@ mod payoff;
 mod pricing;
 mod risk;
 mod vol;
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod contract_tests;

--- a/wasm/src/payoff.rs
+++ b/wasm/src/payoff.rs
@@ -1,5 +1,7 @@
 use wasm_bindgen::prelude::*;
 
+use crate::error::check_batch_lengths;
+
 /// Strategy intrinsic PnL at expiry for a set of option legs across a spot axis.
 #[wasm_bindgen]
 pub fn strategy_intrinsic_pnl_wasm(
@@ -8,10 +10,19 @@ pub fn strategy_intrinsic_pnl_wasm(
     quantities: &[f64],
     is_calls: &[u8],
     total_cost: f64,
-) -> Vec<f64> {
-    openferric::pricing::payoff::strategy_intrinsic_pnl(
+) -> Result<Vec<f64>, JsValue> {
+    check_batch_lengths(
+        "strikes",
+        strikes.len(),
+        &[
+            ("quantities", quantities.len()),
+            ("is_calls", is_calls.len()),
+        ],
+    )?;
+
+    Ok(openferric::pricing::payoff::strategy_intrinsic_pnl(
         spot_axis, strikes, quantities, is_calls, total_cost,
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -22,7 +33,7 @@ mod tests {
     fn long_call_pnl() {
         // Long 1 call at K=100, cost=5
         let spots = [80.0, 90.0, 100.0, 110.0, 120.0];
-        let pnl = strategy_intrinsic_pnl_wasm(&spots, &[100.0], &[1.0], &[1u8], 5.0);
+        let pnl = strategy_intrinsic_pnl_wasm(&spots, &[100.0], &[1.0], &[1u8], 5.0).unwrap();
         assert_eq!(pnl.len(), 5);
         // Below strike: PnL = -cost
         assert!((pnl[0] - (-5.0)).abs() < 1e-10);
@@ -37,7 +48,7 @@ mod tests {
     fn long_put_pnl() {
         // Long 1 put at K=100, cost=5
         let spots = [80.0, 90.0, 100.0, 110.0, 120.0];
-        let pnl = strategy_intrinsic_pnl_wasm(&spots, &[100.0], &[1.0], &[0u8], 5.0);
+        let pnl = strategy_intrinsic_pnl_wasm(&spots, &[100.0], &[1.0], &[0u8], 5.0).unwrap();
         assert_eq!(pnl.len(), 5);
         assert!((pnl[0] - 15.0).abs() < 1e-10); // 100-80-5
         assert!((pnl[1] - 5.0).abs() < 1e-10); // 100-90-5
@@ -50,7 +61,8 @@ mod tests {
         // Long call K=100, short call K=110, net debit=3
         let spots = [90.0, 100.0, 105.0, 110.0, 120.0];
         let pnl =
-            strategy_intrinsic_pnl_wasm(&spots, &[100.0, 110.0], &[1.0, -1.0], &[1u8, 1u8], 3.0);
+            strategy_intrinsic_pnl_wasm(&spots, &[100.0, 110.0], &[1.0, -1.0], &[1u8, 1u8], 3.0)
+                .unwrap();
         assert_eq!(pnl.len(), 5);
         // Below both strikes: max loss = -cost
         assert!((pnl[0] - (-3.0)).abs() < 1e-10);
@@ -62,7 +74,7 @@ mod tests {
 
     #[test]
     fn empty_spot_axis() {
-        let pnl = strategy_intrinsic_pnl_wasm(&[], &[100.0], &[1.0], &[1u8], 5.0);
+        let pnl = strategy_intrinsic_pnl_wasm(&[], &[100.0], &[1.0], &[1u8], 5.0).unwrap();
         assert!(pnl.is_empty());
     }
 }

--- a/wasm/src/pricing.rs
+++ b/wasm/src/pricing.rs
@@ -1,5 +1,8 @@
 use wasm_bindgen::prelude::*;
 
+use crate::error::{
+    check_batch_lengths, js_error, require_finite, require_non_negative, require_positive,
+};
 use openferric::core::types::{BarrierDirection, BarrierStyle, OptionType};
 use openferric::greeks::black_scholes_merton_greeks;
 use openferric::math::{normal_cdf, normal_pdf};
@@ -17,7 +20,14 @@ pub fn bs_price(
     vol: f64,
     maturity: f64,
     is_call: bool,
-) -> f64 {
+) -> Result<f64, JsValue> {
+    require_positive("spot", spot)?;
+    require_positive("strike", strike)?;
+    require_non_negative("vol", vol)?;
+    require_non_negative("maturity", maturity)?;
+    require_finite("rate", rate)?;
+    require_finite("div_yield", div_yield)?;
+
     let ot = if is_call {
         OptionType::Call
     } else {
@@ -25,7 +35,7 @@ pub fn bs_price(
     };
     // Adjust for continuous dividend yield: S_adj = S * e^{-q*T}
     let s_adj = spot * (-div_yield * maturity).exp();
-    black_scholes_price(ot, s_adj, strike, rate, vol, maturity)
+    Ok(black_scholes_price(ot, s_adj, strike, rate, vol, maturity))
 }
 
 /// Black-Scholes implied volatility.
@@ -38,14 +48,22 @@ pub fn bs_implied_vol(
     div_yield: f64,
     maturity: f64,
     is_call: bool,
-) -> f64 {
+) -> Result<f64, JsValue> {
+    require_finite("price", price)?;
+    require_positive("spot", spot)?;
+    require_positive("strike", strike)?;
+    require_positive("maturity", maturity)?;
+    require_finite("rate", rate)?;
+    require_finite("div_yield", div_yield)?;
+
     let ot = if is_call {
         OptionType::Call
     } else {
         OptionType::Put
     };
     let s_adj = spot * (-div_yield * maturity).exp();
-    implied_vol(ot, s_adj, strike, rate, maturity, price, 1e-12, 64).unwrap_or(f64::NAN)
+    implied_vol(ot, s_adj, strike, rate, maturity, price, 1e-12, 64)
+        .map_err(|e| js_error(format!("implied volatility solve failed: {e}")))
 }
 
 /// BSM Greeks: returns [delta, gamma, vega, theta, rho, vanna, volga].
@@ -58,14 +76,23 @@ pub fn bsm_greeks_wasm(
     vol: f64,
     expiry: f64,
     is_call: bool,
-) -> Vec<f64> {
+) -> Result<Vec<f64>, JsValue> {
+    require_positive("spot", spot)?;
+    require_positive("strike", strike)?;
+    require_non_negative("vol", vol)?;
+    require_non_negative("expiry", expiry)?;
+    require_finite("rate", rate)?;
+    require_finite("div_yield", div_yield)?;
+
     let option_type = if is_call {
         OptionType::Call
     } else {
         OptionType::Put
     };
     let g = black_scholes_merton_greeks(option_type, spot, strike, rate, div_yield, vol, expiry);
-    vec![g.delta, g.gamma, g.vega, g.theta, g.rho, g.vanna, g.volga]
+    Ok(vec![
+        g.delta, g.gamma, g.vega, g.theta, g.rho, g.vanna, g.volga,
+    ])
 }
 
 #[inline]
@@ -113,25 +140,6 @@ fn black76_greeks_7(
     [delta, gamma, vega, theta, rho, vanna, volga]
 }
 
-/// Validate that every batch input slice matches the primary slice length.
-///
-/// Returns the error message as a `String` so it can be unit-tested on
-/// non-wasm targets; callers convert it to a `JsValue` at the boundary.
-fn batch_length_error(n: usize, others: &[(&str, usize)]) -> Result<(), String> {
-    for (name, len) in others {
-        if *len != n {
-            return Err(format!(
-                "batch input length mismatch: `{name}` has {len} entries, expected {n}"
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn check_batch_lengths(n: usize, others: &[(&str, usize)]) -> Result<(), JsValue> {
-    batch_length_error(n, others).map_err(|message| JsValue::from_str(&message))
-}
-
 /// Batch Black-Scholes pricing: one WASM call for N options.
 ///
 /// All input slices must have the same length.  `is_calls` uses `1` = call,
@@ -150,6 +158,7 @@ pub fn bs_price_batch_wasm(
 ) -> Result<Vec<f64>, JsValue> {
     let n = spots.len();
     check_batch_lengths(
+        "spots",
         n,
         &[
             ("strikes", strikes.len()),
@@ -198,6 +207,7 @@ pub fn black76_price_batch_wasm(
 ) -> Result<Vec<f64>, JsValue> {
     let n = forwards.len();
     check_batch_lengths(
+        "forwards",
         n,
         &[
             ("strikes", strikes.len()),
@@ -246,6 +256,7 @@ pub fn bsm_greeks_batch_wasm(
 ) -> Result<Vec<f64>, JsValue> {
     let n = spots.len();
     check_batch_lengths(
+        "spots",
         n,
         &[
             ("strikes", strikes.len()),
@@ -305,6 +316,7 @@ pub fn black76_greeks_batch_wasm(
 ) -> Result<Vec<f64>, JsValue> {
     let n = forwards.len();
     check_batch_lengths(
+        "forwards",
         n,
         &[
             ("strikes", strikes.len()),
@@ -342,7 +354,15 @@ pub fn barrier_price(
     maturity: f64,
     barrier_type: &str,
     is_call: bool,
-) -> f64 {
+) -> Result<f64, JsValue> {
+    require_positive("spot", spot)?;
+    require_positive("strike", strike)?;
+    require_positive("barrier", barrier)?;
+    require_non_negative("vol", vol)?;
+    require_non_negative("maturity", maturity)?;
+    require_finite("rate", rate)?;
+    require_finite("div_yield", div_yield)?;
+
     let ot = if is_call {
         OptionType::Call
     } else {
@@ -353,11 +373,15 @@ pub fn barrier_price(
         "up-out" => (BarrierDirection::Up, BarrierStyle::Out),
         "down-in" => (BarrierDirection::Down, BarrierStyle::In),
         "down-out" => (BarrierDirection::Down, BarrierStyle::Out),
-        _ => return f64::NAN,
+        _ => {
+            return Err(js_error(
+                "`barrier_type` must be one of up-in, up-out, down-in, down-out",
+            ));
+        }
     };
-    barrier_price_closed_form_with_carry_and_rebate(
+    Ok(barrier_price_closed_form_with_carry_and_rebate(
         ot, style, direction, spot, strike, barrier, rate, div_yield, vol, maturity, 0.0,
-    )
+    ))
 }
 
 /// Simple fixed-rate bond dirty price using flat yield discounting.
@@ -368,9 +392,13 @@ pub fn bond_price(
     maturity_years: f64,
     yield_rate: f64,
     frequency: u32,
-) -> f64 {
-    if frequency == 0 || maturity_years <= 0.0 {
-        return f64::NAN;
+) -> Result<f64, JsValue> {
+    require_positive("face_value", face_value)?;
+    require_non_negative("coupon_rate", coupon_rate)?;
+    require_positive("maturity_years", maturity_years)?;
+    require_finite("yield_rate", yield_rate)?;
+    if frequency == 0 {
+        return Err(js_error("`frequency` must be positive"));
     }
     let freq = frequency as f64;
     let coupon = face_value * coupon_rate / freq;
@@ -383,7 +411,7 @@ pub fn bond_price(
         pv += coupon * df;
     }
     pv += face_value * (1.0 + r_per).powi(-(n_periods as i32));
-    pv
+    Ok(pv)
 }
 
 #[cfg(test)]
@@ -396,13 +424,13 @@ mod tests {
 
     #[test]
     fn bs_price_atm_call() {
-        let price = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let price = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert!((price - 10.4506).abs() < 0.01);
     }
 
     #[test]
     fn bs_price_atm_put() {
-        let price = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, false);
+        let price = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, false).unwrap();
         assert!((price - 5.5735).abs() < 0.01);
     }
 
@@ -413,8 +441,8 @@ mod tests {
         let r = 0.05;
         let q = 0.0;
         let t = 1.0;
-        let call = bs_price(s, k, r, q, 0.20, t, true);
-        let put = bs_price(s, k, r, q, 0.20, t, false);
+        let call = bs_price(s, k, r, q, 0.20, t, true).unwrap();
+        let put = bs_price(s, k, r, q, 0.20, t, false).unwrap();
         let s_adj = s * (-q * t).exp();
         let parity = call - put - (s_adj - k * (-r * t).exp());
         assert!(parity.abs() < 1e-8);
@@ -422,8 +450,8 @@ mod tests {
 
     #[test]
     fn bs_price_with_dividend() {
-        let no_div = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
-        let with_div = bs_price(100.0, 100.0, 0.05, 0.03, 0.20, 1.0, true);
+        let no_div = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
+        let with_div = bs_price(100.0, 100.0, 0.05, 0.03, 0.20, 1.0, true).unwrap();
         assert!(with_div < no_div);
     }
 
@@ -432,16 +460,16 @@ mod tests {
     #[test]
     fn bs_implied_vol_round_trip() {
         let vol = 0.25;
-        let price = bs_price(100.0, 100.0, 0.05, 0.0, vol, 1.0, true);
-        let recovered = bs_implied_vol(price, 100.0, 100.0, 0.05, 0.0, 1.0, true);
+        let price = bs_price(100.0, 100.0, 0.05, 0.0, vol, 1.0, true).unwrap();
+        let recovered = bs_implied_vol(price, 100.0, 100.0, 0.05, 0.0, 1.0, true).unwrap();
         assert!((recovered - vol).abs() < 1e-4);
     }
 
     #[test]
     fn bs_implied_vol_put_round_trip() {
         let vol = 0.30;
-        let price = bs_price(100.0, 110.0, 0.03, 0.0, vol, 0.5, false);
-        let recovered = bs_implied_vol(price, 100.0, 110.0, 0.03, 0.0, 0.5, false);
+        let price = bs_price(100.0, 110.0, 0.03, 0.0, vol, 0.5, false).unwrap();
+        let recovered = bs_implied_vol(price, 100.0, 110.0, 0.03, 0.0, 0.5, false).unwrap();
         assert!((recovered - vol).abs() < 1e-3);
     }
 
@@ -449,32 +477,32 @@ mod tests {
 
     #[test]
     fn bsm_greeks_call_has_7_values() {
-        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert_eq!(g.len(), 7);
     }
 
     #[test]
     fn bsm_greeks_call_delta_range() {
-        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         let delta = g[0];
         assert!(delta > 0.0 && delta < 1.0);
     }
 
     #[test]
     fn bsm_greeks_put_delta_negative() {
-        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, false);
+        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, false).unwrap();
         assert!(g[0] < 0.0);
     }
 
     #[test]
     fn bsm_greeks_gamma_positive() {
-        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert!(g[1] > 0.0);
     }
 
     #[test]
     fn bsm_greeks_vega_positive() {
-        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let g = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert!(g[2] > 0.0);
     }
 
@@ -492,19 +520,19 @@ mod tests {
         let batch =
             bs_price_batch_wasm(&spots, &strikes, &rates, &divs, &vols, &mats, &calls).unwrap();
         assert_eq!(batch.len(), 2);
-        let p1 = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
-        let p2 = bs_price(100.0, 110.0, 0.05, 0.0, 0.20, 1.0, false);
+        let p1 = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
+        let p2 = bs_price(100.0, 110.0, 0.05, 0.0, 0.20, 1.0, false).unwrap();
         assert!((batch[0] - p1).abs() < TOL);
         assert!((batch[1] - p2).abs() < TOL);
     }
 
     #[test]
     fn batch_length_mismatch_is_rejected() {
-        // Tested via the String-level helper because constructing a JsValue
-        // is not supported on non-wasm test targets.
-        let err = batch_length_error(2, &[("strikes", 1)]).unwrap_err();
+        let err = crate::error::batch_length_error("spots", 2, &[("strikes", 1)]).unwrap_err();
         assert!(err.contains("strikes"));
-        assert!(batch_length_error(2, &[("strikes", 2), ("vols", 2)]).is_ok());
+        assert!(
+            crate::error::batch_length_error("spots", 2, &[("strikes", 2), ("vols", 2)]).is_ok()
+        );
     }
 
     // -- bsm_greeks_batch_wasm --
@@ -521,7 +549,7 @@ mod tests {
         let batch =
             bsm_greeks_batch_wasm(&spots, &strikes, &rates, &divs, &vols, &expiries, &calls)
                 .unwrap();
-        let single = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let single = bsm_greeks_wasm(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert_eq!(batch.len(), 7);
         for i in 0..7 {
             assert!((batch[i] - single[i]).abs() < TOL);
@@ -584,29 +612,24 @@ mod tests {
 
     #[test]
     fn barrier_up_out_call_less_than_vanilla() {
-        let vanilla = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
-        let bp = barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-out", true);
+        let vanilla = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
+        let bp = barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-out", true).unwrap();
         assert!(bp > 0.0 && bp < vanilla);
     }
 
     #[test]
     fn barrier_in_plus_out_equals_vanilla() {
-        let in_p = barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-in", true);
-        let out_p = barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-out", true);
-        let vanilla = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true);
+        let in_p = barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-in", true).unwrap();
+        let out_p =
+            barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "up-out", true).unwrap();
+        let vanilla = bs_price(100.0, 100.0, 0.05, 0.0, 0.20, 1.0, true).unwrap();
         assert!((in_p + out_p - vanilla).abs() < 1e-3);
     }
 
     #[test]
-    fn barrier_invalid_type_returns_nan() {
-        assert!(
-            barrier_price(100.0, 100.0, 120.0, 0.05, 0.0, 0.20, 1.0, "sideways", true).is_nan()
-        );
-    }
-
-    #[test]
     fn barrier_down_in_put() {
-        let price = barrier_price(100.0, 100.0, 80.0, 0.05, 0.0, 0.20, 1.0, "down-in", false);
+        let price =
+            barrier_price(100.0, 100.0, 80.0, 0.05, 0.0, 0.20, 1.0, "down-in", false).unwrap();
         assert!(price > 0.0);
     }
 
@@ -615,31 +638,21 @@ mod tests {
     #[test]
     fn bond_price_par() {
         // When coupon rate == yield rate, bond price ≈ face value
-        let price = bond_price(1000.0, 0.05, 10.0, 0.05, 2);
+        let price = bond_price(1000.0, 0.05, 10.0, 0.05, 2).unwrap();
         assert!((price - 1000.0).abs() < 0.01);
     }
 
     #[test]
     fn bond_price_premium() {
         // Coupon > yield → premium
-        let price = bond_price(1000.0, 0.08, 10.0, 0.05, 2);
+        let price = bond_price(1000.0, 0.08, 10.0, 0.05, 2).unwrap();
         assert!(price > 1000.0);
     }
 
     #[test]
     fn bond_price_discount() {
         // Coupon < yield → discount
-        let price = bond_price(1000.0, 0.03, 10.0, 0.05, 2);
+        let price = bond_price(1000.0, 0.03, 10.0, 0.05, 2).unwrap();
         assert!(price < 1000.0);
-    }
-
-    #[test]
-    fn bond_price_zero_freq_nan() {
-        assert!(bond_price(1000.0, 0.05, 10.0, 0.05, 0).is_nan());
-    }
-
-    #[test]
-    fn bond_price_negative_maturity_nan() {
-        assert!(bond_price(1000.0, 0.05, -1.0, 0.05, 2).is_nan());
     }
 }

--- a/wasm/src/risk.rs
+++ b/wasm/src/risk.rs
@@ -1,14 +1,16 @@
 use wasm_bindgen::prelude::*;
 
+use crate::error::{js_error, require_open_probability};
 use openferric::risk::var::historical_var;
 
 /// Historical Value-at-Risk from a flat array of P&L returns.
 #[wasm_bindgen]
-pub fn var_historical(returns_flat: &[f64], confidence: f64) -> f64 {
+pub fn var_historical(returns_flat: &[f64], confidence: f64) -> Result<f64, JsValue> {
     if returns_flat.is_empty() {
-        return f64::NAN;
+        return Err(js_error("`returns_flat` must not be empty"));
     }
-    historical_var(returns_flat, confidence)
+    require_open_probability("confidence", confidence)?;
+    Ok(historical_var(returns_flat, confidence))
 }
 
 #[cfg(test)]
@@ -20,7 +22,7 @@ mod tests {
         let returns = [
             -0.10, -0.05, -0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.05,
         ];
-        let var = var_historical(&returns, 0.95);
+        let var = var_historical(&returns, 0.95).unwrap();
         assert!(var > 0.0);
     }
 
@@ -29,20 +31,15 @@ mod tests {
         let returns = [
             -0.10, -0.05, -0.03, -0.02, -0.01, 0.0, 0.01, 0.02, 0.03, 0.05,
         ];
-        let var_90 = var_historical(&returns, 0.90);
-        let var_99 = var_historical(&returns, 0.99);
+        let var_90 = var_historical(&returns, 0.90).unwrap();
+        let var_99 = var_historical(&returns, 0.99).unwrap();
         assert!(var_99 >= var_90);
-    }
-
-    #[test]
-    fn var_historical_empty_returns_nan() {
-        assert!(var_historical(&[], 0.95).is_nan());
     }
 
     #[test]
     fn var_historical_all_positive() {
         let returns = [0.01, 0.02, 0.03, 0.04, 0.05];
-        let var = var_historical(&returns, 0.95);
+        let var = var_historical(&returns, 0.95).unwrap();
         assert!(var <= 0.01);
     }
 }


### PR DESCRIPTION
## Summary

- Add shared WASM boundary validation helpers that convert invalid inputs into JS errors.
- Harden pricing, Heston, payoff, risk, and credit WASM exports against invalid scalar inputs and mismatched typed-array lengths.
- Add Node-based `wasm-bindgen-test` contract tests and CI coverage for the generated WASM package.
- Add a WASM binary size budget check and update repo docs with the new test command.
- Fix a clippy warning in a correlation test loop that blocked the repository pre-commit hook.

## Validation

- `cargo test -p openferric-wasm`
- `wasm-pack test --node wasm`
- `wasm-pack build wasm --target web --out-dir ../www/pkg`
- `cargo fmt --all --check`
- `cargo clippy -p openferric-wasm --all-targets`
- pre-commit hook: fmt, clippy, eslint, tsc, ruff check, ruff format

## Notes

Unrelated local dirty files were left out of this PR: `vendor/QuantLib`, `vscode-ext/dist/extension.js`, and `vscode-ext/server/openferric-lsp`.