### PR TITLE
Harden pricing numerics, validation, and runtime dispatch

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,7 @@
 name: Benchmarks
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "17 3 * * 1"
@@ -11,9 +12,16 @@ permissions:
 jobs:
   cpu:
     name: Stable CPU benchmark
+    # Stable hosts are currently reserved for scheduled/manual runs. Keeping
+    # pull requests off unavailable self-hosted labels avoids indefinitely
+    # queued checks; the hosted ARM64 sweep below supplies the PR regression
+    # signal.
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, linux, x64, openferric-benchmark]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
@@ -23,22 +31,49 @@ jobs:
       - name: Self-test benchmark regression gate
         run: python3 scripts/test-check-criterion-regression.py
 
+      - name: Resolve distinct benchmark revisions
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=2 origin main:refs/remotes/origin/main
+          candidate_sha="$(git rev-parse HEAD)"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            baseline_sha="${PR_BASE_SHA}"
+            git fetch --no-tags --depth=1 origin "${baseline_sha}"
+          else
+            baseline_sha="$(git rev-parse refs/remotes/origin/main)"
+            if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+              baseline_sha="$(git rev-parse "${candidate_sha}^")"
+            fi
+          fi
+          git cat-file -e "${baseline_sha}^{commit}"
+          if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+            echo "Benchmark baseline and candidate resolve to the same commit" >&2
+            exit 1
+          fi
+          echo "BENCHMARK_BASE_SHA=${baseline_sha}" >> "${GITHUB_ENV}"
+          echo "BENCHMARK_CANDIDATE_SHA=${candidate_sha}" >> "${GITHUB_ENV}"
+
       - name: Record runner provenance
         run: |
           mkdir -p target/benchmark-metadata
           rustc -Vv > target/benchmark-metadata/rustc.txt
           lscpu > target/benchmark-metadata/lscpu.txt
-          git rev-parse HEAD > target/benchmark-metadata/commit.txt
+          printf '%s\n' "${BENCHMARK_BASE_SHA}" \
+            > target/benchmark-metadata/baseline-commit.txt
+          printf '%s\n' "${BENCHMARK_CANDIDATE_SHA}" \
+            > target/benchmark-metadata/candidate-commit.txt
 
-      - name: Benchmark origin/main on the same CPU host
+      - name: Benchmark the base revision on the same CPU host
         run: |
-          set -o pipefail
+          set -euo pipefail
           rm -rf "${GITHUB_WORKSPACE}/target/criterion"
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          baseline_dir="${RUNNER_TEMP}/openferric-main-cpu-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git worktree add --detach "${baseline_dir}" refs/remotes/origin/main
+          baseline_dir="${RUNNER_TEMP}/openferric-base-cpu-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git worktree add --detach "${baseline_dir}" "${BENCHMARK_BASE_SHA}"
           trap 'git worktree remove --force "${baseline_dir}"' EXIT
-          # Use the current benchmark harness against main's library so newly
+          # Use the current benchmark harness against the base library so newly
           # added crossover groups have a like-for-like first baseline.
           cp "${GITHUB_WORKSPACE}/benches/simd_bench.rs" \
             "${baseline_dir}/benches/simd_bench.rs"
@@ -50,7 +85,7 @@ jobs:
               RUSTFLAGS="" \
               cargo bench --locked -p openferric --features parallel,simd,jit -- \
                 --noplot --save-baseline main
-          ) 2>&1 | tee target/benchmark-metadata/cpu-main-baseline.log
+          ) 2>&1 | tee target/benchmark-metadata/cpu-base-baseline.log
 
       - name: Run scalar and accelerated benchmarks
         run: |
@@ -91,9 +126,12 @@ jobs:
 
   gpu:
     name: Stable GPU benchmark
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, linux, x64, gpu, openferric-benchmark]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Install pinned Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
@@ -103,11 +141,39 @@ jobs:
       - name: Self-test benchmark regression gate
         run: python3 scripts/test-check-criterion-regression.py
 
+      - name: Resolve distinct benchmark revisions
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=2 origin main:refs/remotes/origin/main
+          candidate_sha="$(git rev-parse HEAD)"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            baseline_sha="${PR_BASE_SHA}"
+            git fetch --no-tags --depth=1 origin "${baseline_sha}"
+          else
+            baseline_sha="$(git rev-parse refs/remotes/origin/main)"
+            if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+              baseline_sha="$(git rev-parse "${candidate_sha}^")"
+            fi
+          fi
+          git cat-file -e "${baseline_sha}^{commit}"
+          if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+            echo "Benchmark baseline and candidate resolve to the same commit" >&2
+            exit 1
+          fi
+          echo "BENCHMARK_BASE_SHA=${baseline_sha}" >> "${GITHUB_ENV}"
+          echo "BENCHMARK_CANDIDATE_SHA=${candidate_sha}" >> "${GITHUB_ENV}"
+
       - name: Record GPU runner provenance
         run: |
           mkdir -p target/benchmark-metadata
           rustc -Vv > target/benchmark-metadata/rustc.txt
-          git rev-parse HEAD > target/benchmark-metadata/commit.txt
+          printf '%s\n' "${BENCHMARK_BASE_SHA}" \
+            > target/benchmark-metadata/baseline-commit.txt
+          printf '%s\n' "${BENCHMARK_CANDIDATE_SHA}" \
+            > target/benchmark-metadata/candidate-commit.txt
           uname -a > target/benchmark-metadata/system.txt
           if command -v lspci >/dev/null 2>&1; then
             lspci -nn | grep -Ei 'vga|3d|display' > target/benchmark-metadata/gpu-pci.txt || true
@@ -123,13 +189,12 @@ jobs:
               > target/benchmark-metadata/amd-rocm.txt 2>&1 || true
           fi
 
-      - name: Benchmark origin/main on the same GPU host
+      - name: Benchmark the base revision on the same GPU host
         run: |
-          set -o pipefail
+          set -euo pipefail
           rm -rf "${GITHUB_WORKSPACE}/target/criterion"
-          git fetch --no-tags origin main:refs/remotes/origin/main
-          baseline_dir="${RUNNER_TEMP}/openferric-main-gpu-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git worktree add --detach "${baseline_dir}" refs/remotes/origin/main
+          baseline_dir="${RUNNER_TEMP}/openferric-base-gpu-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git worktree add --detach "${baseline_dir}" "${BENCHMARK_BASE_SHA}"
           trap 'git worktree remove --force "${baseline_dir}"' EXIT
           (
             cd "${baseline_dir}"
@@ -139,10 +204,10 @@ jobs:
               cargo bench --locked -p openferric --bench gpu_bench \
                 --features gpu,parallel,simd -- \
                 --noplot --save-baseline main
-          ) 2>&1 | tee target/benchmark-metadata/gpu-main-baseline.log
+          ) 2>&1 | tee target/benchmark-metadata/gpu-base-baseline.log
           if grep -q 'Criterion.rs ERROR:' \
-            target/benchmark-metadata/gpu-main-baseline.log; then
-            echo "Criterion reported an error while recording the main baseline" >&2
+            target/benchmark-metadata/gpu-base-baseline.log; then
+            echo "Criterion reported an error while recording the base baseline" >&2
             exit 1
           fi
           find target/criterion/gpu_terminal_european \
@@ -176,6 +241,105 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: criterion-gpu-${{ github.sha }}
+          path: |
+            target/criterion
+            target/benchmark-metadata
+          retention-days: 90
+
+  arm64:
+    name: Linux ARM64 exact-terminal sweep
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Self-test benchmark regression gate
+        run: python3 scripts/test-check-criterion-regression.py
+
+      - name: Resolve distinct benchmark revisions
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=2 origin main:refs/remotes/origin/main
+          candidate_sha="$(git rev-parse HEAD)"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            baseline_sha="${PR_BASE_SHA}"
+            git fetch --no-tags --depth=1 origin "${baseline_sha}"
+          else
+            baseline_sha="$(git rev-parse refs/remotes/origin/main)"
+            if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+              baseline_sha="$(git rev-parse "${candidate_sha}^")"
+            fi
+          fi
+          git cat-file -e "${baseline_sha}^{commit}"
+          if [[ "${baseline_sha}" == "${candidate_sha}" ]]; then
+            echo "Benchmark baseline and candidate resolve to the same commit" >&2
+            exit 1
+          fi
+          echo "BENCHMARK_BASE_SHA=${baseline_sha}" >> "${GITHUB_ENV}"
+          echo "BENCHMARK_CANDIDATE_SHA=${candidate_sha}" >> "${GITHUB_ENV}"
+
+      - name: Record ARM runner provenance
+        run: |
+          mkdir -p target/benchmark-metadata
+          rustc -Vv > target/benchmark-metadata/rustc.txt
+          lscpu > target/benchmark-metadata/lscpu.txt
+          printf '%s\n' "${BENCHMARK_BASE_SHA}" \
+            > target/benchmark-metadata/baseline-commit.txt
+          printf '%s\n' "${BENCHMARK_CANDIDATE_SHA}" \
+            > target/benchmark-metadata/candidate-commit.txt
+
+      - name: Benchmark the base revision across the Linux ARM64 bracket
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE}/target/criterion"
+          baseline_dir="${RUNNER_TEMP}/openferric-base-arm64-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git worktree add --detach "${baseline_dir}" "${BENCHMARK_BASE_SHA}"
+          trap 'git worktree remove --force "${baseline_dir}"' EXIT
+          cp "${GITHUB_WORKSPACE}/benches/hot_paths_bench.rs" \
+            "${baseline_dir}/benches/hot_paths_bench.rs"
+          (
+            cd "${baseline_dir}"
+            CARGO_TARGET_DIR="${GITHUB_WORKSPACE}/target" \
+              RUSTFLAGS="" \
+              cargo bench --locked -p openferric --bench hot_paths_bench \
+                --features simd -- \
+                'mc_exact_terminal_auto_crossover/(scalar|simd|auto)/(4096|8192|16384)$' \
+                --noplot --save-baseline main
+          ) 2>&1 | tee target/benchmark-metadata/arm64-base-baseline.log
+
+      - name: Benchmark the candidate across the Linux ARM64 bracket
+        run: |
+          set -euo pipefail
+          cargo bench --locked -p openferric --bench hot_paths_bench \
+            --features simd -- \
+            'mc_exact_terminal_auto_crossover/(scalar|simd|auto)/(4096|8192|16384)$' \
+            --noplot --save-baseline candidate \
+            2>&1 | tee target/benchmark-metadata/arm64-candidate.log
+          python3 scripts/check-criterion-regression.py \
+            target/criterion/mc_exact_terminal_auto_crossover \
+            --baseline main \
+            --current candidate \
+            --expected-benchmarks 9 \
+            --max-regression-percent 20
+        env:
+          RUSTFLAGS: ""
+
+      - name: Upload ARM Criterion history
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-arm64-${{ github.sha }}
           path: |
             target/criterion
             target/benchmark-metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,11 +208,11 @@ jobs:
             args: --all-features
           - name: windows-accelerated
             os: windows-latest
-            command: check
+            command: test
             args: --no-default-features --features parallel,simd,jit
           - name: macos-accelerated
             os: macos-latest
-            command: check
+            command: test
             args: --no-default-features --features parallel,simd,jit
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deep-tests.yml
+++ b/.github/workflows/deep-tests.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Fuzz trade JSON
         run: cargo fuzz run trade_json -- -max_total_time=120
 
+      - name: Fuzz compiled-product JSON validation
+        run: cargo fuzz run compiled_product_json -- -max_total_time=120
+
   miri:
     name: Miri unsafe-kernel checks
     runs-on: ubuntu-latest
@@ -69,6 +72,7 @@ jobs:
             --package openferric \
             --features accelerated-native \
             --file src/core/engine.rs \
+            --file src/dsl/ir.rs \
             --file src/pricing/european.rs \
             --file src/engines/analytic/bs_simd.rs \
             --timeout-multiplier 3 \

--- a/benches/hot_paths_bench.rs
+++ b/benches/hot_paths_bench.rs
@@ -153,10 +153,9 @@ fn bench_mc_european_50k(c: &mut Criterion) {
     group.finish();
 }
 
-/// Keeps the exact-terminal Auto crossover calibrated. The implementation has
-/// no SIMD-only allocation pass, so the cost model selects SIMD once one full
-/// native vector is available. These sizes cover likely NEON, AVX2, and
-/// AVX-512 boundaries plus the former 512-path cutoff.
+/// Keeps the exact-terminal Auto crossover calibrated. Small sizes cover
+/// native vector/tail boundaries; 4,096/8,192/16,384 bracket the measured
+/// Apple M4 scalar-to-NEON crossover.
 fn bench_mc_exact_terminal_auto_crossover(c: &mut Criterion) {
     let market = benchmark_market();
     let option = VanillaOption::european_call(100.0, 1.0);
@@ -169,7 +168,9 @@ fn bench_mc_exact_terminal_auto_crossover(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("mc_exact_terminal_auto_crossover");
     group.sample_size(20);
-    for paths in [1_usize, 2, 3, 4, 7, 8, 15, 16, 31, 32, 255, 256, 511, 512] {
+    for paths in [
+        1_usize, 2, 3, 4, 7, 8, 15, 16, 31, 32, 255, 256, 511, 512, 4_096, 8_192, 16_384,
+    ] {
         group.throughput(Throughput::Elements(paths as u64));
         for (name, policy) in [
             ("scalar", ExecutionPolicy::Scalar),

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -479,10 +479,11 @@ validation; the native live-adapter comparison skips only when no adapter is
 available. DSL tests compare every example product against the interpreter
 when JIT is enabled.
 
-CI runs the full scalar and all-feature core suites on Linux. Parallel-only,
-SIMD-only, Windows, and macOS matrix entries are compile checks because their
-runtime paths are already exercised by the Linux all-feature suite; native
-ARM64 separately executes the NEON/Rayon tests. The WASM job executes the
+CI runs the full scalar and all-feature core suites on Linux. Parallel-only
+and SIMD-only Linux matrix entries are compile checks; Windows and macOS run
+the complete accelerated native tests so architecture-specific JIT and
+dispatch behavior cannot be hidden by a successful cross-platform build.
+Native ARM64 separately executes the NEON/Rayon tests. The WASM job executes the
 portable ABI and the same ABI compiled with required SIMD128 support under
 Node, including differential tests of the explicit uniform Black-Scholes
 price and Greek kernels. It also initializes a threaded Rayon pool and prices
@@ -508,22 +509,25 @@ cargo +nightly llvm-cov report --branch --codecov \
 Codecov enforces an 80% patch target. The coverage workflow additionally
 builds an instrumented Python wheel and runs `python/tests`.
 
-Scheduled deep verification runs two libFuzzer targets, Miri, and mutation
+Scheduled deep verification runs three libFuzzer targets, Miri, and mutation
 testing. The equivalent focused commands are:
 
 ```bash
 cargo +nightly fuzz run dsl_pipeline -- -max_total_time=120
 cargo +nightly fuzz run trade_json -- -max_total_time=120
+cargo +nightly fuzz run compiled_product_json -- -max_total_time=120
 cargo +nightly miri test -p openferric --no-default-features --lib math::
 cargo mutants --package openferric --features accelerated-native \
   --file src/core/engine.rs \
+  --file src/dsl/ir.rs \
   --file src/pricing/european.rs \
   --file src/engines/analytic/bs_simd.rs \
   --timeout-multiplier 3 --jobs 2 \
   --cargo-test-arg=--lib
 ```
 
-The fuzzers cover the complete DSL parse/diagnostic/compile pipeline and
-serialized `TradeInstrument`/`Portfolio` inputs. Miri targets scalar math
+The fuzzers cover the complete DSL parse/diagnostic/compile pipeline,
+serialized `TradeInstrument`/`Portfolio` inputs, and validation of deserialized
+`CompiledProduct` IR. Miri targets scalar math
 where unsupported SIMD instructions do not obscure memory-safety checks;
 platform SIMD is covered by the native x86-64 and ARM64 test matrix.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,5 +26,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "compiled_product_json"
+path = "fuzz_targets/compiled_product_json.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]
 members = ["."]

--- a/fuzz/fuzz_targets/compiled_product_json.rs
+++ b/fuzz/fuzz_targets/compiled_product_json.rs
@@ -1,0 +1,35 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use openferric::dsl::{CompiledProduct, ProductEvaluator};
+
+fuzz_target!(|data: &[u8]| {
+    // Keep this target focused on structural correctness rather than expected
+    // resource exhaustion from enormous products.
+    if data.len() > 64 * 1024 {
+        return;
+    }
+    let Ok(product) = serde_json::from_slice::<CompiledProduct>(data) else {
+        return;
+    };
+    if product.num_underlyings > 8
+        || product.state_vars.len() > 64
+        || product.schedules.len() > 16
+        || product
+            .schedules
+            .iter()
+            .map(|schedule| schedule.dates.len())
+            .sum::<usize>()
+            > 64
+    {
+        return;
+    }
+    if product.validate().is_ok() {
+        let num_steps = 8;
+        if let Ok(mut evaluator) = ProductEvaluator::new(&product, num_steps, 0.0) {
+            let initial_spots = vec![100.0; product.num_underlyings];
+            let path_spots = vec![initial_spots.clone(); num_steps + 1];
+            let _ = evaluator.evaluate(&path_spots, &initial_spots);
+        }
+    }
+});

--- a/python/src/mc.rs
+++ b/python/src/mc.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -34,38 +34,23 @@ fn rng_kind_name(kind: FastRngKind) -> &'static str {
 
 fn python_path_evaluator(
     callable: Py<PyAny>,
-) -> (core_mc::PathEvaluator, Arc<Mutex<Option<String>>>) {
-    let error = Arc::new(Mutex::new(None::<String>));
-    let error_slot = Arc::clone(&error);
-
-    let evaluator = Arc::new(move |path: &[f64]| -> f64 {
+    callback_name: &'static str,
+) -> core_mc::FalliblePathEvaluator<PyErr> {
+    Arc::new(move |path: &[f64]| -> PyResult<f64> {
         Python::attach(|py| {
             let bound = callable.bind(py);
-            match bound.call1((path.to_vec(),)) {
-                Ok(result) => match result.extract::<f64>() {
-                    Ok(value) => value,
-                    Err(err) => {
-                        if let Ok(mut slot) = error_slot.lock()
-                            && slot.is_none()
-                        {
-                            *slot = Some(err.to_string());
-                        }
-                        f64::NAN
-                    }
-                },
-                Err(err) => {
-                    if let Ok(mut slot) = error_slot.lock()
-                        && slot.is_none()
-                    {
-                        *slot = Some(err.to_string());
-                    }
-                    f64::NAN
-                }
+            let value = bound
+                .call1((path.to_vec(),))
+                .and_then(|result| result.extract::<f64>())?;
+            if value.is_finite() {
+                Ok(value)
+            } else {
+                Err(py_value_error(format!(
+                    "{callback_name} must return a finite float"
+                )))
             }
         })
-    });
-
-    (evaluator, error)
+    })
 }
 
 #[pyclass(module = "openferric", from_py_object)]
@@ -235,6 +220,11 @@ impl Clone for ControlVariate {
 impl ControlVariate {
     #[new]
     fn new(py: Python<'_>, expected: f64, evaluator: Py<PyAny>) -> PyResult<Self> {
+        if !expected.is_finite() {
+            return Err(py_value_error(
+                "control variate expected value must be finite",
+            ));
+        }
         if !evaluator.bind(py).is_callable() {
             return Err(py_value_error("control variate evaluator must be callable"));
         }
@@ -274,7 +264,7 @@ impl MonteCarloEngine {
         &self,
     ) -> (
         core_mc::MonteCarloEngine,
-        Option<Arc<Mutex<Option<String>>>>,
+        Option<core_mc::FallibleControlVariate<PyErr>>,
     ) {
         let mut inner = core_mc::MonteCarloEngine::new(self.num_paths, self.seed)
             .with_antithetic(self.antithetic)
@@ -284,33 +274,33 @@ impl MonteCarloEngine {
             inner = inner.with_randomized_streams();
         }
 
-        let mut control_error = None;
-        if let Some(control) = &self.control_variate {
+        let control_variate = self.control_variate.as_ref().map(|control| {
             let callable = Python::attach(|py| control.evaluator.clone_ref(py));
-            let (evaluator, error) = python_path_evaluator(callable);
-            inner = inner.with_control_variate(core_mc::ControlVariate {
+            core_mc::FallibleControlVariate {
                 expected: control.expected,
-                evaluator,
-            });
-            control_error = Some(error);
-        }
+                evaluator: python_path_evaluator(callable, "control variate callback"),
+            }
+        });
 
-        (inner, control_error)
+        (inner, control_variate)
     }
 }
 
 #[pymethods]
 impl MonteCarloEngine {
     #[new]
-    fn new(num_paths: usize, seed: u64) -> Self {
-        Self {
+    fn new(num_paths: usize, seed: u64) -> PyResult<Self> {
+        if num_paths == 0 {
+            return Err(py_value_error("num_paths must be > 0"));
+        }
+        Ok(Self {
             num_paths,
             antithetic: false,
             control_variate: None,
             seed,
             rng_kind: FastRngKind::Xoshiro256PlusPlus,
             reproducible: true,
-        }
+        })
     }
 
     #[getter]
@@ -389,31 +379,27 @@ impl MonteCarloEngine {
         if !payoff.bind(py).is_callable() {
             return Err(py_value_error("payoff must be callable"));
         }
-        let (core_engine, control_error) = self.to_core();
+        if !discount_factor.is_finite() || discount_factor < 0.0 {
+            return Err(py_value_error(
+                "discount_factor must be finite and non-negative",
+            ));
+        }
+        let (core_engine, control_variate) = self.to_core();
         // Python callbacks serialize on the GIL and may carry observable
         // side effects, so preserve deterministic callback order rather than
         // dispatching them from Rayon workers.
         let core_engine = core_engine.with_execution_policy(core_mc::CpuExecutionPolicy::Scalar);
-        let (payoff_fn, payoff_error) = python_path_evaluator(payoff);
+        let payoff_fn = python_path_evaluator(payoff, "payoff callback");
         // The Rust simulation owns the hot loop. Release the GIL while it is
         // running; Python callbacks briefly re-attach only when invoked.
-        let result = py.detach(|| {
-            core_engine.run(
+        py.detach(|| {
+            core_engine.run_fallible(
                 &generator.inner,
                 move |path| payoff_fn(path),
                 discount_factor,
+                control_variate,
             )
-        });
-
-        if let Some(message) = payoff_error.lock().ok().and_then(|slot| slot.clone()) {
-            return Err(py_value_error(message));
-        }
-        if let Some(message) =
-            control_error.and_then(|slot| slot.lock().ok().and_then(|guard| guard.clone()))
-        {
-            return Err(py_value_error(message));
-        }
-        Ok(result)
+        })
     }
 
     fn run_heston(
@@ -426,28 +412,24 @@ impl MonteCarloEngine {
         if !payoff.bind(py).is_callable() {
             return Err(py_value_error("payoff must be callable"));
         }
-        let (core_engine, control_error) = self.to_core();
+        if !discount_factor.is_finite() || discount_factor < 0.0 {
+            return Err(py_value_error(
+                "discount_factor must be finite and non-negative",
+            ));
+        }
+        let (core_engine, control_variate) = self.to_core();
         let core_engine = core_engine.with_execution_policy(core_mc::CpuExecutionPolicy::Scalar);
-        let (payoff_fn, payoff_error) = python_path_evaluator(payoff);
+        let payoff_fn = python_path_evaluator(payoff, "payoff callback");
         // The Rust simulation owns the hot loop. Release the GIL while it is
         // running; Python callbacks briefly re-attach only when invoked.
-        let result = py.detach(|| {
-            core_engine.run(
+        py.detach(|| {
+            core_engine.run_fallible(
                 &generator.inner,
                 move |path| payoff_fn(path),
                 discount_factor,
+                control_variate,
             )
-        });
-
-        if let Some(message) = payoff_error.lock().ok().and_then(|slot| slot.clone()) {
-            return Err(py_value_error(message));
-        }
-        if let Some(message) =
-            control_error.and_then(|slot| slot.lock().ok().and_then(|guard| guard.clone()))
-        {
-            return Err(py_value_error(message));
-        }
-        Ok(result)
+        })
     }
 
     fn __repr__(&self) -> String {

--- a/python/src/pricing.rs
+++ b/python/src/pricing.rs
@@ -1,8 +1,9 @@
 use numpy::{PyArray1, PyReadonlyArray1};
 use openferric_core::core::{Greeks as CoreGreeks, PricingEngine, PricingError};
 use openferric_core::engines::analytic::{
-    DigitalAnalyticEngine, ExoticAnalyticEngine, GarmanKohlhagenEngine, bs_price_batch,
-    kirk_spread_price, margrabe_exchange_price,
+    DigitalAnalyticEngine, ExoticAnalyticEngine, GarmanKohlhagenEngine,
+    black76_price as validated_black76_price, bs_price_batch, kirk_spread_price,
+    margrabe_exchange_price,
 };
 use openferric_core::greeks::black_scholes_merton_greeks;
 use openferric_core::instruments::{
@@ -37,7 +38,7 @@ use openferric_core::pricing::discrete_div::{
     escrowed_dividend_adjusted_spot_mixed, european_price_discrete_div,
     european_price_discrete_div_mixed, forward_price_discrete_div,
 };
-use openferric_core::pricing::european::{black_76_price, black_scholes_price};
+use openferric_core::pricing::european::black_scholes_price;
 use openferric_core::pricing::payoff::strategy_intrinsic_pnl;
 use openferric_core::pricing::range_accrual::{
     RangeAccrualResult as CoreRangeAccrualResult, dual_range_accrual_mc_price,
@@ -970,12 +971,17 @@ pub fn py_black76_price(
     vol: f64,
     rate: f64,
     option_type: &str,
-) -> f64 {
-    let Some(option_type) = parse_option_type(option_type) else {
-        return f64::NAN;
-    };
-
-    black_76_price(option_type, forward, strike, rate, vol, expiry)
+) -> PyResult<f64> {
+    let option_type = parse_option_type(option_type)
+        .ok_or_else(|| PyValueError::new_err("option_type must be 'call' or 'put'"))?;
+    let price = validated_black76_price(option_type, forward, strike, rate, vol, expiry)
+        .map_err(pricing_error_to_pyerr)?;
+    if !price.is_finite() {
+        return Err(PyValueError::new_err(
+            "Black-76 price is non-finite for the supplied inputs",
+        ));
+    }
+    Ok(price)
 }
 
 #[pyfunction]

--- a/python/tests/test_mc.py
+++ b/python/tests/test_mc.py
@@ -4,7 +4,7 @@ import math
 
 import pytest
 from conftest import assert_releases_gil
-from openferric import GbmPathGenerator, HestonPathGenerator, McEngine, MonteCarloEngine
+from openferric import ControlVariate, GbmPathGenerator, HestonPathGenerator, McEngine, MonteCarloEngine
 
 
 def vanilla_price(**overrides):
@@ -88,6 +88,121 @@ def test_custom_payoff_validates_callback():
 
     with pytest.raises(ValueError, match="payoff must be callable"):
         engine.run_gbm(generator, 42, 1.0)
+
+
+def test_custom_engine_rejects_zero_paths():
+    with pytest.raises(ValueError, match="num_paths"):
+        MonteCarloEngine(0, 7)
+
+
+@pytest.mark.parametrize("discount_factor", [math.nan, math.inf, -math.inf, -0.1])
+def test_custom_payoff_rejects_invalid_discount_factor(discount_factor):
+    generator = GbmPathGenerator(0.0, 0.2, 100.0, 0.25, 8)
+    engine = MonteCarloEngine(100, 7)
+
+    with pytest.raises(ValueError, match="discount_factor"):
+        engine.run_gbm(generator, lambda path: path[-1], discount_factor)
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_custom_payoff_rejects_non_finite_callback_values(value):
+    generator = GbmPathGenerator(0.0, 0.2, 100.0, 0.25, 8)
+    engine = MonteCarloEngine(10_000, 7)
+    calls = 0
+
+    def payoff(_path):
+        nonlocal calls
+        calls += 1
+        return value
+
+    with pytest.raises(ValueError, match="payoff callback must return a finite"):
+        engine.run_gbm(generator, payoff, 1.0)
+    assert calls == 1
+
+
+@pytest.mark.parametrize("expected", [math.nan, math.inf, -math.inf])
+def test_control_variate_rejects_non_finite_expected_value(expected):
+    with pytest.raises(ValueError, match="expected value must be finite"):
+        ControlVariate(expected, lambda path: path[-1])
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_control_variate_rejects_non_finite_callback_values(value):
+    generator = GbmPathGenerator(0.0, 0.2, 100.0, 0.25, 8)
+    control = ControlVariate(100.0, lambda _path: value)
+    engine = MonteCarloEngine(10_000, 7).with_control_variate(control)
+
+    with pytest.raises(ValueError, match="control variate callback must return a finite"):
+        engine.run_gbm(generator, lambda path: path[-1], 1.0)
+
+
+def test_gbm_callback_failure_stops_immediately_and_preserves_exception():
+    class PayoffFailureError(RuntimeError):
+        pass
+
+    calls = 0
+
+    def failing_payoff(path):
+        nonlocal calls
+        calls += 1
+        raise PayoffFailureError(f"failed at terminal value {path[-1]}")
+
+    generator = GbmPathGenerator(0.0, 0.2, 100.0, 0.25, 8)
+    engine = MonteCarloEngine(10_000, 7)
+
+    with pytest.raises(PayoffFailureError, match="failed at terminal value"):
+        engine.run_gbm(generator, failing_payoff, 1.0)
+    assert calls == 1
+
+
+def test_heston_callback_failure_stops_immediately_and_preserves_exception():
+    calls = 0
+
+    def failing_payoff(_path):
+        nonlocal calls
+        calls += 1
+        raise LookupError("heston payoff failed")
+
+    generator = HestonPathGenerator(
+        mu=0.07,
+        kappa=1.5,
+        theta=0.04,
+        xi=0.3,
+        rho=-0.7,
+        v0=0.04,
+        s0=100.0,
+        maturity=0.25,
+        steps=8,
+    )
+    engine = MonteCarloEngine(10_000, 11)
+
+    with pytest.raises(LookupError, match="heston payoff failed"):
+        engine.run_heston(generator, failing_payoff, 1.0)
+    assert calls == 1
+
+
+def test_control_variate_failure_stops_immediately_and_preserves_exception():
+    control_calls = 0
+    payoff_calls = 0
+
+    def payoff(path):
+        nonlocal payoff_calls
+        payoff_calls += 1
+        return path[-1]
+
+    def failing_control(_path):
+        nonlocal control_calls
+        control_calls += 1
+        raise ArithmeticError("control variate failed")
+
+    generator = GbmPathGenerator(0.0, 0.2, 100.0, 0.25, 8)
+    control = ControlVariate(100.0, failing_control)
+    engine = MonteCarloEngine(10_000, 7).with_control_variate(control)
+
+    with pytest.raises(ArithmeticError, match="control variate failed"):
+        engine.run_gbm(generator, payoff, 1.0)
+    assert payoff_calls == 1
+    assert control_calls == 1
 
 
 def test_pure_rust_mc_entry_points_release_gil():

--- a/python/tests/test_pricing.py
+++ b/python/tests/test_pricing.py
@@ -13,6 +13,7 @@ from openferric import (
     py_american_price,
     py_arithmetic_asian_price_mc,
     py_barrier_price,
+    py_black76_price,
     py_bs_greeks,
     py_bs_price,
     py_digital_price,
@@ -187,6 +188,63 @@ class TestBsPrice:
 
         assert values.shape == (length,)
         assert np.isfinite(values[[0, -1]]).all()
+
+
+class TestLegacyBlack76Price:
+    def test_matches_validated_analytic_entry_point(self):
+        legacy = py_black76_price(
+            forward=103.0,
+            strike=100.0,
+            expiry=1.25,
+            vol=0.24,
+            rate=0.03,
+            option_type="call",
+        )
+        validated = AnalyticEngine.black76_price(
+            option_type="call",
+            forward=103.0,
+            strike=100.0,
+            rate=0.03,
+            vol=0.24,
+            expiry=1.25,
+        )
+        assert legacy == validated
+
+    @pytest.mark.parametrize(
+        ("input_name", "bad_value"),
+        [
+            ("forward", -1.0),
+            ("forward", math.nan),
+            ("strike", 0.0),
+            ("strike", math.inf),
+            ("expiry", -1.0),
+            ("expiry", math.nan),
+            ("vol", -0.1),
+            ("vol", math.inf),
+            ("rate", math.nan),
+            ("rate", math.inf),
+        ],
+    )
+    def test_rejects_invalid_numeric_domain(self, input_name, bad_value):
+        inputs = dict(
+            forward=100.0,
+            strike=100.0,
+            expiry=1.0,
+            vol=0.2,
+            rate=0.03,
+            option_type="call",
+        )
+        inputs[input_name] = bad_value
+        with pytest.raises(ValueError):
+            py_black76_price(**inputs)
+
+    def test_rejects_invalid_option_type(self):
+        with pytest.raises(ValueError, match="option_type"):
+            py_black76_price(100.0, 100.0, 1.0, 0.2, 0.03, "straddle")
+
+    def test_rejects_non_finite_computed_price(self):
+        with pytest.raises(ValueError, match="non-finite"):
+            py_black76_price(100.0, 100.0, 1.0, 0.2, -1e308, "call")
 
 
 # =========================================================================

--- a/src/dsl/engine.rs
+++ b/src/dsl/engine.rs
@@ -11,11 +11,12 @@ use crate::dsl::eval::evaluate_product_with_plan_batch_neon;
 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
 use crate::dsl::eval::evaluate_product_with_plan_batch_x86;
 use crate::dsl::eval::{
-    ProductExecutionPlan, build_execution_plan, evaluate_product_with_plan_in_place,
+    ProductExecutionPlan, build_execution_plan_for_validated_product,
+    evaluate_product_with_plan_in_place,
 };
-use crate::dsl::ir::CompiledProduct;
+use crate::dsl::ir::{CompiledProduct, UnderlyingType};
 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
-use crate::dsl::jit::{JitEvaluationScratch, JitProductEvaluator};
+use crate::dsl::jit::{JitEvaluationScratch, JitProductEvaluator, jit_platform_supported};
 use crate::dsl::market::{AssetMarketData, MultiAssetMarket};
 use crate::engines::monte_carlo::correlated_mc::{
     cholesky_for_correlation, sample_correlated_normals_cholesky_with_scratch,
@@ -52,6 +53,24 @@ enum AssetStepper {
         exp_neg_a_dt: f64,
         vol_step: f64,
     },
+}
+
+fn market_asset_type(asset: &AssetMarketData) -> UnderlyingType {
+    match asset {
+        AssetMarketData::Equity { .. } => UnderlyingType::Equity,
+        AssetMarketData::Fx { .. } => UnderlyingType::Fx,
+        AssetMarketData::Commodity { .. } => UnderlyingType::Commodity,
+        AssetMarketData::Rate { .. } => UnderlyingType::Rate,
+    }
+}
+
+fn underlying_type_name(underlying_type: UnderlyingType) -> &'static str {
+    match underlying_type {
+        UnderlyingType::Equity => "equity",
+        UnderlyingType::Fx => "FX",
+        UnderlyingType::Commodity => "commodity",
+        UnderlyingType::Rate => "rate",
+    }
 }
 
 impl AssetStepper {
@@ -364,7 +383,14 @@ impl DslMonteCarloEngine {
             ExecutionPolicy::Jit => {
                 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
                 {
-                    Ok(ExecutionBackend::Jit)
+                    if jit_platform_supported() {
+                        Ok(ExecutionBackend::Jit)
+                    } else {
+                        Err(PricingError::InvalidInput(format!(
+                            "JIT execution is unsupported on {}; the current native backend requires x86_64",
+                            std::env::consts::ARCH
+                        )))
+                    }
                 }
                 #[cfg(not(all(feature = "jit", not(target_family = "wasm"))))]
                 {
@@ -379,7 +405,10 @@ impl DslMonteCarloEngine {
                 // non-SIMD build, JIT compilation is amortized only for a
                 // sufficiently large path count.
                 #[cfg(all(feature = "jit", not(target_family = "wasm")))]
-                if !simd_available && self.num_paths >= MIN_AUTO_JIT_PATHS {
+                if jit_platform_supported()
+                    && !simd_available
+                    && self.num_paths >= MIN_AUTO_JIT_PATHS
+                {
                     return Ok(ExecutionBackend::Jit);
                 }
 
@@ -443,7 +472,28 @@ impl DslMonteCarloEngine {
         market: &MultiAssetMarket,
         execution_policy: ExecutionPolicy,
     ) -> Result<PricingResult, PricingError> {
+        product.validate()?;
         market.validate()?;
+
+        if market.assets.len() != product.num_underlyings {
+            return Err(PricingError::InvalidInput(format!(
+                "market has {} assets, but product declares {} underlyings",
+                market.assets.len(),
+                product.num_underlyings
+            )));
+        }
+        for underlying in &product.underlyings {
+            let market_type = market_asset_type(&market.assets[underlying.asset_index]);
+            if underlying.underlying_type != market_type {
+                return Err(PricingError::InvalidInput(format!(
+                    "product underlying '{}' at asset index {} declares {}, but the market provides {} data",
+                    underlying.name,
+                    underlying.asset_index,
+                    underlying_type_name(underlying.underlying_type),
+                    underlying_type_name(market_type)
+                )));
+            }
+        }
 
         if self.num_paths == 0 {
             return Err(PricingError::InvalidInput(
@@ -475,7 +525,7 @@ impl DslMonteCarloEngine {
             ExecutionBackend::Scalar | ExecutionBackend::Simd | ExecutionBackend::Parallel
         ) {
             Some((
-                build_execution_plan(product, n_steps, market.rate)
+                build_execution_plan_for_validated_product(product, n_steps, market.rate)
                     .map_err(|e| PricingError::NumericalError(e.to_string()))?,
                 product.max_local_slots(),
             ))
@@ -578,6 +628,11 @@ impl DslMonteCarloEngine {
         let mean = chunk_stats.mean_pv;
         let variance = chunk_stats.sample_variance();
         let stderr = (variance / n).sqrt();
+        if !mean.is_finite() || !stderr.is_finite() {
+            return Err(PricingError::NumericalError(
+                "DSL evaluation produced a non-finite price or standard error".to_string(),
+            ));
+        }
 
         let mut diagnostics = Diagnostics::new();
         diagnostics.insert_key(DiagKey::NumPaths, n);
@@ -1519,6 +1574,146 @@ mod tests {
     }
 
     #[test]
+    fn price_rejects_product_market_dimension_mismatch() {
+        let mut product = make_forward_product();
+        product.num_underlyings = 2;
+        product.underlyings.push(UnderlyingDef {
+            name: "SX5E".to_string(),
+            asset_index: 1,
+            underlying_type: Default::default(),
+        });
+        let one_asset_market = MultiAssetMarket::single(100.0, 0.20, 0.05, 0.02);
+        let engine = DslMonteCarloEngine::new(16, 4, 42);
+
+        let error = engine
+            .price_multi_asset_with_policy(&product, &one_asset_market, ExecutionPolicy::Scalar)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("product declares 2"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn single_market_for_type(underlying_type: UnderlyingType) -> MultiAssetMarket {
+        let asset = match underlying_type {
+            UnderlyingType::Equity => AssetMarketData::Equity {
+                spot: 100.0,
+                vol: 0.2,
+                dividend_yield: 0.01,
+            },
+            UnderlyingType::Fx => AssetMarketData::Fx {
+                spot: 1.1,
+                vol: 0.15,
+                domestic_rate: 0.03,
+                foreign_rate: 0.02,
+            },
+            UnderlyingType::Commodity => AssetMarketData::Commodity {
+                spot: 75.0,
+                vol: 0.3,
+                convenience_yield: 0.01,
+                kappa: 1.0,
+                mu: 75.0_f64.ln(),
+            },
+            UnderlyingType::Rate => AssetMarketData::Rate {
+                initial_rate: 0.03,
+                vol: 0.01,
+                mean_reversion: 0.1,
+                long_run_mean: 0.04,
+            },
+        };
+        MultiAssetMarket {
+            assets: vec![asset],
+            correlation: vec![vec![1.0]],
+            rate: 0.03,
+        }
+    }
+
+    #[test]
+    fn price_rejects_underlying_market_type_mismatches_for_all_variants() {
+        let cases = [
+            (UnderlyingType::Equity, UnderlyingType::Fx),
+            (UnderlyingType::Fx, UnderlyingType::Commodity),
+            (UnderlyingType::Commodity, UnderlyingType::Rate),
+            (UnderlyingType::Rate, UnderlyingType::Equity),
+        ];
+        let engine = DslMonteCarloEngine::new(16, 4, 42);
+
+        for (declared_type, market_type) in cases {
+            let mut product = make_forward_product();
+            product.underlyings[0].name = "TEST".to_string();
+            product.underlyings[0].underlying_type = declared_type;
+            let market = single_market_for_type(market_type);
+
+            let error = engine
+                .price_multi_asset_with_policy(&product, &market, ExecutionPolicy::Scalar)
+                .unwrap_err();
+            let message = error.to_string();
+            assert!(message.contains("'TEST'"), "unexpected error: {message}");
+            assert!(
+                message.contains("asset index 0"),
+                "unexpected error: {message}"
+            );
+            assert!(
+                message.contains(underlying_type_name(declared_type)),
+                "unexpected error: {message}"
+            );
+            assert!(
+                message.contains(underlying_type_name(market_type)),
+                "unexpected error: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_cashflow_without_underlying_allows_any_market_variant() {
+        let mut product = make_constant_product(10.0);
+        product.underlyings.clear();
+        let market = single_market_for_type(UnderlyingType::Rate);
+        let engine = DslMonteCarloEngine::new(16, 4, 42);
+
+        let result = engine
+            .price_multi_asset_with_policy(&product, &market, ExecutionPolicy::Scalar)
+            .unwrap();
+        let expected = 10.0 * (-market.rate).exp();
+        assert!((result.price - expected).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn pricing_backends_reject_non_finite_results() {
+        let mut product = make_constant_product(1.0);
+        product.schedules[0].body = vec![Statement::Redeem {
+            amount: Expr::Call {
+                func: BuiltinFn::Exp,
+                args: vec![Expr::Literal(Value::F64(1_000.0))],
+            },
+        }];
+        let market = MultiAssetMarket::single(100.0, 0.20, 0.05, 0.02);
+        let engine = DslMonteCarloEngine::new(16, 4, 42);
+
+        let mut policies = vec![ExecutionPolicy::Scalar];
+        if engine
+            .resolve_execution_backend(ExecutionPolicy::Simd)
+            .is_ok()
+        {
+            policies.push(ExecutionPolicy::Simd);
+        }
+        #[cfg(feature = "parallel")]
+        policies.push(ExecutionPolicy::Parallel);
+        #[cfg(all(feature = "jit", not(target_family = "wasm"), target_arch = "x86_64"))]
+        policies.push(ExecutionPolicy::Jit);
+
+        for policy in policies {
+            let error = engine
+                .price_multi_asset_with_policy(&product, &market, policy)
+                .unwrap_err();
+            assert!(
+                error.to_string().contains("non-finite"),
+                "{policy:?} returned unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn forward_product_prices_near_forward() {
         let product = make_forward_product();
         let market = MultiAssetMarket::single(100.0, 0.20, 0.05, 0.02);
@@ -1853,7 +2048,12 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "jit", feature = "parallel", not(target_family = "wasm")))]
+    #[cfg(all(
+        feature = "jit",
+        feature = "parallel",
+        not(target_family = "wasm"),
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn explicit_jit_is_reproducible_across_pool_sizes() {
         let product = make_forward_product();
@@ -1880,7 +2080,7 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[cfg(all(feature = "jit", not(target_family = "wasm"), target_arch = "x86_64"))]
     #[test]
     fn explicit_jit_policy_matches_scalar_and_reports_backend() {
         let product = make_forward_product();
@@ -1910,7 +2110,8 @@ mod tests {
         feature = "jit",
         not(feature = "simd"),
         not(feature = "parallel"),
-        not(target_family = "wasm")
+        not(target_family = "wasm"),
+        target_arch = "x86_64"
     ))]
     #[test]
     fn auto_jit_policy_uses_conservative_path_threshold() {
@@ -1931,7 +2132,31 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[cfg(all(
+        feature = "jit",
+        not(target_family = "wasm"),
+        not(target_arch = "x86_64")
+    ))]
+    #[test]
+    fn unsupported_jit_policy_returns_error_and_auto_avoids_jit() {
+        let engine = DslMonteCarloEngine::new(MIN_AUTO_JIT_PATHS, 32, 42);
+
+        let error = engine
+            .resolve_execution_backend(ExecutionPolicy::Jit)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("unsupported"),
+            "unexpected error: {error}"
+        );
+        assert_ne!(
+            engine
+                .resolve_execution_backend(ExecutionPolicy::Auto)
+                .unwrap(),
+            ExecutionBackend::Jit
+        );
+    }
+
+    #[cfg(all(feature = "jit", not(target_family = "wasm"), target_arch = "x86_64"))]
     #[test]
     fn prepared_jit_evaluator_cache_reuses_identical_plan() {
         let product = make_forward_product();
@@ -1940,7 +2165,7 @@ mod tests {
         assert!(Arc::ptr_eq(&first, &second));
     }
 
-    #[cfg(all(feature = "jit", not(target_family = "wasm")))]
+    #[cfg(all(feature = "jit", not(target_family = "wasm"), target_arch = "x86_64"))]
     #[test]
     fn prepared_jit_evaluator_cache_retains_alternating_plans() {
         let first_product = make_forward_product();

--- a/src/dsl/eval.rs
+++ b/src/dsl/eval.rs
@@ -338,6 +338,30 @@ pub(crate) fn build_execution_plan(
     num_steps: usize,
     rate: f64,
 ) -> Result<ProductExecutionPlan, DslError> {
+    product.validate()?;
+    build_execution_plan_for_validated_product(product, num_steps, rate)
+}
+
+/// Build an execution plan after the caller has validated `product`.
+///
+/// This is crate-private so public evaluator construction always enters
+/// through [`build_execution_plan`] and cannot bypass product validation.
+pub(crate) fn build_execution_plan_for_validated_product(
+    product: &CompiledProduct,
+    num_steps: usize,
+    rate: f64,
+) -> Result<ProductExecutionPlan, DslError> {
+    if num_steps == 0 {
+        return Err(DslError::EvalError(
+            "product evaluation requires num_steps > 0".to_string(),
+        ));
+    }
+    if !rate.is_finite() {
+        return Err(DslError::EvalError(
+            "product evaluation requires a finite rate".to_string(),
+        ));
+    }
+
     let maturity = product.maturity;
     let step_scale = if maturity > 0.0 {
         num_steps as f64 / maturity
@@ -456,6 +480,44 @@ impl ProductEvaluator {
         path_spots: &[Vec<f64>],
         initial_spots: &[f64],
     ) -> Result<f64, DslError> {
+        if initial_spots.len() != self.product.num_underlyings {
+            return Err(DslError::EvalError(format!(
+                "initial_spots has {} assets, expected {}",
+                initial_spots.len(),
+                self.product.num_underlyings
+            )));
+        }
+        if let Some((asset, _)) = initial_spots
+            .iter()
+            .enumerate()
+            .find(|(_, spot)| !spot.is_finite())
+        {
+            return Err(DslError::EvalError(format!(
+                "initial_spots[{asset}] must be finite"
+            )));
+        }
+        if let Some((step, spots)) = path_spots
+            .iter()
+            .enumerate()
+            .find(|(_, spots)| spots.len() != self.product.num_underlyings)
+        {
+            return Err(DslError::EvalError(format!(
+                "path_spots step {step} has {} assets, expected {}",
+                spots.len(),
+                self.product.num_underlyings
+            )));
+        }
+        if let Some((step, asset)) = path_spots.iter().enumerate().find_map(|(step, spots)| {
+            spots
+                .iter()
+                .position(|spot| !spot.is_finite())
+                .map(|asset| (step, asset))
+        }) {
+            return Err(DslError::EvalError(format!(
+                "path_spots[{step}][{asset}] must be finite"
+            )));
+        }
+
         // A path shorter than the plan's highest snapshot step would leave
         // some snapshot buffers unwritten: empty on the first call (worst_of/
         // best_of would silently return +-inf) and stale from the previous
@@ -480,7 +542,7 @@ impl ProductEvaluator {
             }
         }
 
-        evaluate_product_with_plan_in_place(
+        let pv = evaluate_product_with_plan_in_place(
             &self.product,
             &self.plan,
             &self.observation_spots,
@@ -488,7 +550,13 @@ impl ProductEvaluator {
             &mut self.locals,
             &mut self.state,
             &mut self.stack,
-        )
+        )?;
+        if !pv.is_finite() {
+            return Err(DslError::EvalError(
+                "product evaluation produced a non-finite present value".to_string(),
+            ));
+        }
+        Ok(pv)
     }
 }
 
@@ -2538,7 +2606,7 @@ mod tests {
     }
 
     #[test]
-    fn scalar_min_max_worst_best_propagate_nan() {
+    fn public_scalar_evaluation_rejects_nan_from_min_max_worst_best() {
         let initial_spots = vec![100.0];
         let path_spots = vec![vec![100.0], vec![100.0]];
         for func in [
@@ -2549,10 +2617,11 @@ mod tests {
         ] {
             for nan_first in [true, false] {
                 let product = nan_probe_product(func, nan_first);
-                let pv = evaluate_product(&product, &path_spots, &initial_spots, 1, 0.0).unwrap();
+                let error =
+                    evaluate_product(&product, &path_spots, &initial_spots, 1, 0.0).unwrap_err();
                 assert!(
-                    pv.is_nan(),
-                    "{func:?} (nan_first={nan_first}) must propagate NaN, got {pv}"
+                    error.to_string().contains("non-finite present value"),
+                    "{func:?} (nan_first={nan_first}) returned unexpected error: {error}"
                 );
             }
         }
@@ -2856,7 +2925,7 @@ mod tests {
         let err = build_execution_plan(&product, 4, 0.05).unwrap_err();
         match err {
             DslError::EvalError(msg) => {
-                assert!(msg.contains("exceeds product maturity"), "got: {msg}");
+                assert!(msg.contains("outside [0, 1]"), "got: {msg}");
             }
             other => panic!("expected EvalError, got {other:?}"),
         }
@@ -2892,6 +2961,85 @@ mod tests {
                 "evaluator reuse {reused} != one-shot {one_shot}"
             );
         }
+    }
+
+    #[test]
+    fn public_product_evaluator_rejects_non_finite_present_value() {
+        let product = CompiledProduct {
+            name: "Overflowing payoff".to_string(),
+            notional: 1.0,
+            maturity: 1.0,
+            num_underlyings: 1,
+            underlyings: vec![],
+            state_vars: vec![],
+            constants: vec![],
+            schedules: vec![Schedule {
+                dates: vec![1.0],
+                body: vec![Statement::Redeem {
+                    amount: Expr::Call {
+                        func: BuiltinFn::Exp,
+                        args: vec![Expr::Literal(Value::F64(1_000.0))],
+                    },
+                }],
+            }],
+        };
+        let path_spots = vec![vec![100.0], vec![100.0]];
+
+        let error = evaluate_product(&product, &path_spots, &[100.0], 1, 0.0).unwrap_err();
+        assert!(
+            error.to_string().contains("non-finite present value"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn public_product_evaluator_rejects_non_finite_spots_before_branching() {
+        let product = CompiledProduct {
+            name: "Finite fallback".to_string(),
+            notional: 1.0,
+            maturity: 1.0,
+            num_underlyings: 1,
+            underlyings: vec![UnderlyingDef {
+                name: "SPX".to_string(),
+                asset_index: 0,
+                underlying_type: UnderlyingType::Equity,
+            }],
+            state_vars: vec![],
+            constants: vec![],
+            schedules: vec![Schedule {
+                dates: vec![1.0],
+                body: vec![Statement::If {
+                    condition: Expr::BinOp {
+                        op: BinOp::Gt,
+                        lhs: Box::new(Expr::Call {
+                            func: BuiltinFn::Price,
+                            args: vec![Expr::Literal(Value::F64(0.0))],
+                        }),
+                        rhs: Box::new(Expr::Literal(Value::F64(0.0))),
+                    },
+                    then_body: vec![Statement::Redeem {
+                        amount: Expr::Literal(Value::F64(1.0)),
+                    }],
+                    else_body: vec![Statement::Redeem {
+                        amount: Expr::Literal(Value::F64(2.0)),
+                    }],
+                }],
+            }],
+        };
+
+        let nan_path = vec![vec![100.0], vec![f64::NAN]];
+        let error = evaluate_product(&product, &nan_path, &[100.0], 1, 0.0).unwrap_err();
+        assert!(
+            error.to_string().contains("path_spots[1][0]"),
+            "unexpected error: {error}"
+        );
+
+        let finite_path = vec![vec![100.0], vec![100.0]];
+        let error = evaluate_product(&product, &finite_path, &[f64::INFINITY], 1, 0.0).unwrap_err();
+        assert!(
+            error.to_string().contains("initial_spots[0]"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/dsl/ir.rs
+++ b/src/dsl/ir.rs
@@ -4,6 +4,9 @@
 //! slot indices (array indexing) rather than hash maps for O(1) access on the
 //! hot MC path.
 
+use crate::dsl::error::DslError;
+use std::collections::HashSet;
+
 /// Runtime value in the evaluator.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Value {
@@ -186,6 +189,302 @@ pub struct CompiledProduct {
 }
 
 impl CompiledProduct {
+    /// Validate a compiled product before constructing an evaluation backend.
+    ///
+    /// `CompiledProduct` is public and deserializable, so callers are not
+    /// required to obtain it through the DSL compiler. Evaluation backends
+    /// rely on dense slot-indexed storage and finite product data; this method
+    /// establishes those invariants for hand-built and deserialized products.
+    pub fn validate(&self) -> Result<(), DslError> {
+        fn invalid(message: impl Into<String>) -> DslError {
+            DslError::EvalError(format!("invalid compiled product: {}", message.into()))
+        }
+
+        fn validate_value(value: Value, context: &str) -> Result<(), DslError> {
+            if let Value::F64(value) = value
+                && !value.is_finite()
+            {
+                return Err(DslError::EvalError(format!(
+                    "invalid compiled product: {context} must be finite"
+                )));
+            }
+            Ok(())
+        }
+
+        fn collect_local_slots(
+            statements: &[Statement],
+            slots: &mut HashSet<usize>,
+        ) -> Result<(), DslError> {
+            for statement in statements {
+                match statement {
+                    Statement::Let { slot, .. } => {
+                        if *slot > u16::MAX as usize {
+                            return Err(DslError::CompileError {
+                                message: format!(
+                                    "local variable slot {slot} exceeds the bytecode operand limit of {}",
+                                    u16::MAX
+                                ),
+                                span: None,
+                            });
+                        }
+                        // A slot may be reused in mutually exclusive branches.
+                        // The storage invariant is that every referenced slot
+                        // belongs to the dense allocated range, not that each
+                        // slot has exactly one syntactic declaration.
+                        slots.insert(*slot);
+                    }
+                    Statement::If {
+                        then_body,
+                        else_body,
+                        ..
+                    } => {
+                        collect_local_slots(then_body, slots)?;
+                        collect_local_slots(else_body, slots)?;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(())
+        }
+
+        fn validate_expr(
+            expr: &Expr,
+            assigned_local_slots: &HashSet<usize>,
+            num_state_vars: usize,
+            context: &str,
+        ) -> Result<(), DslError> {
+            match expr {
+                Expr::Literal(value) => validate_value(*value, context),
+                Expr::LocalVar(slot) => {
+                    if !assigned_local_slots.contains(slot) {
+                        return Err(DslError::EvalError(format!(
+                            "invalid compiled product: local variable slot {slot} is read before assignment or outside its declaring scope"
+                        )));
+                    }
+                    Ok(())
+                }
+                Expr::StateVar(slot) => {
+                    if *slot >= num_state_vars {
+                        return Err(DslError::EvalError(format!(
+                            "invalid compiled product: state variable slot {slot} is outside the declared range 0..{num_state_vars}"
+                        )));
+                    }
+                    Ok(())
+                }
+                Expr::BinOp { lhs, rhs, .. } => {
+                    validate_expr(lhs, assigned_local_slots, num_state_vars, context)?;
+                    validate_expr(rhs, assigned_local_slots, num_state_vars, context)
+                }
+                Expr::UnaryOp { operand, .. } => {
+                    validate_expr(operand, assigned_local_slots, num_state_vars, context)
+                }
+                Expr::Call { args, .. } => {
+                    for argument in args {
+                        validate_expr(argument, assigned_local_slots, num_state_vars, context)?;
+                    }
+                    Ok(())
+                }
+                Expr::Notional | Expr::ObservationDate | Expr::IsFinal => Ok(()),
+            }
+        }
+
+        fn validate_statements(
+            statements: &[Statement],
+            assigned_local_slots: &mut HashSet<usize>,
+            num_state_vars: usize,
+            schedule_index: usize,
+        ) -> Result<(), DslError> {
+            for statement in statements {
+                match statement {
+                    Statement::Let { slot, expr } => {
+                        validate_expr(
+                            expr,
+                            assigned_local_slots,
+                            num_state_vars,
+                            &format!("schedule {schedule_index} local expression"),
+                        )?;
+                        assigned_local_slots.insert(*slot);
+                    }
+                    Statement::If {
+                        condition,
+                        then_body,
+                        else_body,
+                    } => {
+                        validate_expr(
+                            condition,
+                            assigned_local_slots,
+                            num_state_vars,
+                            &format!("schedule {schedule_index} condition"),
+                        )?;
+                        // Branch-local `let` bindings are lexical: outer
+                        // assignments are visible inside a branch, but new
+                        // bindings do not escape it.
+                        let mut then_assignments = assigned_local_slots.clone();
+                        validate_statements(
+                            then_body,
+                            &mut then_assignments,
+                            num_state_vars,
+                            schedule_index,
+                        )?;
+                        let mut else_assignments = assigned_local_slots.clone();
+                        validate_statements(
+                            else_body,
+                            &mut else_assignments,
+                            num_state_vars,
+                            schedule_index,
+                        )?;
+                    }
+                    Statement::Pay { amount } | Statement::Redeem { amount } => {
+                        validate_expr(
+                            amount,
+                            assigned_local_slots,
+                            num_state_vars,
+                            &format!("schedule {schedule_index} payment expression"),
+                        )?;
+                    }
+                    Statement::SetState { slot, expr } => {
+                        if *slot >= num_state_vars {
+                            return Err(DslError::EvalError(format!(
+                                "invalid compiled product: state variable slot {slot} is outside the declared range 0..{num_state_vars}"
+                            )));
+                        }
+                        validate_expr(
+                            expr,
+                            assigned_local_slots,
+                            num_state_vars,
+                            &format!("schedule {schedule_index} state expression"),
+                        )?;
+                    }
+                    Statement::Skip => {}
+                }
+            }
+            Ok(())
+        }
+
+        if !self.notional.is_finite() {
+            return Err(invalid("notional must be finite"));
+        }
+        if !self.maturity.is_finite() || self.maturity <= 0.0 {
+            return Err(invalid("maturity must be positive and finite"));
+        }
+        if self.num_underlyings == 0 {
+            return Err(invalid("num_underlyings must be greater than zero"));
+        }
+
+        // Products without an underlying declaration (for example, a fixed
+        // cashflow) retain one simulated market dimension. Otherwise every
+        // declared underlying must map one-to-one to a product dimension.
+        if self.underlyings.is_empty() && self.num_underlyings != 1 {
+            return Err(invalid(format!(
+                "products without underlying definitions require exactly one market dimension, not {}",
+                self.num_underlyings
+            )));
+        }
+        if !self.underlyings.is_empty() && self.underlyings.len() != self.num_underlyings {
+            return Err(invalid(format!(
+                "num_underlyings is {}, but {} underlying definitions were provided",
+                self.num_underlyings,
+                self.underlyings.len()
+            )));
+        }
+
+        let mut underlying_names = HashSet::with_capacity(self.underlyings.len());
+        let mut asset_indices = HashSet::with_capacity(self.underlyings.len());
+        for underlying in &self.underlyings {
+            if !underlying_names.insert(underlying.name.as_str()) {
+                return Err(invalid(format!(
+                    "underlying name '{}' is declared more than once",
+                    underlying.name
+                )));
+            }
+            if underlying.asset_index >= self.num_underlyings {
+                return Err(invalid(format!(
+                    "underlying '{}' has asset index {}, outside the declared range 0..{}",
+                    underlying.name, underlying.asset_index, self.num_underlyings
+                )));
+            }
+            if !asset_indices.insert(underlying.asset_index) {
+                return Err(invalid(format!(
+                    "asset index {} is assigned to more than one underlying",
+                    underlying.asset_index
+                )));
+            }
+        }
+
+        let mut state_names = HashSet::with_capacity(self.state_vars.len());
+        for (expected_slot, state_var) in self.state_vars.iter().enumerate() {
+            if state_var.slot != expected_slot {
+                return Err(invalid(format!(
+                    "state variable '{}' has slot {}, expected dense slot {expected_slot}",
+                    state_var.name, state_var.slot
+                )));
+            }
+            if !state_names.insert(state_var.name.as_str()) {
+                return Err(invalid(format!(
+                    "state variable name '{}' is declared more than once",
+                    state_var.name
+                )));
+            }
+            validate_value(
+                state_var.initial,
+                &format!("initial value for state variable '{}'", state_var.name),
+            )?;
+        }
+
+        let mut constant_names = HashSet::with_capacity(self.constants.len());
+        for (name, value) in &self.constants {
+            if !constant_names.insert(name.as_str()) {
+                return Err(invalid(format!(
+                    "constant '{name}' is declared more than once"
+                )));
+            }
+            validate_value(*value, &format!("constant '{name}'"))?;
+        }
+
+        for (schedule_index, schedule) in self.schedules.iter().enumerate() {
+            if schedule.dates.is_empty() {
+                return Err(invalid(format!("schedule {schedule_index} has no dates")));
+            }
+            for (date_index, &date) in schedule.dates.iter().enumerate() {
+                if !date.is_finite() {
+                    return Err(invalid(format!(
+                        "schedule {schedule_index} date {date_index} must be finite"
+                    )));
+                }
+                if date < 0.0 || date > self.maturity {
+                    return Err(invalid(format!(
+                        "schedule {schedule_index} date {date} is outside [0, {}]",
+                        self.maturity
+                    )));
+                }
+                if date_index > 0 && date <= schedule.dates[date_index - 1] {
+                    return Err(invalid(format!(
+                        "schedule {schedule_index} dates must be strictly increasing"
+                    )));
+                }
+            }
+
+            let mut local_slots = HashSet::new();
+            collect_local_slots(&schedule.body, &mut local_slots)?;
+            if let Some(max_slot) = local_slots.iter().copied().max()
+                && max_slot + 1 != local_slots.len()
+            {
+                return Err(invalid(format!(
+                    "schedule {schedule_index} local variable slots must form a dense range starting at zero"
+                )));
+            }
+            let mut assigned_local_slots = HashSet::new();
+            validate_statements(
+                &schedule.body,
+                &mut assigned_local_slots,
+                self.state_vars.len(),
+                schedule_index,
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Returns the total number of local variable slots needed.
     /// This is computed by walking the statement tree and finding the max slot index.
     pub fn max_local_slots(&self) -> usize {
@@ -193,7 +492,7 @@ impl CompiledProduct {
             let mut max = 0;
             for stmt in stmts {
                 match stmt {
-                    Statement::Let { slot, .. } => max = max.max(*slot + 1),
+                    Statement::Let { slot, .. } => max = max.max(slot.saturating_add(1)),
                     Statement::If {
                         then_body,
                         else_body,
@@ -219,6 +518,42 @@ impl CompiledProduct {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn valid_product() -> CompiledProduct {
+        CompiledProduct {
+            name: "Validated".to_string(),
+            notional: 100.0,
+            maturity: 1.0,
+            num_underlyings: 1,
+            underlyings: vec![UnderlyingDef {
+                name: "SPX".to_string(),
+                asset_index: 0,
+                underlying_type: UnderlyingType::Equity,
+            }],
+            state_vars: vec![StateVarDef {
+                name: "called".to_string(),
+                slot: 0,
+                initial: Value::Bool(false),
+            }],
+            constants: vec![("coupon".to_string(), Value::F64(0.05))],
+            schedules: vec![Schedule {
+                dates: vec![0.5, 1.0],
+                body: vec![
+                    Statement::Let {
+                        slot: 0,
+                        expr: Expr::Literal(Value::F64(1.0)),
+                    },
+                    Statement::Pay {
+                        amount: Expr::LocalVar(0),
+                    },
+                    Statement::SetState {
+                        slot: 0,
+                        expr: Expr::Literal(Value::Bool(true)),
+                    },
+                ],
+            }],
+        }
+    }
 
     #[test]
     fn value_conversions() {
@@ -256,5 +591,198 @@ mod tests {
             }],
         };
         assert_eq!(product.max_local_slots(), 3);
+    }
+
+    #[test]
+    fn compiled_product_validation_accepts_dense_slots_reused_across_branches() {
+        let mut product = valid_product();
+        product.schedules[0].body = vec![Statement::If {
+            condition: Expr::Literal(Value::Bool(true)),
+            then_body: vec![
+                Statement::Let {
+                    slot: 0,
+                    expr: Expr::Literal(Value::F64(1.0)),
+                },
+                Statement::Pay {
+                    amount: Expr::LocalVar(0),
+                },
+            ],
+            else_body: vec![
+                Statement::Let {
+                    slot: 0,
+                    expr: Expr::Literal(Value::F64(2.0)),
+                },
+                Statement::Pay {
+                    amount: Expr::LocalVar(0),
+                },
+            ],
+        }];
+
+        product.validate().unwrap();
+    }
+
+    #[test]
+    fn compiled_product_validation_rejects_non_finite_values() {
+        let mut product = valid_product();
+        product.notional = f64::NAN;
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("notional")
+        );
+
+        let mut product = valid_product();
+        product.state_vars[0].initial = Value::F64(f64::INFINITY);
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("initial value")
+        );
+
+        let mut product = valid_product();
+        product.schedules[0].body[0] = Statement::Let {
+            slot: 0,
+            expr: Expr::Literal(Value::F64(f64::NAN)),
+        };
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("local expression")
+        );
+    }
+
+    #[test]
+    fn compiled_product_validation_rejects_invalid_schedule_dates() {
+        for dates in [
+            vec![f64::NAN],
+            vec![-0.1, 0.5],
+            vec![0.75, 0.5],
+            vec![0.5, 1.5],
+            Vec::new(),
+        ] {
+            let mut product = valid_product();
+            product.schedules[0].dates = dates;
+            assert!(product.validate().is_err());
+        }
+    }
+
+    #[test]
+    fn compiled_product_validation_rejects_inconsistent_dimensions_and_slots() {
+        let mut product = valid_product();
+        product.num_underlyings = 2;
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("underlying definitions")
+        );
+
+        let mut product = valid_product();
+        product.underlyings.clear();
+        product.num_underlyings = 2;
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("exactly one market dimension")
+        );
+
+        let mut product = valid_product();
+        product.underlyings[0].asset_index = 1;
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("asset index")
+        );
+
+        let mut product = valid_product();
+        product.state_vars[0].slot = 1;
+        assert!(
+            product
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("dense slot")
+        );
+    }
+
+    #[test]
+    fn deserialized_product_rejects_undeclared_local_and_state_references() {
+        let mut product = valid_product();
+        product.schedules[0].body = vec![Statement::Pay {
+            amount: Expr::BinOp {
+                op: BinOp::Add,
+                lhs: Box::new(Expr::LocalVar(1)),
+                rhs: Box::new(Expr::StateVar(1)),
+            },
+        }];
+
+        let json = serde_json::to_string(&product).unwrap();
+        let deserialized: CompiledProduct = serde_json::from_str(&json).unwrap();
+        let error = deserialized.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("local variable slot 1"),
+            "unexpected error: {error}"
+        );
+
+        let mut product = valid_product();
+        product.schedules[0].body = vec![Statement::SetState {
+            slot: 1,
+            expr: Expr::Literal(Value::Bool(true)),
+        }];
+        let error = product.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("state variable slot 1"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn compiled_product_validation_enforces_local_assignment_and_branch_scope() {
+        let mut read_before_assignment = valid_product();
+        read_before_assignment.schedules[0].body = vec![
+            Statement::Pay {
+                amount: Expr::LocalVar(0),
+            },
+            Statement::Let {
+                slot: 0,
+                expr: Expr::Literal(Value::F64(1.0)),
+            },
+        ];
+        let error = read_before_assignment.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("before assignment"),
+            "unexpected error: {error}"
+        );
+
+        let mut branch_escape = valid_product();
+        branch_escape.schedules[0].body = vec![
+            Statement::If {
+                condition: Expr::Literal(Value::Bool(true)),
+                then_body: vec![Statement::Let {
+                    slot: 0,
+                    expr: Expr::Literal(Value::F64(1.0)),
+                }],
+                else_body: vec![],
+            },
+            Statement::Pay {
+                amount: Expr::LocalVar(0),
+            },
+        ];
+        let error = branch_escape.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("outside its declaring scope"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/src/dsl/jit.rs
+++ b/src/dsl/jit.rs
@@ -28,7 +28,8 @@ use cranelift_module::{FuncId, Linkage, Module};
 
 use super::error::DslError;
 use super::eval::{
-    Instruction, ObservationResult, ProductExecutionPlan, Program, build_execution_plan, opcode,
+    Instruction, ObservationResult, ProductExecutionPlan, Program,
+    build_execution_plan_for_validated_product, opcode,
 };
 use super::ir::CompiledProduct;
 
@@ -36,6 +37,26 @@ const RESULT_CONTINUE: u8 = 0;
 const RESULT_REDEEMED: u8 = 1;
 const RESULT_SKIPPED: u8 = 2;
 const RESULT_INVALID_PRICE_INDEX: u8 = 3;
+
+/// Whether the current Cranelift JIT configuration is supported.
+///
+/// Cranelift 0.116's JIT module requires x86-64 PLT support. Constructing it
+/// on another architecture can panic inside the dependency, so policy
+/// selection and direct compilation both reject those targets first.
+pub(crate) const fn jit_platform_supported() -> bool {
+    cfg!(target_arch = "x86_64")
+}
+
+fn ensure_jit_platform_supported() -> Result<(), String> {
+    if jit_platform_supported() {
+        Ok(())
+    } else {
+        Err(format!(
+            "JIT execution is unsupported on {}; the current native backend requires x86_64",
+            std::env::consts::ARCH
+        ))
+    }
+}
 
 // ---- External helper functions (called from JIT code) ----
 
@@ -272,6 +293,9 @@ impl JitProductEvaluator {
         num_steps: usize,
         rate: f64,
     ) -> Result<Self, DslError> {
+        product.validate()?;
+        ensure_jit_platform_supported().map_err(DslError::EvalError)?;
+
         if num_steps == 0 {
             return Err(DslError::EvalError(
                 "JIT evaluation requires num_steps > 0".to_string(),
@@ -288,7 +312,7 @@ impl JitProductEvaluator {
             ));
         }
 
-        let plan = build_execution_plan(product, num_steps, rate)?;
+        let plan = build_execution_plan_for_validated_product(product, num_steps, rate)?;
         let programs = plan
             .schedules
             .iter()
@@ -425,12 +449,12 @@ impl JitProductEvaluator {
                     result,
                     ObservationResult::Redeemed | ObservationResult::Skipped
                 ) {
-                    return Ok(pv);
+                    return ensure_finite_pv(pv);
                 }
             }
         }
 
-        Ok(pv)
+        ensure_finite_pv(pv)
     }
 
     fn validate_inputs(
@@ -453,6 +477,15 @@ impl JitProductEvaluator {
                 self.num_underlyings
             )));
         }
+        if let Some((asset, _)) = initial_spots
+            .iter()
+            .enumerate()
+            .find(|(_, spot)| !spot.is_finite())
+        {
+            return Err(DslError::EvalError(format!(
+                "JIT initial_spots[{asset}] must be finite"
+            )));
+        }
         if let Some((step, spots)) = path_spots
             .iter()
             .enumerate()
@@ -462,6 +495,16 @@ impl JitProductEvaluator {
                 "JIT path step {step} has {} assets, expected {}",
                 spots.len(),
                 self.num_underlyings
+            )));
+        }
+        if let Some((step, asset)) = path_spots.iter().enumerate().find_map(|(step, spots)| {
+            spots
+                .iter()
+                .position(|spot| !spot.is_finite())
+                .map(|asset| (step, asset))
+        }) {
+            return Err(DslError::EvalError(format!(
+                "JIT path_spots[{step}][{asset}] must be finite"
             )));
         }
         self.validate_scratch(scratch)
@@ -481,6 +524,16 @@ impl JitProductEvaluator {
             ));
         }
         Ok(())
+    }
+}
+
+fn ensure_finite_pv(pv: f64) -> Result<f64, DslError> {
+    if pv.is_finite() {
+        Ok(pv)
+    } else {
+        Err(DslError::EvalError(
+            "JIT product evaluation produced a non-finite present value".to_string(),
+        ))
     }
 }
 
@@ -532,6 +585,7 @@ fn compile_program(
     instructions: &[Instruction],
     constants: &[f64],
 ) -> Result<JitCompiledProgram, String> {
+    ensure_jit_platform_supported()?;
     validate_program(instructions, constants)?;
 
     // 1. Create the JIT module.
@@ -1327,7 +1381,23 @@ mod libm_ffi {
 
 // ---- Tests ----
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "x86_64")))]
+mod unsupported_platform_tests {
+    use super::*;
+
+    #[test]
+    fn direct_jit_compilation_returns_unsupported_without_initializing_backend() {
+        let error = JitCompiledProgram::compile(&[], &[])
+            .err()
+            .expect("non-x86_64 JIT compilation must be unsupported");
+        assert!(
+            error.contains("unsupported"),
+            "unexpected JIT platform error: {error}"
+        );
+    }
+}
+
+#[cfg(all(test, target_arch = "x86_64"))]
 mod tests {
     use super::*;
     use crate::dsl::{eval::evaluate_product, parse_and_compile};
@@ -2618,5 +2688,41 @@ product \"Invalid Price Index\"
             .evaluate_path(&path, &[100.0])
             .unwrap_err();
         assert!(error.to_string().contains("asset index"));
+    }
+
+    #[test]
+    fn prepared_jit_evaluator_rejects_non_finite_spots_before_branching() {
+        let product = parse_and_compile(
+            "\
+product \"Finite fallback\"
+    notional: 1
+    maturity: 1.0
+    underlyings
+        SPX = asset(0)
+    schedule annual from 1.0 to 1.0
+        if price(0) > 0 then
+            redeem 1
+        else
+            redeem 2
+",
+        )
+        .unwrap();
+        let evaluator = JitProductEvaluator::compile(&product, 1, 0.0).unwrap();
+
+        let nan_path = vec![vec![100.0], vec![f64::NAN]];
+        let error = evaluator.evaluate_path(&nan_path, &[100.0]).unwrap_err();
+        assert!(
+            error.to_string().contains("path_spots[1][0]"),
+            "unexpected error: {error}"
+        );
+
+        let finite_path = vec![vec![100.0], vec![100.0]];
+        let error = evaluator
+            .evaluate_path(&finite_path, &[f64::INFINITY])
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("initial_spots[0]"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/src/dsl/market.rs
+++ b/src/dsl/market.rs
@@ -189,11 +189,21 @@ impl MultiAssetMarket {
 
     /// Validates the market data.
     pub fn validate(&self) -> Result<(), PricingError> {
+        fn require_finite(name: &str, value: f64) -> Result<(), PricingError> {
+            if value.is_finite() {
+                Ok(())
+            } else {
+                Err(PricingError::InvalidInput(format!("{name} must be finite")))
+            }
+        }
+
         if self.assets.is_empty() {
             return Err(PricingError::InvalidInput(
                 "multi-asset market requires at least one asset".to_string(),
             ));
         }
+        require_finite("market rate", self.rate)?;
+
         let n = self.assets.len();
         if self.correlation.len() != n {
             return Err(PricingError::InvalidInput(format!(
@@ -208,27 +218,109 @@ impl MultiAssetMarket {
                     row.len()
                 )));
             }
+            for (j, &correlation) in row.iter().enumerate() {
+                require_finite(&format!("correlation[{i}][{j}]"), correlation)?;
+            }
         }
-        for asset in &self.assets {
+        for (index, asset) in self.assets.iter().enumerate() {
             match asset {
-                AssetMarketData::Rate { vol, .. } => {
-                    // Rate initial_value can be negative (negative rates).
-                    if *vol <= 0.0 || !vol.is_finite() {
-                        return Err(PricingError::InvalidInput(
-                            "rate asset vol must be finite and > 0".to_string(),
-                        ));
+                AssetMarketData::Equity {
+                    spot,
+                    vol,
+                    dividend_yield,
+                } => {
+                    require_finite(&format!("equity asset {index} spot"), *spot)?;
+                    require_finite(&format!("equity asset {index} vol"), *vol)?;
+                    require_finite(
+                        &format!("equity asset {index} dividend yield"),
+                        *dividend_yield,
+                    )?;
+                    if *spot <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "equity asset {index} spot must be > 0"
+                        )));
+                    }
+                    if *vol <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "equity asset {index} vol must be > 0"
+                        )));
                     }
                 }
-                _ => {
-                    if asset.initial_value() <= 0.0 {
-                        return Err(PricingError::InvalidInput(
-                            "asset spot must be > 0".to_string(),
-                        ));
+                AssetMarketData::Fx {
+                    spot,
+                    vol,
+                    domestic_rate,
+                    foreign_rate,
+                } => {
+                    require_finite(&format!("FX asset {index} spot"), *spot)?;
+                    require_finite(&format!("FX asset {index} vol"), *vol)?;
+                    require_finite(&format!("FX asset {index} domestic rate"), *domestic_rate)?;
+                    require_finite(&format!("FX asset {index} foreign rate"), *foreign_rate)?;
+                    if *spot <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "FX asset {index} spot must be > 0"
+                        )));
                     }
-                    if asset.vol() <= 0.0 || !asset.vol().is_finite() {
-                        return Err(PricingError::InvalidInput(
-                            "asset vol must be finite and > 0".to_string(),
-                        ));
+                    if *vol <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "FX asset {index} vol must be > 0"
+                        )));
+                    }
+                }
+                AssetMarketData::Commodity {
+                    spot,
+                    vol,
+                    convenience_yield,
+                    kappa,
+                    mu,
+                } => {
+                    require_finite(&format!("commodity asset {index} spot"), *spot)?;
+                    require_finite(&format!("commodity asset {index} vol"), *vol)?;
+                    require_finite(
+                        &format!("commodity asset {index} convenience yield"),
+                        *convenience_yield,
+                    )?;
+                    require_finite(&format!("commodity asset {index} kappa"), *kappa)?;
+                    require_finite(&format!("commodity asset {index} mu"), *mu)?;
+                    if *spot <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "commodity asset {index} spot must be > 0"
+                        )));
+                    }
+                    if *vol <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "commodity asset {index} vol must be > 0"
+                        )));
+                    }
+                    if *kappa <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "commodity asset {index} kappa must be > 0"
+                        )));
+                    }
+                }
+                AssetMarketData::Rate {
+                    initial_rate,
+                    vol,
+                    mean_reversion,
+                    long_run_mean,
+                } => {
+                    // Rate initial_value can be negative (negative rates).
+                    require_finite(&format!("rate asset {index} initial rate"), *initial_rate)?;
+                    require_finite(&format!("rate asset {index} vol"), *vol)?;
+                    require_finite(
+                        &format!("rate asset {index} mean reversion"),
+                        *mean_reversion,
+                    )?;
+                    require_finite(&format!("rate asset {index} long-run mean"), *long_run_mean)?;
+                    if *vol <= 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "rate asset {index} vol must be > 0"
+                        )));
+                    }
+                    if *mean_reversion < 0.0 {
+                        return Err(PricingError::InvalidInput(format!(
+                            "rate asset {index} mean reversion must be >= 0"
+                        )));
                     }
                 }
             }
@@ -239,5 +331,93 @@ impl MultiAssetMarket {
     /// Returns a vector of initial values (spot prices / initial rates).
     pub fn initial_spots(&self) -> Vec<f64> {
         self.assets.iter().map(|a| a.initial_value()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn market_with(asset: AssetMarketData) -> MultiAssetMarket {
+        MultiAssetMarket {
+            assets: vec![asset],
+            correlation: vec![vec![1.0]],
+            rate: 0.03,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_top_level_market_values() {
+        let mut market = MultiAssetMarket::single(100.0, 0.2, f64::NAN, 0.01);
+        assert!(market.validate().unwrap_err().to_string().contains("rate"));
+
+        market.rate = 0.03;
+        market.correlation[0][0] = f64::INFINITY;
+        assert!(
+            market
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("correlation[0][0]")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_finite_parameter_for_every_asset_variant() {
+        let assets = [
+            AssetMarketData::Equity {
+                spot: f64::NAN,
+                vol: 0.2,
+                dividend_yield: 0.01,
+            },
+            AssetMarketData::Fx {
+                spot: 1.1,
+                vol: 0.15,
+                domestic_rate: f64::NAN,
+                foreign_rate: 0.02,
+            },
+            AssetMarketData::Commodity {
+                spot: 75.0,
+                vol: 0.3,
+                convenience_yield: 0.01,
+                kappa: f64::NAN,
+                mu: 4.0,
+            },
+            AssetMarketData::Rate {
+                initial_rate: 0.03,
+                vol: 0.01,
+                mean_reversion: 0.1,
+                long_run_mean: f64::NAN,
+            },
+        ];
+
+        for asset in assets {
+            assert!(market_with(asset).validate().is_err());
+        }
+    }
+
+    #[test]
+    fn validate_rejects_invalid_mean_reversion_domains() {
+        let commodity = AssetMarketData::Commodity {
+            spot: 75.0,
+            vol: 0.3,
+            convenience_yield: 0.01,
+            kappa: 0.0,
+            mu: 4.0,
+        };
+        let error = market_with(commodity).validate().unwrap_err().to_string();
+        assert!(error.contains("kappa must be > 0"), "unexpected: {error}");
+
+        let rate = AssetMarketData::Rate {
+            initial_rate: 0.03,
+            vol: 0.01,
+            mean_reversion: -0.1,
+            long_run_mean: 0.04,
+        };
+        let error = market_with(rate).validate().unwrap_err().to_string();
+        assert!(
+            error.contains("mean reversion must be >= 0"),
+            "unexpected: {error}"
+        );
     }
 }

--- a/src/engines/analytic/bachelier.rs
+++ b/src/engines/analytic/bachelier.rs
@@ -20,6 +20,53 @@ fn intrinsic(option_type: OptionType, forward: f64, strike: f64) -> f64 {
     }
 }
 
+#[inline]
+fn normalised_moneyness(forward: f64, strike: f64, standard_deviation: f64) -> f64 {
+    let difference = forward - strike;
+    if difference.is_finite() {
+        difference / standard_deviation
+    } else {
+        forward / standard_deviation - strike / standard_deviation
+    }
+}
+
+/// Dimensionless value of an out-of-the-money Bachelier option:
+/// `phi(x) - x Phi(-x)`, for `x >= 0`.
+#[inline]
+fn standard_normal_otm_value(x: f64) -> f64 {
+    if x.is_infinite() {
+        return 0.0;
+    }
+    if x < 8.0 {
+        return normal_pdf(x).mul_add(1.0, -(x * normal_cdf(-x)));
+    }
+
+    // From the asymptotic Mills-ratio expansion:
+    // 1 - x R(x) ~ x^-2 - 3x^-4 + 15x^-6 - 105x^-8 + ...
+    // Stop at the least term because this is an asymptotic, not convergent,
+    // series.
+    let inverse_sq = 1.0 / (x * x);
+    let mut term = inverse_sq;
+    let mut sum = term;
+    let mut previous_abs = term.abs();
+    let mut odd = 3.0;
+    for _ in 0..128 {
+        let next = term * (-odd * inverse_sq);
+        if next.abs() >= previous_abs {
+            break;
+        }
+        let updated = sum + next;
+        if updated == sum {
+            break;
+        }
+        sum = updated;
+        term = next;
+        previous_abs = next.abs();
+        odd += 2.0;
+    }
+    normal_pdf(x) * sum
+}
+
 /// Bachelier (normal) model price for European options on forwards.
 #[allow(clippy::too_many_arguments)]
 #[inline]
@@ -63,17 +110,23 @@ pub fn bachelier_price(
 
     let sqrt_t = t.sqrt();
     let denom = sigma_n * sqrt_t;
-    let d = (forward - strike) / denom;
-
-    // Compute call price; derive put via put-call parity: P = C - df*(F-K).
-    let nd = normal_cdf(d);
-    let pdf_d = normal_pdf(d);
-    let call = df * ((forward - strike).mul_add(nd, denom * pdf_d));
+    if denom == 0.0 {
+        return Ok(df * intrinsic(option_type, forward, strike));
+    }
+    let difference = forward - strike;
+    let d = normalised_moneyness(forward, strike, denom);
+    let otm = df * denom * standard_normal_otm_value(d.abs());
     let price = match option_type {
-        OptionType::Call => call,
-        OptionType::Put => call - df * (forward - strike),
+        OptionType::Call if difference > 0.0 => df * difference + otm,
+        OptionType::Put if difference < 0.0 => -df * difference + otm,
+        _ => otm,
     };
 
+    if !price.is_finite() || price < 0.0 {
+        return Err(PricingError::NumericalError(format!(
+            "bachelier price invariant failed: price={price}"
+        )));
+    }
     Ok(price)
 }
 
@@ -89,7 +142,7 @@ pub fn bachelier_greeks(
     t: f64,
 ) -> Result<Greeks, PricingError> {
     let price = bachelier_price(option_type, forward, strike, r, sigma_n, t)?;
-    if t <= 0.0 || sigma_n <= 0.0 {
+    if t <= 0.0 {
         return Ok(Greeks {
             delta: 0.0,
             gamma: 0.0,
@@ -102,14 +155,40 @@ pub fn bachelier_greeks(
     let df = (-r * t).exp();
     let sqrt_t = t.sqrt();
     let denom = sigma_n * sqrt_t;
-    let d = (forward - strike) / denom;
+    if sigma_n == 0.0 || denom == 0.0 {
+        let payoff_moneyness = match option_type {
+            OptionType::Call => forward - strike,
+            OptionType::Put => strike - forward,
+        };
+        let delta = match payoff_moneyness.partial_cmp(&0.0) {
+            Some(std::cmp::Ordering::Greater) => match option_type {
+                OptionType::Call => df,
+                OptionType::Put => -df,
+            },
+            Some(std::cmp::Ordering::Less) => 0.0,
+            Some(std::cmp::Ordering::Equal) | None => f64::NAN,
+        };
+        let at_boundary = forward == strike;
+        return Ok(Greeks {
+            delta,
+            gamma: if at_boundary { f64::NAN } else { 0.0 },
+            // At F=K this is the right derivative as sigma_n approaches zero.
+            vega: if at_boundary {
+                df * sqrt_t * normal_pdf(0.0)
+            } else {
+                0.0
+            },
+            theta: r * price,
+            rho: -t * price,
+        });
+    }
+    let d = normalised_moneyness(forward, strike, denom);
 
-    // Compute CDF and PDF once, derive put delta via N(d) - 1.
     let nd = normal_cdf(d);
     let pdf_d = normal_pdf(d);
     let delta = match option_type {
         OptionType::Call => df * nd,
-        OptionType::Put => df * (nd - 1.0),
+        OptionType::Put => -df * normal_cdf(-d),
     };
     let gamma = df * pdf_d / denom;
     let vega = df * sqrt_t * pdf_d;
@@ -184,5 +263,65 @@ mod tests {
         let t_dn = bachelier_price(OptionType::Call, f, k, r, sigma_n, t - eps_t).unwrap();
         let theta_fd = -(t_up - t_dn) / (2.0 * eps_t);
         assert_relative_eq!(g.theta, theta_fd, epsilon = 2e-6);
+    }
+
+    #[test]
+    fn deep_otm_put_matches_high_precision_reference_and_homogeneity() {
+        // 100-decimal erfc reference for d=9.
+        const EXPECTED: f64 = 1.224_779_180_843_489_7;
+        let scaled = bachelier_price(OptionType::Put, 1.0e21, 1.0e20, 0.0, 1.0e20, 1.0).unwrap();
+        let unit = bachelier_price(OptionType::Put, 10.0, 1.0, 0.0, 1.0, 1.0).unwrap();
+        assert!(scaled > 0.0);
+        assert!(unit > 0.0);
+        assert!(
+            ((scaled - EXPECTED) / EXPECTED).abs() <= 2.0e-14,
+            "scaled={scaled:.17e}"
+        );
+        assert!(
+            ((scaled / 1.0e20 - unit) / unit).abs() <= 2.0e-14,
+            "scaled={scaled:.17e} unit={unit:.17e}"
+        );
+    }
+
+    #[test]
+    fn zero_and_underflowed_width_return_deterministic_limit_greeks() {
+        let r = 0.05_f64;
+        let t = 2.0_f64;
+        let df = (-r * t).exp();
+
+        for (option_type, forward, expected_delta) in
+            [(OptionType::Call, 2.0, df), (OptionType::Put, 0.0, -df)]
+        {
+            let greeks = bachelier_greeks(option_type, forward, 1.0, r, 0.0, t).unwrap();
+            let price = bachelier_price(option_type, forward, 1.0, r, 0.0, t).unwrap();
+            assert_eq!(greeks.delta, expected_delta);
+            assert_eq!(greeks.gamma, 0.0);
+            assert_eq!(greeks.vega, 0.0);
+            assert_eq!(greeks.theta, r * price);
+            assert_eq!(greeks.rho, -t * price);
+        }
+
+        // sigma_n and sqrt(T) are individually nonzero, but their product
+        // underflows. The option remains an ITM discounted-forward payoff.
+        let underflow =
+            bachelier_greeks(OptionType::Call, 2.0, 1.0, 0.03, 1.0e-300, 1.0e-100).unwrap();
+        assert_eq!(underflow.delta, 1.0);
+        assert_eq!(underflow.gamma, 0.0);
+        assert_eq!(underflow.vega, 0.0);
+        assert_eq!(underflow.theta, 0.03);
+        assert_eq!(underflow.rho, -1.0e-100);
+    }
+
+    #[test]
+    fn zero_width_at_the_strike_exposes_the_one_sided_vega_and_undefined_spot_greeks() {
+        let r = 0.05_f64;
+        let t = 2.0_f64;
+        let df = (-r * t).exp();
+        let greeks = bachelier_greeks(OptionType::Call, 1.0, 1.0, r, 0.0, t).unwrap();
+        assert!(greeks.delta.is_nan());
+        assert!(greeks.gamma.is_nan());
+        assert_eq!(greeks.vega, df * t.sqrt() * 0.398_942_280_401_432_7);
+        assert_eq!(greeks.theta, 0.0);
+        assert_eq!(greeks.rho, 0.0);
     }
 }

--- a/src/engines/analytic/black76.rs
+++ b/src/engines/analytic/black76.rs
@@ -36,32 +36,47 @@ fn intrinsic(option_type: OptionType, forward: f64, strike: f64) -> f64 {
 #[inline]
 fn black76_price_greeks(option: &FuturesOption) -> (f64, Greeks, f64, f64) {
     let sqrt_t = option.t.sqrt();
-    let sig_sqrt_t = option.vol * sqrt_t;
-    let d1 = ((option.forward / option.strike).ln() + 0.5 * option.vol * option.vol * option.t)
-        / sig_sqrt_t;
-    let d2 = d1 - sig_sqrt_t;
+    let (d1, d2) = super::bs_inline::stable_d1_d2(
+        option.forward,
+        option.strike,
+        0.0,
+        0.0,
+        option.vol,
+        option.t,
+    );
 
     let df = (-option.r * option.t).exp();
     let nd1 = normal_cdf(d1);
-    let nd2 = normal_cdf(d2);
     let pdf_d1 = normal_pdf(d1);
 
-    // Compute call price, derive put via put-call parity.
-    let call = df * option.forward.mul_add(nd1, -(option.strike * nd2));
-    let price = match option.option_type {
-        OptionType::Call => call,
-        OptionType::Put => call - df * (option.forward - option.strike),
-    };
+    // Black-76 is Black-Scholes with spot equal to the supplied forward and
+    // both carry rates equal to r. Reuse the cancellation-safe price path.
+    let price = super::black_scholes::bs_price(
+        option.option_type,
+        option.forward,
+        option.strike,
+        option.r,
+        option.r,
+        option.vol,
+        option.t,
+    );
 
     let delta = match option.option_type {
         OptionType::Call => df * nd1,
-        OptionType::Put => df * (nd1 - 1.0),
+        OptionType::Put => -df * normal_cdf(-d1),
     };
-    let gamma = df * pdf_d1 / (option.forward * option.vol * sqrt_t);
+    let gamma = super::bs_inline::stable_gamma(
+        df * pdf_d1,
+        option.forward,
+        option.vol,
+        sqrt_t,
+        d1,
+        -option.r * option.t,
+    );
     let vega = df * option.forward * pdf_d1 * sqrt_t;
     let theta = option.r.mul_add(
         price,
-        -(df * option.forward * pdf_d1 * option.vol / (2.0 * sqrt_t)),
+        super::bs_inline::stable_theta_diffusion(df * option.forward * pdf_d1, option.vol, sqrt_t),
     );
 
     // Sensitivity to r for fixed forward input.
@@ -281,5 +296,23 @@ mod tests {
         assert!(result.greeks.is_some());
         assert!(result.diagnostics.contains_key("d1"));
         assert!(result.diagnostics.contains_key("d2"));
+    }
+
+    #[test]
+    fn deep_tail_and_finite_width_cases_match_independent_references() {
+        let tail = black76_price(OptionType::Put, 5.0e18, 1.0e18, 0.0, 0.2, 1.0).unwrap();
+        const TAIL_EXPECTED: f64 = 22.752_884_600_977_636;
+        assert!(
+            ((tail - TAIL_EXPECTED) / TAIL_EXPECTED).abs() <= 2.0e-12,
+            "tail={tail:.17e}"
+        );
+
+        let finite_width =
+            black76_price(OptionType::Call, 100.0, 100.0, 0.0, 1.0e155, 1.0e-310).unwrap();
+        const WIDTH_EXPECTED: f64 = 38.292_492_254_802_62;
+        assert!(
+            (finite_width - WIDTH_EXPECTED).abs() <= 2.0e-12,
+            "finite_width={finite_width:.17e}"
+        );
     }
 }

--- a/src/engines/analytic/black_scholes.rs
+++ b/src/engines/analytic/black_scholes.rs
@@ -144,7 +144,16 @@ pub fn bs_price(
             OptionType::Put => (strike * df_r - spot * df_q).max(0.0),
         };
     }
-    if !(spot * df_q).is_finite() || !(strike * df_r).is_finite() {
+    let is_call = matches!(option_type, OptionType::Call);
+    if super::bs_inline::requires_stable_price(
+        spot,
+        strike,
+        rate,
+        dividend_yield,
+        vol,
+        expiry,
+        is_call,
+    ) {
         return super::bs_inline::stable_short_total_vol_price(
             spot,
             strike,
@@ -152,18 +161,7 @@ pub fn bs_price(
             dividend_yield,
             vol,
             expiry,
-            matches!(option_type, OptionType::Call),
-        );
-    }
-    if vol * expiry.sqrt() <= super::bs_inline::ACCURATE_CDF_TOTAL_VOL {
-        return super::bs_inline::stable_short_total_vol_price(
-            spot,
-            strike,
-            rate,
-            dividend_yield,
-            vol,
-            expiry,
-            matches!(option_type, OptionType::Call),
+            is_call,
         );
     }
 
@@ -176,7 +174,7 @@ pub fn bs_price(
             dividend_yield,
             vol,
             expiry,
-            matches!(option_type, OptionType::Call),
+            is_call,
         );
     }
 
@@ -224,7 +222,7 @@ pub fn bs_delta(
     let df_q = (-dividend_yield * expiry).exp();
     match option_type {
         OptionType::Call => df_q * norm_cdf(d1),
-        OptionType::Put => df_q * (norm_cdf(d1) - 1.0),
+        OptionType::Put => -df_q * norm_cdf(-d1),
     }
 }
 
@@ -259,7 +257,14 @@ pub fn bs_gamma(
     }
     let (d1, _) = d1_d2(spot, strike, rate, dividend_yield, vol, expiry);
     let df_q = (-dividend_yield * expiry).exp();
-    df_q * norm_pdf(d1) / (spot * vol * expiry.sqrt())
+    super::bs_inline::stable_gamma(
+        df_q * norm_pdf(d1),
+        spot,
+        vol,
+        expiry.sqrt(),
+        d1,
+        -dividend_yield * expiry,
+    )
 }
 
 #[inline]
@@ -329,14 +334,15 @@ pub fn bs_theta(
     let df_r = (-rate * expiry).exp();
     let nd1 = norm_cdf(d1);
     let nd2 = norm_cdf(d2);
-    let theta_common = -spot * df_q * norm_pdf(d1) * vol / (2.0 * sqrt_t);
+    let theta_common =
+        super::bs_inline::stable_theta_diffusion(spot * df_q * norm_pdf(d1), vol, sqrt_t);
     match option_type {
         OptionType::Call => {
             theta_common + dividend_yield * spot * df_q * nd1 - rate * strike * df_r * nd2
         }
         OptionType::Put => {
-            theta_common - dividend_yield * spot * df_q * (1.0 - nd1)
-                + rate * strike * df_r * (1.0 - nd2)
+            theta_common - dividend_yield * spot * df_q * norm_cdf(-d1)
+                + rate * strike * df_r * norm_cdf(-d2)
         }
     }
 }
@@ -373,7 +379,7 @@ pub fn bs_rho(
     let nd2 = norm_cdf(d2);
     match option_type {
         OptionType::Call => strike * expiry * df_r * nd2,
-        OptionType::Put => -strike * expiry * df_r * (1.0 - nd2),
+        OptionType::Put => -strike * expiry * df_r * norm_cdf(-d2),
     }
 }
 
@@ -415,7 +421,6 @@ fn bs_price_greeks_with_dividend(
 
     // Shared intermediates — computed exactly once.
     let sqrt_t = expiry.sqrt();
-    let sig_sqrt_t = vol * sqrt_t;
     let (d1, d2) = d1_d2(spot, strike, rate, dividend_yield, vol, expiry);
 
     let df_r = (-rate * expiry).exp();
@@ -430,9 +435,16 @@ fn bs_price_greeks_with_dividend(
     let s_df_q = spot * df_q;
     let k_df_r = strike * df_r;
     let call = s_df_q.mul_add(nd1, -(k_df_r * nd2));
-    let sensitive_price = (sig_sqrt_t <= super::bs_inline::ACCURATE_CDF_TOTAL_VOL
-        || !s_df_q.is_finite()
-        || !k_df_r.is_finite())
+    let is_call = matches!(option_type, OptionType::Call);
+    let sensitive_price = super::bs_inline::requires_stable_price(
+        spot,
+        strike,
+        rate,
+        dividend_yield,
+        vol,
+        expiry,
+        is_call,
+    )
     .then(|| {
         super::bs_inline::stable_short_total_vol_price(
             spot,
@@ -441,10 +453,10 @@ fn bs_price_greeks_with_dividend(
             dividend_yield,
             vol,
             expiry,
-            matches!(option_type, OptionType::Call),
+            is_call,
         )
     });
-    let theta_common = -s_df_q * pdf_d1 * vol / (2.0 * sqrt_t);
+    let theta_common = super::bs_inline::stable_theta_diffusion(s_df_q * pdf_d1, vol, sqrt_t);
 
     let (price, delta, theta) = match option_type {
         OptionType::Call => {
@@ -453,21 +465,28 @@ fn bs_price_greeks_with_dividend(
             (sensitive_price.unwrap_or(call), d, th)
         }
         OptionType::Put => {
-            let nmd1 = 1.0 - nd1;
-            let nmd2 = 1.0 - nd2;
+            let nmd1 = norm_cdf(-d1);
+            let nmd2 = norm_cdf(-d2);
             let p = call - s_df_q + k_df_r;
-            let d = df_q * (nd1 - 1.0);
+            let d = -df_q * nmd1;
             let th = theta_common - dividend_yield * s_df_q * nmd1 + rate * k_df_r * nmd2;
             (sensitive_price.unwrap_or(p), d, th)
         }
     };
 
     // Greeks that are independent of call/put.
-    let gamma = df_q * pdf_d1 / (spot * vol * sqrt_t);
+    let gamma = super::bs_inline::stable_gamma(
+        df_q * pdf_d1,
+        spot,
+        vol,
+        sqrt_t,
+        d1,
+        -dividend_yield * expiry,
+    );
     let vega = spot * df_q * pdf_d1 * sqrt_t;
     let rho = match option_type {
         OptionType::Call => strike * expiry * df_r * nd2,
-        OptionType::Put => -strike * expiry * df_r * (1.0 - nd2),
+        OptionType::Put => -strike * expiry * df_r * norm_cdf(-d2),
     };
 
     (
@@ -648,4 +667,45 @@ pub fn black_scholes(
         .build()?;
     let engine = BlackScholesEngine::new();
     Ok(engine.price(&instrument, &market)?.price)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deep_tail_price_is_nonnegative_and_homogeneous() {
+        let unit = bs_price(OptionType::Put, 5.0, 1.0, 0.0, 0.0, 0.2, 1.0);
+        let scaled = bs_price(OptionType::Put, 5.0e18, 1.0e18, 0.0, 0.0, 0.2, 1.0);
+        const EXPECTED_SCALED: f64 = 22.752_884_600_977_636;
+        assert!(unit >= 0.0);
+        assert!(scaled >= 0.0);
+        assert!(
+            ((scaled - EXPECTED_SCALED) / EXPECTED_SCALED).abs() <= 2.0e-12,
+            "scaled={scaled:.17e}"
+        );
+        assert!(
+            ((scaled / 1.0e18 - unit) / unit).abs() <= 2.0e-12,
+            "unit={unit:.17e} scaled={scaled:.17e}"
+        );
+    }
+
+    #[test]
+    fn gamma_avoids_overflowing_spot_times_total_volatility() {
+        // Independent closed-form constant: phi(1) / (2 * 1e308).
+        const EXPECTED: f64 = 1.209_853_622_595_72e-309;
+        let gamma = bs_gamma(1.0e308, 1.0e308, 0.0, 0.0, 2.0, 1.0);
+        assert!(gamma > 0.0, "gamma={gamma:.17e}");
+        assert!(
+            ((gamma - EXPECTED) / EXPECTED).abs() <= 2.0e-14,
+            "gamma={gamma:.17e} expected={EXPECTED:.17e}"
+        );
+    }
+
+    #[test]
+    fn gamma_is_zero_not_nan_when_pdf_and_total_volatility_underflow() {
+        let gamma = bs_gamma(2.0, 1.0, 0.0, 0.0, 1.0e-300, 1.0e-100);
+        assert!(gamma.is_finite(), "gamma={gamma}");
+        assert_eq!(gamma, 0.0);
+    }
 }

--- a/src/engines/analytic/bs_inline.rs
+++ b/src/engines/analytic/bs_inline.rs
@@ -27,6 +27,24 @@ pub(crate) fn stable_log_spot_strike(spot: f64, strike: f64) -> f64 {
     }
 }
 
+/// `(rate - dividend_yield) * expiry` without first overflowing the rate
+/// difference when multiplication by a small expiry would bring it back into
+/// range.
+#[inline]
+pub(crate) fn stable_carry(rate: f64, dividend_yield: f64, expiry: f64) -> f64 {
+    let direct = (rate - dividend_yield) * expiry;
+    if direct.is_finite() {
+        direct
+    } else {
+        let scaled_separately = rate * expiry - dividend_yield * expiry;
+        if scaled_separately.is_finite() {
+            scaled_separately
+        } else {
+            direct
+        }
+    }
+}
+
 /// Black-Scholes `d1`/`d2` with a log-domain total-volatility division when
 /// `vol * sqrt(expiry)` rounds to zero.
 #[inline]
@@ -39,17 +57,91 @@ pub(crate) fn stable_d1_d2(
     expiry: f64,
 ) -> (f64, f64) {
     let width = vol * expiry.sqrt();
-    let numerator = stable_log_spot_strike(spot, strike)
-        + (0.5 * vol).mul_add(vol, rate - dividend_yield) * expiry;
-    let d1 = if width != 0.0 {
-        numerator / width
-    } else if numerator == 0.0 {
+    let log_forward_moneyness =
+        stable_log_spot_strike(spot, strike) + stable_carry(rate, dividend_yield, expiry);
+    let midpoint = if width != 0.0 {
+        log_forward_moneyness / width
+    } else if log_forward_moneyness == 0.0 {
         0.0
     } else {
         let log_width = vol.ln() + 0.5 * expiry.ln();
-        numerator.signum() * (numerator.abs().ln() - log_width).exp()
+        log_forward_moneyness.signum() * (log_forward_moneyness.abs().ln() - log_width).exp()
     };
-    (d1, d1 - width)
+    let half_width = 0.5 * width;
+    (midpoint + half_width, midpoint - half_width)
+}
+
+/// Scale the Black-Scholes gamma numerator by `spot * vol * sqrt(expiry)`.
+///
+/// The ordinary arithmetic path is retained for common inputs. If its PDF or
+/// denominator underflows/overflows, reconstruct gamma from logarithms so
+/// `0 / 0` does not become NaN and a representable subnormal result is not
+/// erased.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+pub(crate) fn stable_gamma(
+    numerator: f64,
+    spot: f64,
+    vol: f64,
+    sqrt_expiry: f64,
+    d1: f64,
+    log_discount: f64,
+) -> f64 {
+    let grouped_denominator = (spot * vol) * sqrt_expiry;
+    if grouped_denominator.is_finite() && grouped_denominator != 0.0 {
+        let gamma = numerator / grouped_denominator;
+        if gamma.is_finite() && gamma != 0.0 {
+            return gamma;
+        }
+    }
+
+    let log_pdf = -0.5 * d1 * d1 - 0.5 * std::f64::consts::TAU.ln();
+    let log_total_vol = vol.ln() + sqrt_expiry.ln();
+    (log_discount + log_pdf - spot.ln() - log_total_vol).exp()
+}
+
+/// Black-Scholes diffusion theta term
+/// `-scale * vol / (2 * sqrt(expiry))` with multiplication ordered to retain
+/// subnormal volatilities and a fallback for overflowing scales.
+#[inline]
+pub(crate) fn stable_theta_diffusion(scale: f64, vol: f64, sqrt_expiry: f64) -> f64 {
+    let grouped_numerator = scale * vol;
+    if grouped_numerator.is_finite() && grouped_numerator != 0.0 {
+        -(0.5 * grouped_numerator) / sqrt_expiry
+    } else {
+        -(scale / sqrt_expiry) * (0.5 * vol)
+    }
+}
+
+/// Whether the ordinary two-CDF formula would lose a representable option
+/// value through cancellation, or cannot safely form its discounted scales.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+pub(crate) fn requires_stable_price(
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+    expiry: f64,
+    is_call: bool,
+) -> bool {
+    let width = vol * expiry.sqrt();
+    if width <= ACCURATE_CDF_TOTAL_VOL
+        || !(spot * (-dividend_yield * expiry).exp()).is_finite()
+        || !(strike * (-rate * expiry).exp()).is_finite()
+    {
+        return true;
+    }
+
+    let log_forward_moneyness =
+        stable_log_spot_strike(spot, strike) + stable_carry(rate, dividend_yield, expiry);
+    let midpoint = log_forward_moneyness / width;
+    if is_call {
+        midpoint <= -LOG_DOMAIN_TAIL_MIDPOINT
+    } else {
+        midpoint >= LOG_DOMAIN_TAIL_MIDPOINT
+    }
 }
 
 #[inline]
@@ -170,12 +262,42 @@ pub(crate) fn stable_short_total_vol_price(
         log_width + sum_over_width.ln()
     }
 
+    #[inline]
+    fn mills_ratio(value: f64) -> f64 {
+        let density = normal_pdf(value);
+        let tail = normal_cdf(-value);
+        if density > 0.0 && tail > 0.0 {
+            return tail / density;
+        }
+
+        let inverse_sq = 1.0 / (value * value);
+        let mut term = 1.0 / value;
+        let mut sum = term;
+        let mut previous_abs = term.abs();
+        let mut odd = 1.0;
+        for _ in 0..128 {
+            let next = term * (-odd * inverse_sq);
+            if next.abs() >= previous_abs {
+                break;
+            }
+            let updated = sum + next;
+            if updated == sum {
+                break;
+            }
+            sum = updated;
+            term = next;
+            previous_abs = next.abs();
+            odd += 2.0;
+        }
+        sum
+    }
+
     // Division rounds an adjacent-f64 ratio much more coarsely than the
     // original spot/strike difference. Use log1p in the near-ATM region and
     // separate logarithms outside it to avoid both that loss and ratio
     // overflow for finite extreme inputs.
     let log_forward_moneyness =
-        stable_log_spot_strike(spot, strike) + (rate - dividend_yield) * expiry;
+        stable_log_spot_strike(spot, strike) + stable_carry(rate, dividend_yield, expiry);
     let sqrt_t = expiry.sqrt();
     let width = vol * sqrt_t;
     let log_width = vol.ln() + 0.5 * expiry.ln();
@@ -205,12 +327,16 @@ pub(crate) fn stable_short_total_vol_price(
     // finite spot or strike would bring the option value back into range.
     // Price the OTM leg as a log-domain difference and recover the ITM leg
     // through put-call parity.
-    if midpoint.abs() >= LOG_DOMAIN_TAIL_MIDPOINT {
+    let absolute_midpoint = midpoint.abs();
+    let lower = absolute_midpoint - 0.5 * width;
+    if absolute_midpoint >= LOG_DOMAIN_TAIL_MIDPOINT && lower > 0.0 {
         let log_discounted_strike = strike.ln() - rate * expiry;
-        let absolute_midpoint = midpoint.abs();
-        let lower = absolute_midpoint - 0.5 * width;
         let upper = absolute_midpoint + 0.5 * width;
-        let log_mills_difference = log_mills_ratio_difference(lower, width, log_width);
+        let log_mills_difference = if lower >= LOG_DOMAIN_TAIL_MIDPOINT {
+            log_mills_ratio_difference(lower, width, log_width)
+        } else {
+            (mills_ratio(lower) - mills_ratio(upper)).ln()
+        };
         let (call, put) = if log_forward_moneyness < 0.0 {
             let log_call =
                 log_discounted_strike - 0.5 * upper * upper - 0.5 * std::f64::consts::TAU.ln()
@@ -348,20 +474,7 @@ fn bs_price_scalar_reference(
             (strike * df_r - spot * df_q).max(0.0)
         };
     }
-    if !(spot * df_q).is_finite() || !(strike * df_r).is_finite() {
-        return stable_short_total_vol_price(
-            spot,
-            strike,
-            rate,
-            dividend_yield,
-            vol,
-            expiry,
-            is_call,
-        );
-    }
-
-    let sig_sqrt_t = vol * expiry.sqrt();
-    if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL {
+    if requires_stable_price(spot, strike, rate, dividend_yield, vol, expiry, is_call) {
         return stable_short_total_vol_price(
             spot,
             strike,
@@ -408,16 +521,12 @@ pub fn bs_price_asm(
     expiry: f64,
     is_call: bool,
 ) -> f64 {
-    let nonfinite_discount_scale = expiry > 0.0
-        && ((spot * (-dividend_yield * expiry).exp()).is_infinite()
-            || (strike * (-rate * expiry).exp()).is_infinite());
     if invalid_inputs(spot, strike, rate, dividend_yield, vol, expiry)
         || expiry <= 0.0
         || vol == 0.0
         || spot == 0.0
         || strike == 0.0
-        || vol * expiry.sqrt() <= ACCURATE_CDF_TOTAL_VOL
-        || nonfinite_discount_scale
+        || requires_stable_price(spot, strike, rate, dividend_yield, vol, expiry, is_call)
     {
         return bs_price_scalar_reference(spot, strike, rate, dividend_yield, vol, expiry, is_call);
     }
@@ -476,25 +585,12 @@ unsafe fn bs_price_asm_impl(
     let sig_sqrt_t = vol * sqrt_t;
     let ln_sk = stable_log_spot_strike(spot, strike);
 
-    let mut drift_t = (rate - dividend_yield) * expiry;
-    let vol2 = vol * vol;
-    let half_t = 0.5 * expiry;
-    // SAFETY: executed only with AVX/FMA enabled by target_feature and runtime detection.
-    unsafe {
-        asm!(
-            "vfmadd231sd {acc}, {vol2}, {half_t}",
-            acc = inout(xmm_reg) drift_t,
-            vol2 = in(xmm_reg) vol2,
-            half_t = in(xmm_reg) half_t,
-            options(pure, nomem, nostack),
-        );
-    }
-
     let (d1, d2) = if sig_sqrt_t == 0.0 {
         stable_d1_d2(spot, strike, rate, dividend_yield, vol, expiry)
     } else {
-        let d1 = (ln_sk + drift_t) / sig_sqrt_t;
-        (d1, d1 - sig_sqrt_t)
+        let midpoint = ln_sk / sig_sqrt_t + stable_carry(rate, dividend_yield, expiry) / sig_sqrt_t;
+        let half_width = 0.5 * sig_sqrt_t;
+        (midpoint + half_width, midpoint - half_width)
     };
 
     // Compute call, derive put via put-call parity to halve CDF evaluations.
@@ -530,5 +626,46 @@ mod tests {
                 "s={s} k={k} r={r} q={q} vol={vol} t={t} is_call={is_call} fast={fast} ref={reference}",
             );
         }
+    }
+
+    #[test]
+    fn deep_otm_put_preserves_high_precision_tail_value() {
+        // 100-decimal mpmath/erfc reference, evaluated independently from the
+        // production CDF and pricing implementation.
+        const EXPECTED: f64 = 22.752_884_600_977_636;
+        let price = bs_price_scalar_reference(5.0e18, 1.0e18, 0.0, 0.0, 0.2, 1.0, false);
+        let relative_error = ((price - EXPECTED) / EXPECTED).abs();
+        assert!(
+            relative_error <= 2.0e-12,
+            "price={price:.17e} expected={EXPECTED:.17e} rel={relative_error}"
+        );
+    }
+
+    #[test]
+    fn finite_total_volatility_survives_sigma_squared_overflow() {
+        // sigma^2 overflows, but sigma*sqrt(T) is exactly order one.
+        const EXPECTED: f64 = 38.292_492_254_802_62;
+        let (d1, d2) = stable_d1_d2(100.0, 100.0, 0.0, 0.0, 1.0e155, 1.0e-310);
+        assert!((d1 - 0.5).abs() <= 2.0e-14, "d1={d1}");
+        assert!((d2 + 0.5).abs() <= 2.0e-14, "d2={d2}");
+
+        let price = bs_price_scalar_reference(100.0, 100.0, 0.0, 0.0, 1.0e155, 1.0e-310, true);
+        assert!(
+            (price - EXPECTED).abs() <= 2.0e-12,
+            "price={price:.17e} expected={EXPECTED:.17e}"
+        );
+    }
+
+    #[test]
+    fn wide_distribution_does_not_use_mills_expansion_outside_the_tail() {
+        // Here midpoint=8.1 but d2=0.1. The 100-decimal erfc reference must
+        // use the central formula, not the asymptotic Mills expansion.
+        const EXPECTED: f64 = 0.435_610_762_433_962_74;
+        let price =
+            bs_price_scalar_reference(1.925_594_579_148_456_7e56, 1.0, 0.0, 0.0, 16.0, 1.0, false);
+        assert!(
+            (price - EXPECTED).abs() <= 2.0e-15,
+            "price={price:.17e} expected={EXPECTED:.17e}"
+        );
     }
 }

--- a/src/engines/analytic/bs_simd.rs
+++ b/src/engines/analytic/bs_simd.rs
@@ -73,13 +73,23 @@ fn simd_is_worthwhile(len: usize, backend: BatchSimdBackend) -> bool {
 }
 
 #[inline]
-fn batch_requires_scalar(spots: &[f64], strikes: &[f64], r: f64, q: f64, vol: f64, t: f64) -> bool {
+fn batch_requires_scalar(
+    spots: &[f64],
+    strikes: &[f64],
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> bool {
     let df_r = (-r * t).exp();
     let df_q = (-q * t).exp();
+    let vector_drift = (0.5 * vol).mul_add(vol, r - q) * t;
     !r.is_finite()
         || !q.is_finite()
         || !vol.is_finite()
         || !t.is_finite()
+        || !vector_drift.is_finite()
         || spots.iter().zip(strikes.iter()).any(|(&spot, &strike)| {
             !spot.is_finite()
                 || !strike.is_finite()
@@ -87,7 +97,48 @@ fn batch_requires_scalar(spots: &[f64], strikes: &[f64], r: f64, q: f64, vol: f6
                 || strike <= 0.0
                 || !(spot * df_q).is_finite()
                 || !(strike * df_r).is_finite()
+                || !(spot / strike).is_finite()
+                || super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call)
         })
+}
+
+#[inline]
+fn selected_price_backend(
+    spots: &[f64],
+    strikes: &[f64],
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> BatchSimdBackend {
+    let backend = detected_batch_simd_backend();
+    selected_price_backend_for(backend, spots, strikes, r, q, vol, t, is_call)
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn selected_price_backend_for(
+    backend: BatchSimdBackend,
+    spots: &[f64],
+    strikes: &[f64],
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> BatchSimdBackend {
+    let sensitive_total_vol = t > 0.0 && vol > 0.0 && vol * t.sqrt() <= ACCURATE_CDF_TOTAL_VOL;
+    if t <= 0.0
+        || vol <= 0.0
+        || sensitive_total_vol
+        || !simd_is_worthwhile(spots.len(), backend)
+        || batch_requires_scalar(spots, strikes, r, q, vol, t, is_call)
+    {
+        BatchSimdBackend::Scalar
+    } else {
+        backend
+    }
 }
 
 /// Scalar Abramowitz & Stegun 7.1.26 normal CDF approximation.
@@ -213,14 +264,8 @@ pub fn bs_price_batch_into(
 ) {
     assert_eq!(spots.len(), strikes.len(), "spots and strikes must match");
     assert_eq!(spots.len(), out.len(), "output length must match input");
-    let backend = detected_batch_simd_backend();
-    let sensitive_total_vol = t > 0.0 && vol > 0.0 && vol * t.sqrt() <= ACCURATE_CDF_TOTAL_VOL;
-    if t <= 0.0
-        || vol <= 0.0
-        || sensitive_total_vol
-        || !simd_is_worthwhile(spots.len(), backend)
-        || batch_requires_scalar(spots, strikes, r, q, vol, t)
-    {
+    let backend = selected_price_backend(spots, strikes, r, q, vol, t, is_call);
+    if matches!(backend, BatchSimdBackend::Scalar) {
         for i in 0..spots.len() {
             out[i] = bs_price_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
         }
@@ -319,7 +364,7 @@ pub fn bs_greeks_batch_into(
         || vol <= 0.0
         || sensitive_total_vol
         || !simd_is_worthwhile(n, backend)
-        || batch_requires_scalar(spots, strikes, r, q, vol, t)
+        || batch_requires_scalar(spots, strikes, r, q, vol, t, is_call)
     {
         for i in 0..n {
             let (d, g, v, th) = bs_greeks_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
@@ -419,13 +464,7 @@ fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_
             (strike * df_r - spot * df_q).max(0.0)
         };
     }
-    if !(spot * df_q).is_finite() || !(strike * df_r).is_finite() {
-        return super::bs_inline::stable_short_total_vol_price(spot, strike, r, q, vol, t, is_call);
-    }
-
-    let sqrt_t = t.sqrt();
-    let sig_sqrt_t = vol * sqrt_t;
-    if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL {
+    if super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call) {
         return super::bs_inline::stable_short_total_vol_price(spot, strike, r, q, vol, t, is_call);
     }
     let (d1, d2) = super::bs_inline::stable_d1_d2(spot, strike, r, q, vol, t);
@@ -513,7 +552,9 @@ fn bs_greeks_scalar(
     let pdf = normal_pdf_scalar(d1);
 
     // Only 2 CDF evaluations; derive N(-d) = 1 - N(d) for puts.
-    let cdf = if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL {
+    let cdf = if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL
+        || super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call)
+    {
         accurate_norm_cdf
     } else {
         normal_cdf_approx
@@ -524,16 +565,16 @@ fn bs_greeks_scalar(
     let delta = if is_call {
         df_q * nd1
     } else {
-        df_q * (nd1 - 1.0)
+        -df_q * cdf(-d1)
     };
-    let gamma = df_q * pdf / (spot * vol * sqrt_t);
+    let gamma = super::bs_inline::stable_gamma(df_q * pdf, spot, vol, sqrt_t, d1, -q * t);
     let vega = spot * df_q * pdf * sqrt_t;
 
-    let theta_common = -spot * df_q * pdf * vol / (2.0 * sqrt_t);
+    let theta_common = super::bs_inline::stable_theta_diffusion(spot * df_q * pdf, vol, sqrt_t);
     let theta = if is_call {
         theta_common + q * spot * df_q * nd1 - r * strike * df_r * nd2
     } else {
-        theta_common - q * spot * df_q * (1.0 - nd1) + r * strike * df_r * (1.0 - nd2)
+        theta_common - q * spot * df_q * cdf(-d1) + r * strike * df_r * cdf(-d2)
     };
 
     (delta, gamma, vega, theta)
@@ -1397,3 +1438,103 @@ use avx512_impl::{bs_greeks_batch_avx512, bs_price_batch_avx512, normal_cdf_batc
 use neon_impl::{bs_greeks_batch_neon, normal_cdf_batch_neon};
 #[cfg(all(feature = "simd", target_arch = "wasm32", target_feature = "simd128"))]
 use wasm_simd_impl::{bs_greeks_batch_wasm_simd, bs_price_batch_wasm_simd};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forced_backend_selection_routes_sensitive_prices_to_scalar() {
+        let tail_spots = [5.0e18; 16];
+        let tail_strikes = [1.0e18; 16];
+        let ordinary_spots = [100.0; 16];
+        let ordinary_strikes = [105.0; 16];
+
+        for backend in [
+            BatchSimdBackend::Scalar,
+            BatchSimdBackend::Avx2,
+            BatchSimdBackend::Avx512,
+            BatchSimdBackend::Neon,
+            BatchSimdBackend::WasmSimd128,
+        ] {
+            assert_eq!(
+                selected_price_backend_for(
+                    backend,
+                    &tail_spots,
+                    &tail_strikes,
+                    0.0,
+                    0.0,
+                    0.2,
+                    1.0,
+                    false,
+                ),
+                BatchSimdBackend::Scalar,
+                "tail backend={backend:?}"
+            );
+
+            let ordinary = selected_price_backend_for(
+                backend,
+                &ordinary_spots,
+                &ordinary_strikes,
+                0.02,
+                0.0,
+                0.2,
+                1.0,
+                true,
+            );
+            let expected = backend;
+            assert_eq!(ordinary, expected, "ordinary backend={backend:?}");
+        }
+
+        assert_eq!(
+            selected_price_backend_for(
+                BatchSimdBackend::Avx512,
+                &ordinary_spots,
+                &ordinary_strikes,
+                0.0,
+                0.0,
+                1.0e155,
+                1.0e-310,
+                true,
+            ),
+            BatchSimdBackend::Scalar
+        );
+    }
+
+    #[test]
+    fn deep_tail_price_is_batch_length_invariant_above_every_backend_width() {
+        const EXPECTED: f64 = 22.752_884_600_977_636;
+        let mut reference_bits = None;
+        for len in [1, 2, 4, 8, 15, 16, 17, 32] {
+            let spots = vec![5.0e18; len];
+            let strikes = vec![1.0e18; len];
+            let prices = bs_price_batch(&spots, &strikes, 0.0, 0.0, 0.2, 1.0, false);
+            for price in prices {
+                assert!(price >= 0.0);
+                assert!(
+                    ((price - EXPECTED) / EXPECTED).abs() <= 2.0e-12,
+                    "len={len} price={price:.17e}"
+                );
+                if let Some(bits) = reference_bits {
+                    assert_eq!(price.to_bits(), bits, "len={len}");
+                } else {
+                    reference_bits = Some(price.to_bits());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn gamma_underflow_is_batch_length_invariant_and_finite() {
+        for len in [1, 2, 4, 8, 16, 17] {
+            let spots = vec![2.0; len];
+            let strikes = vec![1.0; len];
+            let (_, gamma, _, _) =
+                bs_greeks_batch(&spots, &strikes, 0.0, 0.0, 1.0e-300, 1.0e-100, true);
+            assert!(
+                gamma.iter().all(|value| value.is_finite() && *value == 0.0),
+                "len={len} gamma={gamma:?}"
+            );
+        }
+    }
+}

--- a/src/engines/analytic/digital.rs
+++ b/src/engines/analytic/digital.rs
@@ -43,12 +43,7 @@ fn d1_d2(
     vol: f64,
     expiry: f64,
 ) -> (f64, f64) {
-    let sqrt_t = expiry.sqrt();
-    let sig_sqrt_t = vol * sqrt_t;
-    let d1 = ((spot / strike).ln() + (0.5 * vol).mul_add(vol, rate - dividend_yield) * expiry)
-        / sig_sqrt_t;
-    let d2 = d1 - sig_sqrt_t;
-    (d1, d2)
+    super::bs_inline::stable_d1_d2(spot, strike, rate, dividend_yield, vol, expiry)
 }
 
 #[inline]
@@ -99,22 +94,21 @@ fn cash_or_nothing_greeks(
     let (d1, d2) = d1_d2(spot, strike, rate, q, vol, expiry);
     let df_r = (-rate * expiry).exp();
     let npd2 = normal_pdf(d2);
-    let nd2 = normal_cdf(d2);
 
     // sign: +1 for call, -1 for put
     let (sign, nd2_signed) = match option_type {
-        OptionType::Call => (1.0, nd2),
-        OptionType::Put => (-1.0, 1.0 - nd2),
+        OptionType::Call => (1.0, normal_cdf(d2)),
+        OptionType::Put => (-1.0, normal_cdf(-d2)),
     };
 
-    let delta = sign * cash * df_r * npd2 / (spot * sig_sqrt_t);
-    let gamma = -sign * cash * df_r * npd2 * d1 / (spot * spot * vol * vol * expiry);
+    let delta = (sign * cash * df_r * npd2 / spot) / sig_sqrt_t;
+    let gamma = (((-sign * cash * df_r * npd2 * d1) / spot) / spot) / (sig_sqrt_t * sig_sqrt_t);
 
     // ∂d2/∂σ = -d1/σ, so vega = sign * C·df_r·n(d2)·(-d1/σ) (raw, per unit vol)
     let vega = -sign * cash * df_r * npd2 * d1 / vol;
 
     // theta = -∂P/∂T, with ∂d2/∂T = (r - q - σ²/2)/(σ√T) - d2/(2T)
-    let dd2_dt = (rate - q - 0.5 * vol * vol) / sig_sqrt_t - d2 / (2.0 * expiry);
+    let dd2_dt = (rate - q) / sig_sqrt_t - 0.5 * vol / sqrt_t - d2 / (2.0 * expiry);
     let theta = cash * df_r * (rate * nd2_signed - sign * npd2 * dd2_dt);
 
     // rho = ∂P/∂r = C·df_r·(-T·Nd2_signed + sign·n(d2)·√T/σ) (raw, per unit rate)
@@ -149,24 +143,23 @@ fn asset_or_nothing_greeks(
     let (d1, d2) = d1_d2(spot, strike, rate, q, vol, expiry);
     let df_q = (-q * expiry).exp();
     let npd1 = normal_pdf(d1);
-    let nd1 = normal_cdf(d1);
 
     let (sign, nd1_signed) = match option_type {
-        OptionType::Call => (1.0, nd1),
-        OptionType::Put => (-1.0, 1.0 - nd1),
+        OptionType::Call => (1.0, normal_cdf(d1)),
+        OptionType::Put => (-1.0, normal_cdf(-d1)),
     };
 
     // delta = df_q·(Nd1_signed + sign·n(d1)/(σ√T))
     let delta = df_q * (nd1_signed + sign * npd1 / sig_sqrt_t);
 
     // gamma = -sign·df_q·n(d1)·d2/(S·σ²·T), since ∂d1/∂S = 1/(S·σ·√T)
-    let gamma = -sign * df_q * npd1 * d2 / (spot * vol * vol * expiry);
+    let gamma = ((-sign * df_q * npd1 * d2) / spot) / (sig_sqrt_t * sig_sqrt_t);
 
     // vega = -sign·S·df_q·n(d1)·d2/σ (since ∂d1/∂σ = -d2/σ; raw, per unit vol)
     let vega = -sign * spot * df_q * npd1 * d2 / vol;
 
     // theta = -∂P/∂T, with ∂d1/∂T = (r - q + σ²/2)/(σ√T) - d1/(2T)
-    let dd1_dt = (rate - q + 0.5 * vol * vol) / sig_sqrt_t - d1 / (2.0 * expiry);
+    let dd1_dt = (rate - q) / sig_sqrt_t + 0.5 * vol / sqrt_t - d1 / (2.0 * expiry);
     let theta = spot * df_q * (q * nd1_signed - sign * npd1 * dd1_dt);
 
     // rho = sign·S·df_q·n(d1)·√T/σ (since ∂d1/∂r = √T/σ; raw, per unit rate)
@@ -217,11 +210,9 @@ impl PricingEngine<CashOrNothingOption> for DigitalAnalyticEngine {
         );
         let df_r = (-market.rate * instrument.expiry).exp();
 
-        // Compute N(d2) once; derive put price via N(-d2) = 1 - N(d2).
-        let nd2 = normal_cdf(d2);
         let price = match instrument.option_type {
-            OptionType::Call => instrument.cash * df_r * nd2,
-            OptionType::Put => instrument.cash * df_r * (1.0 - nd2),
+            OptionType::Call => instrument.cash * df_r * normal_cdf(d2),
+            OptionType::Put => instrument.cash * df_r * normal_cdf(-d2),
         };
 
         let greeks = cash_or_nothing_greeks(
@@ -283,11 +274,9 @@ impl PricingEngine<AssetOrNothingOption> for DigitalAnalyticEngine {
         );
         let df_q = (-q * instrument.expiry).exp();
 
-        // Compute N(d1) once; derive put price via N(-d1) = 1 - N(d1).
-        let nd1 = normal_cdf(d1);
         let price = match instrument.option_type {
-            OptionType::Call => market.spot * df_q * nd1,
-            OptionType::Put => market.spot * df_q * (1.0 - nd1),
+            OptionType::Call => market.spot * df_q * normal_cdf(d1),
+            OptionType::Put => market.spot * df_q * normal_cdf(-d1),
         };
 
         let greeks = asset_or_nothing_greeks(
@@ -348,18 +337,37 @@ impl PricingEngine<GapOption> for DigitalAnalyticEngine {
             instrument.expiry,
         );
         let df_r = (-market.rate * instrument.expiry).exp();
-        let df_q = (-q * instrument.expiry).exp();
 
-        // Compute N(d1), N(d2) once; derive put via N(-d) = 1 - N(d).
-        let nd1 = normal_cdf(d1);
-        let nd2 = normal_cdf(d2);
-        let call = market
-            .spot
-            .mul_add(df_q * nd1, -(instrument.payoff_strike * df_r * nd2));
+        // Decompose the gap into a cancellation-safe vanilla at the trigger
+        // plus a cash-digital adjustment:
+        // call = C(K2) + (K2-K1) df N(d2)
+        // put  = P(K2) + (K1-K2) df N(-d2).
+        let vanilla = super::black_scholes::bs_price(
+            instrument.option_type,
+            market.spot,
+            instrument.trigger_strike,
+            market.rate,
+            q,
+            vol,
+            instrument.expiry,
+        );
         let price = match instrument.option_type {
-            OptionType::Call => call,
-            OptionType::Put => call - market.spot * df_q + instrument.payoff_strike * df_r,
+            OptionType::Call => {
+                vanilla
+                    + (instrument.trigger_strike - instrument.payoff_strike) * df_r * normal_cdf(d2)
+            }
+            OptionType::Put => {
+                vanilla
+                    + (instrument.payoff_strike - instrument.trigger_strike)
+                        * df_r
+                        * normal_cdf(-d2)
+            }
         };
+        if !price.is_finite() {
+            return Err(PricingError::NumericalError(format!(
+                "gap option price is non-finite: {price}"
+            )));
+        }
 
         // Gap = asset-or-nothing(K2) - K1 * cash-or-nothing(K2, cash=1).
         // Greeks are the linear combination of the two building blocks.
@@ -478,6 +486,54 @@ mod tests {
             .price;
 
         assert_relative_eq!(price, -0.0053, epsilon = 2e-4);
+    }
+
+    #[test]
+    fn cash_put_preserves_deep_tail_probability() {
+        // d2 is exactly 9. The reference is 1e20 * Phi(-9), computed with
+        // 100-decimal erfc arithmetic.
+        const EXPECTED: f64 = 11.285_884_059_538_406;
+        let instrument = CashOrNothingOption::new(OptionType::Put, 1.0, 1.0e20, 1.0);
+        let market = Market::builder()
+            .spot(1.82_f64.exp())
+            .rate(0.0)
+            .dividend_yield(0.0)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let result = DigitalAnalyticEngine::new()
+            .price(&instrument, &market)
+            .unwrap();
+        assert!(
+            ((result.price - EXPECTED) / EXPECTED).abs() <= 2.0e-14,
+            "price={:.17e}",
+            result.price
+        );
+        let greeks = result.greeks.unwrap();
+        assert!(greeks.delta < 0.0);
+        assert!(greeks.rho.is_finite() && greeks.rho != 0.0);
+    }
+
+    #[test]
+    fn vanilla_equivalent_gap_put_preserves_deep_tail_value() {
+        const EXPECTED: f64 = 22.752_884_600_977_636;
+        let instrument = GapOption::new(OptionType::Put, 1.0e18, 1.0e18, 1.0);
+        let market = Market::builder()
+            .spot(5.0e18)
+            .rate(0.0)
+            .dividend_yield(0.0)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let price = DigitalAnalyticEngine::new()
+            .price(&instrument, &market)
+            .unwrap()
+            .price;
+        assert!(price >= 0.0);
+        assert!(
+            ((price - EXPECTED) / EXPECTED).abs() <= 2.0e-12,
+            "price={price:.17e}"
+        );
     }
 
     // --- Finite-difference verification helpers ---

--- a/src/engines/analytic/fx.rs
+++ b/src/engines/analytic/fx.rs
@@ -53,12 +53,14 @@ fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
 #[inline]
 fn garman_kohlhagen_price_greeks(option: &FxOption) -> (f64, FxGreeks, f64, f64) {
     let sqrt_t = option.maturity.sqrt();
-    let sig_sqrt_t = option.vol * sqrt_t;
-    let d1 = ((option.spot_fx / option.strike_fx).ln()
-        + (0.5 * option.vol).mul_add(option.vol, option.domestic_rate - option.foreign_rate)
-            * option.maturity)
-        / sig_sqrt_t;
-    let d2 = d1 - sig_sqrt_t;
+    let (d1, d2) = super::bs_inline::stable_d1_d2(
+        option.spot_fx,
+        option.strike_fx,
+        option.domestic_rate,
+        option.foreign_rate,
+        option.vol,
+        option.maturity,
+    );
 
     let df_d = (-option.domestic_rate * option.maturity).exp();
     let df_f = (-option.foreign_rate * option.maturity).exp();
@@ -68,41 +70,53 @@ fn garman_kohlhagen_price_greeks(option: &FxOption) -> (f64, FxGreeks, f64, f64)
     let nd2 = normal_cdf(d2);
     let pdf_d1 = normal_pdf(d1);
 
-    // Compute call price, derive put via put-call parity.
-    let call = option
-        .spot_fx
-        .mul_add(df_f * nd1, -(option.strike_fx * df_d * nd2));
-    let price = match option.option_type {
-        OptionType::Call => call,
-        OptionType::Put => call - option.spot_fx * df_f + option.strike_fx * df_d,
-    };
+    let price = super::black_scholes::bs_price(
+        option.option_type,
+        option.spot_fx,
+        option.strike_fx,
+        option.domestic_rate,
+        option.foreign_rate,
+        option.vol,
+        option.maturity,
+    );
 
     let delta = match option.option_type {
         OptionType::Call => df_f * nd1,
-        OptionType::Put => df_f * (nd1 - 1.0),
+        OptionType::Put => -df_f * normal_cdf(-d1),
     };
-    let gamma = df_f * pdf_d1 / (option.spot_fx * option.vol * sqrt_t);
+    let gamma = super::bs_inline::stable_gamma(
+        df_f * pdf_d1,
+        option.spot_fx,
+        option.vol,
+        sqrt_t,
+        d1,
+        -option.foreign_rate * option.maturity,
+    );
     let vega = option.spot_fx * df_f * pdf_d1 * sqrt_t;
 
-    let theta_common = -option.spot_fx * df_f * pdf_d1 * option.vol / (2.0 * sqrt_t);
+    let theta_common = super::bs_inline::stable_theta_diffusion(
+        option.spot_fx * df_f * pdf_d1,
+        option.vol,
+        sqrt_t,
+    );
     let theta = match option.option_type {
         OptionType::Call => {
             theta_common + option.foreign_rate * option.spot_fx * df_f * nd1
                 - option.domestic_rate * option.strike_fx * df_d * nd2
         }
         OptionType::Put => {
-            theta_common - option.foreign_rate * option.spot_fx * df_f * (1.0 - nd1)
-                + option.domestic_rate * option.strike_fx * df_d * (1.0 - nd2)
+            theta_common - option.foreign_rate * option.spot_fx * df_f * normal_cdf(-d1)
+                + option.domestic_rate * option.strike_fx * df_d * normal_cdf(-d2)
         }
     };
 
     let rho_domestic = match option.option_type {
         OptionType::Call => option.strike_fx * option.maturity * df_d * nd2,
-        OptionType::Put => -option.strike_fx * option.maturity * df_d * (1.0 - nd2),
+        OptionType::Put => -option.strike_fx * option.maturity * df_d * normal_cdf(-d2),
     };
     let rho_foreign = match option.option_type {
         OptionType::Call => -option.spot_fx * option.maturity * df_f * nd1,
-        OptionType::Put => option.spot_fx * option.maturity * df_f * (1.0 - nd1),
+        OptionType::Put => option.spot_fx * option.maturity * df_f * normal_cdf(-d1),
     };
 
     (

--- a/src/engines/monte_carlo/mc_engine.rs
+++ b/src/engines/monte_carlo/mc_engine.rs
@@ -1216,11 +1216,10 @@ impl MonteCarloPricingEngine {
             }
         }
 
-        // Exact-terminal SIMD has no separate allocation/setup pass. Its
-        // vector kernel becomes useful as soon as at least one complete native
-        // vector is available; below that point execution is entirely the
-        // scalar tail. Tying the crossover to native width also avoids an
-        // x86-specific magic path count on NEON and AVX-512.
+        // Exact-terminal SIMD has no separate allocation/setup pass. Keep the
+        // portable native-width policy until stable benchmarks exist for each
+        // supported CPU generation; one host's crossover must not silently
+        // change dispatch on other machines.
         let simd_width = available_simd_width_f64();
         if exact_terminal && simd_width > 1 && samples >= simd_width {
             ExecutionBackend::Simd
@@ -2481,6 +2480,7 @@ mod tests {
         if width == 1 {
             return;
         }
+        let minimum_samples = width;
         let market = Market::builder()
             .spot(100.0)
             .rate(0.05)
@@ -2489,22 +2489,42 @@ mod tests {
             .unwrap();
         let option = VanillaOption::european_call(100.0, 1.0);
 
+        #[cfg(feature = "parallel")]
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+
         for (variance_reduction, requested_below, requested_at) in [
-            (VarianceReduction::None, width - 1, width),
+            (
+                VarianceReduction::None,
+                minimum_samples - 1,
+                minimum_samples,
+            ),
             (
                 VarianceReduction::Antithetic,
-                2 * (width - 1),
-                2 * width - 1,
+                2 * (minimum_samples - 1),
+                2 * minimum_samples - 1,
             ),
         ] {
-            let below = MonteCarloPricingEngine::new(requested_below, 1, 42)
-                .with_variance_reduction(variance_reduction.clone())
-                .resolve_execution_backend(&option, &market)
-                .unwrap();
-            let at = MonteCarloPricingEngine::new(requested_at, 1, 42)
-                .with_variance_reduction(variance_reduction)
-                .resolve_execution_backend(&option, &market)
-                .unwrap();
+            let resolve = |paths, variance_reduction| {
+                MonteCarloPricingEngine::new(paths, 1, 42)
+                    .with_variance_reduction(variance_reduction)
+                    .resolve_execution_backend(&option, &market)
+                    .unwrap()
+            };
+            #[cfg(feature = "parallel")]
+            let (below, at) = pool.install(|| {
+                (
+                    resolve(requested_below, variance_reduction.clone()),
+                    resolve(requested_at, variance_reduction),
+                )
+            });
+            #[cfg(not(feature = "parallel"))]
+            let (below, at) = (
+                resolve(requested_below, variance_reduction.clone()),
+                resolve(requested_at, variance_reduction),
+            );
             assert_eq!(below, ExecutionBackend::Scalar);
             assert_eq!(at, ExecutionBackend::Simd);
         }

--- a/src/greeks/bsm.rs
+++ b/src/greeks/bsm.rs
@@ -130,20 +130,30 @@ pub fn black_scholes_merton_greeks(
 
     let delta = match option_type {
         OptionType::Call => df_q * normal_cdf(d1),
-        OptionType::Put => df_q * (normal_cdf(d1) - 1.0),
+        OptionType::Put => -df_q * normal_cdf(-d1),
     };
 
-    let gamma = df_q * normal_pdf(d1) / (s * sigma * sqrt_t);
+    let gamma = crate::engines::analytic::bs_inline::stable_gamma(
+        df_q * normal_pdf(d1),
+        s,
+        sigma,
+        sqrt_t,
+        d1,
+        -q * t,
+    );
     let vega = s * df_q * normal_pdf(d1) * sqrt_t;
+    let theta_common = crate::engines::analytic::bs_inline::stable_theta_diffusion(
+        s * df_q * normal_pdf(d1),
+        sigma,
+        sqrt_t,
+    );
 
     let theta = match option_type {
         OptionType::Call => {
-            -s * df_q * normal_pdf(d1) * sigma / (2.0 * sqrt_t) - r * k * df_r * normal_cdf(d2)
-                + q * s * df_q * normal_cdf(d1)
+            theta_common - r * k * df_r * normal_cdf(d2) + q * s * df_q * normal_cdf(d1)
         }
         OptionType::Put => {
-            -s * df_q * normal_pdf(d1) * sigma / (2.0 * sqrt_t) + r * k * df_r * normal_cdf(-d2)
-                - q * s * df_q * normal_cdf(-d1)
+            theta_common + r * k * df_r * normal_cdf(-d2) - q * s * df_q * normal_cdf(-d1)
         }
     };
 

--- a/src/market/market.rs
+++ b/src/market/market.rs
@@ -149,10 +149,10 @@ impl SampledVolSurface {
             let mut row = Vec::with_capacity(strikes.len());
             for &strike in &strikes {
                 let v = surface.vol(strike, expiry);
-                // Preserve non-finite outputs so MarketBuilder/Market::validate
-                // can reject the source instead of silently replacing bad
-                // market data with an arbitrary volatility.
-                row.push(if v.is_finite() { v.max(1.0e-8) } else { v });
+                // Preserve the source value so MarketBuilder/Market::validate
+                // rejects non-finite and non-positive market data rather than
+                // silently replacing it with an arbitrary volatility.
+                row.push(v);
             }
             vols.push(row);
         }
@@ -566,6 +566,15 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct ConstantTraitObjectSurface(f64);
+
+    impl VolSurface for ConstantTraitObjectSurface {
+        fn vol(&self, _strike: f64, _expiry: f64) -> f64 {
+            self.0
+        }
+    }
+
     #[test]
     fn market_builder_rejects_non_finite_inputs() {
         let cases: Vec<(&str, MarketBuilder)> = vec![
@@ -661,6 +670,17 @@ mod tests {
             .vol_surface(Box::new(NonFiniteVolSurface))
             .build();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn market_builder_does_not_clamp_non_positive_trait_object_surface_outputs() {
+        for value in [0.0, -0.2] {
+            let result = Market::builder()
+                .spot(100.0)
+                .vol_surface(Box::new(ConstantTraitObjectSurface(value)))
+                .build();
+            assert!(result.is_err(), "surface value {value} must be rejected");
+        }
     }
 
     #[test]

--- a/src/math/aad.rs
+++ b/src/math/aad.rs
@@ -870,12 +870,21 @@ pub fn black_scholes_price_greeks_aad(
         vol,
         expiry,
     );
-    let nonfinite_discount_scale = !(spot * (-dividend_yield * expiry).exp()).is_finite()
-        || !(strike * (-rate * expiry).exp()).is_finite();
+    let is_call = matches!(option_type, OptionType::Call);
+    let tape_drift = (0.5 * vol).mul_add(vol, rate - dividend_yield) * expiry;
     if sig_sqrt_t_numeric <= crate::engines::analytic::bs_inline::ACCURATE_CDF_TOTAL_VOL
         || !d1_numeric.is_finite()
         || d1_numeric.abs() >= 38.0
-        || nonfinite_discount_scale
+        || !tape_drift.is_finite()
+        || crate::engines::analytic::bs_inline::requires_stable_price(
+            spot,
+            strike,
+            rate,
+            dividend_yield,
+            vol,
+            expiry,
+            is_call,
+        )
     {
         use crate::engines::analytic::black_scholes::{
             bs_delta, bs_gamma, bs_price, bs_rho, bs_theta, bs_vega,
@@ -965,22 +974,8 @@ pub fn black_scholes_price_greeks_aad(
         OptionType::Call => call_2,
         OptionType::Put => call_2 - s2 * df_q_2 + Dual2::constant(strike * df_r_2),
     };
-    let price = if sig_sqrt_t_2 <= crate::engines::analytic::bs_inline::ACCURATE_CDF_TOTAL_VOL {
-        crate::engines::analytic::bs_inline::stable_short_total_vol_price(
-            spot,
-            strike,
-            rate,
-            dividend_yield,
-            vol,
-            expiry,
-            matches!(option_type, OptionType::Call),
-        )
-    } else {
-        tape_price
-    };
-
     (
-        price,
+        tape_price,
         Greeks {
             delta: grads[0],
             gamma: price_2.second,
@@ -1107,6 +1102,44 @@ mod tests {
             assert!((greeks.theta - th_ref).abs() < 1e-10, "theta mismatch");
             assert!((greeks.rho - rh_ref).abs() < 1e-10, "rho mismatch");
         }
+    }
+
+    #[test]
+    fn aad_preserves_deep_tail_and_finite_total_volatility_cases() {
+        let (tail, tail_greeks) =
+            black_scholes_price_greeks_aad(OptionType::Put, 5.0e18, 1.0e18, 0.0, 0.0, 0.2, 1.0);
+        const TAIL_EXPECTED: f64 = 22.752_884_600_977_636;
+        assert!(
+            ((tail - TAIL_EXPECTED) / TAIL_EXPECTED).abs() <= 2.0e-12,
+            "tail={tail:.17e}"
+        );
+        assert!(tail_greeks.delta < 0.0);
+
+        let (price, greeks) = black_scholes_price_greeks_aad(
+            OptionType::Call,
+            100.0,
+            100.0,
+            0.0,
+            0.0,
+            1.0e155,
+            1.0e-310,
+        );
+        const PRICE_EXPECTED: f64 = 38.292_492_254_802_62;
+        const DELTA_EXPECTED: f64 = 0.691_462_461_274_013_1;
+        assert!((price - PRICE_EXPECTED).abs() <= 2.0e-12);
+        assert!((greeks.delta - DELTA_EXPECTED).abs() <= 2.0e-14);
+
+        let (_, underflow_greeks) = black_scholes_price_greeks_aad(
+            OptionType::Call,
+            2.0,
+            1.0,
+            0.0,
+            0.0,
+            1.0e-300,
+            1.0e-100,
+        );
+        assert!(underflow_greeks.gamma.is_finite());
+        assert_eq!(underflow_greeks.gamma, 0.0);
     }
 
     #[test]

--- a/src/math/simd_neon.rs
+++ b/src/math/simd_neon.rs
@@ -24,17 +24,34 @@ const A4: f64 = -1.821_255_978;
 const A5: f64 = 1.330_274_429;
 const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
 
+/// Broadcasts `value` to both lanes of an AArch64 NEON vector.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
 #[inline]
 pub unsafe fn splat_f64x2(value: f64) -> float64x2_t {
     vdupq_n_f64(value)
 }
 
+/// Loads two adjacent values starting at `i`.
+///
+/// # Safety
+///
+/// The caller must execute this where NEON is available and ensure that
+/// `values[i..]` contains at least two elements.
 #[inline]
 pub unsafe fn load_f64x2(values: &[f64], i: usize) -> float64x2_t {
     // SAFETY: caller guarantees there are at least 2 elements starting at `i`.
     unsafe { vld1q_f64(values.as_ptr().add(i)) }
 }
 
+/// Stores both lanes of `v` starting at `i`.
+///
+/// # Safety
+///
+/// The caller must execute this where NEON is available and ensure that
+/// `values[i..]` contains at least two elements.
 #[inline]
 pub unsafe fn store_f64x2(values: &mut [f64], i: usize, v: float64x2_t) {
     // SAFETY: caller guarantees there are at least 2 elements starting at `i`.
@@ -91,6 +108,10 @@ unsafe fn repair_ln_subnormal_lanes(input: float64x2_t, result: float64x2_t) -> 
 /// Matches the AVX2 `exp_f64x4` algorithm from `simd_math.rs`, ported to 2-lane NEON.
 /// Dense differential tests bound relative error by `2e-14` over the practical
 /// finite range `[-700, 700]`.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
 #[inline]
 pub unsafe fn simd_exp_f64x2(x: float64x2_t) -> float64x2_t {
     let input = x;
@@ -228,6 +249,10 @@ pub unsafe fn fast_exp_f64x2(x: float64x2_t) -> float64x2_t {
 /// Vectorized ln(x) for NEON f64x2 using fdlibm kernel with IEEE 754 bit extraction.
 ///
 /// Matches the AVX2 `ln_f64x4` algorithm from `simd_math.rs`, ported to 2-lane NEON.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
 #[inline]
 pub unsafe fn simd_ln_f64x2(x: float64x2_t) -> float64x2_t {
     let one = vdupq_n_f64(1.0);
@@ -254,11 +279,10 @@ pub unsafe fn simd_ln_f64x2(x: float64x2_t) -> float64x2_t {
     // Fold m from [1, 2) into [sqrt(1/2), sqrt(2)). Values at or above
     // sqrt(2) are halved and their binary exponent incremented.
     let adjust = vcgeq_f64(m, sqrt_two);
-    let adjust_bits: uint64x2_t = std::mem::transmute(adjust);
     let m_halved = vmulq_f64(m, vdupq_n_f64(0.5));
     let k_plus_one = vaddq_f64(k, one);
-    m = vbslq_f64(adjust_bits, m_halved, m);
-    k = vbslq_f64(adjust_bits, k_plus_one, k);
+    m = vbslq_f64(adjust, m_halved, m);
+    k = vbslq_f64(adjust, k_plus_one, k);
 
     // f = m - 1, s = f / (2 + f)
     let f = vsubq_f64(m, one);
@@ -314,6 +338,11 @@ pub unsafe fn simd_ln_f64x2(x: float64x2_t) -> float64x2_t {
     repair_ln_subnormal_lanes(x, y)
 }
 
+/// Evaluates the standard-normal density in both vector lanes.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
 #[inline]
 pub unsafe fn norm_pdf_f64x2(x: float64x2_t) -> float64x2_t {
     let exponent = vmulq_f64(vdupq_n_f64(-0.5), vmulq_f64(x, x));
@@ -322,6 +351,11 @@ pub unsafe fn norm_pdf_f64x2(x: float64x2_t) -> float64x2_t {
     })
 }
 
+/// Evaluates the standard-normal cumulative distribution in both vector lanes.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
 #[inline]
 pub unsafe fn norm_cdf_f64x2(x: float64x2_t) -> float64x2_t {
     let one = vdupq_n_f64(1.0);
@@ -346,58 +380,28 @@ pub unsafe fn norm_cdf_f64x2(x: float64x2_t) -> float64x2_t {
 }
 
 #[inline]
-fn normal_cdf_scalar(x: f64) -> f64 {
-    if x == 0.0 {
-        return 0.5;
-    }
-    let z = x.abs();
-    let t = 1.0 / (1.0 + P * z);
-    let poly = ((((A5 * t + A4) * t + A3) * t + A2) * t + A1) * t;
-    let pdf = INV_SQRT_2PI * (-0.5 * z * z).exp();
-    let approx = 1.0 - pdf * poly;
-    if x < 0.0 { 1.0 - approx } else { approx }
-}
-
-#[inline]
 fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_call: bool) -> f64 {
-    if t <= 0.0 {
-        return if is_call {
-            (spot - strike).max(0.0)
+    crate::engines::analytic::black_scholes::bs_price(
+        if is_call {
+            crate::core::OptionType::Call
         } else {
-            (strike - spot).max(0.0)
-        };
-    }
-    if vol < 0.0 {
-        return f64::NAN;
-    }
-    if vol == 0.0 {
-        // Deterministic (zero-vol) limit with t > 0: discounted forward
-        // intrinsic e^{-rT} (S e^{(r-q)T} - K)^+ (put analogue likewise),
-        // not the undiscounted spot intrinsic.
-        let fwd = spot * ((r - q) * t).exp();
-        let df_r = (-r * t).exp();
-        return if is_call {
-            df_r * (fwd - strike).max(0.0)
-        } else {
-            df_r * (strike - fwd).max(0.0)
-        };
-    }
-
-    let df_r = (-r * t).exp();
-    let df_q = (-q * t).exp();
-
-    let sqrt_t = t.sqrt();
-    let sig_sqrt_t = vol * sqrt_t;
-    let d1 = ((spot / strike).ln() + (r - q + 0.5 * vol * vol) * t) / sig_sqrt_t;
-    let d2 = d1 - sig_sqrt_t;
-
-    if is_call {
-        spot * df_q * normal_cdf_scalar(d1) - strike * df_r * normal_cdf_scalar(d2)
-    } else {
-        strike * df_r * normal_cdf_scalar(-d2) - spot * df_q * normal_cdf_scalar(-d1)
-    }
+            crate::core::OptionType::Put
+        },
+        spot,
+        strike,
+        r,
+        q,
+        vol,
+        t,
+    )
 }
 
+/// Prices a homogeneous Black-Scholes batch with AArch64 NEON where safe.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
+/// `spots` and `strikes` must have identical lengths.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn bs_price_neon_batch(
     spots: &[f64],
@@ -421,6 +425,12 @@ pub unsafe fn bs_price_neon_batch(
     out
 }
 
+/// Writes a homogeneous Black-Scholes batch using AArch64 NEON where safe.
+///
+/// # Safety
+///
+/// The caller must execute this on an AArch64 target where NEON is available.
+/// `spots`, `strikes`, and `out` must have identical lengths.
 #[allow(clippy::too_many_arguments)]
 pub unsafe fn bs_price_neon_batch_into(
     spots: &[f64],
@@ -443,7 +453,17 @@ pub unsafe fn bs_price_neon_batch_into(
         "output and input slices must have identical lengths",
     );
 
-    if t <= 0.0 || vol <= 0.0 {
+    let vector_drift = (r - q + 0.5 * vol * vol) * t;
+    let requires_scalar = t <= 0.0
+        || vol <= 0.0
+        || !vector_drift.is_finite()
+        || spots.iter().zip(strikes.iter()).any(|(&spot, &strike)| {
+            !(spot / strike).is_finite()
+                || crate::engines::analytic::bs_inline::requires_stable_price(
+                    spot, strike, r, q, vol, t, is_call,
+                )
+        });
+    if requires_scalar {
         for i in 0..spots.len() {
             out[i] = bs_price_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
         }

--- a/src/mc/simulation.rs
+++ b/src/mc/simulation.rs
@@ -99,6 +99,7 @@ pub(crate) fn should_auto_parallelize_path(
 }
 
 pub type PathEvaluator = Arc<dyn Fn(&[f64]) -> f64 + Send + Sync>;
+pub type FalliblePathEvaluator<E> = Arc<dyn Fn(&[f64]) -> Result<f64, E> + Send + Sync>;
 
 /// CPU execution strategy for the generic path simulation engine.
 ///
@@ -222,6 +223,21 @@ impl PathGenerator for HestonPathGenerator {
 pub struct ControlVariate {
     pub expected: f64,
     pub evaluator: PathEvaluator,
+}
+
+/// Control-variate callback for [`MonteCarloEngine::run_fallible`].
+pub struct FallibleControlVariate<E> {
+    pub expected: f64,
+    pub evaluator: FalliblePathEvaluator<E>,
+}
+
+impl<E> Clone for FallibleControlVariate<E> {
+    fn clone(&self) -> Self {
+        Self {
+            expected: self.expected,
+            evaluator: Arc::clone(&self.evaluator),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -366,6 +382,48 @@ impl MonteCarloEngine {
         G: PathGenerator,
         P: Fn(&[f64]) -> f64 + Send + Sync,
     {
+        let control_variate = self.control_variate.as_ref().map(|control| {
+            let evaluator = Arc::clone(&control.evaluator);
+            FallibleControlVariate {
+                expected: control.expected,
+                evaluator: Arc::new(move |path| {
+                    Ok::<f64, std::convert::Infallible>(evaluator(path))
+                }),
+            }
+        });
+        match self.run_fallible(
+            generator,
+            |path| Ok::<f64, std::convert::Infallible>(payoff(path)),
+            discount_factor,
+            control_variate,
+        ) {
+            Ok(result) => result,
+            Err(never) => match never {},
+        }
+    }
+
+    /// Runs path simulation with callbacks that can fail.
+    ///
+    /// The first callback error stops scalar execution and is returned to the
+    /// caller unchanged. Parallel execution evaluates fixed chunks
+    /// concurrently and deterministically returns the error from the
+    /// lowest-indexed failing chunk; callbacks in other chunks may already
+    /// have run before workers join. Use the scalar policy when callback side
+    /// effects must stop immediately and remain strictly ordered. Supplying
+    /// an explicit fallible control variate replaces the engine's stored
+    /// infallible control variate for this run.
+    pub fn run_fallible<G, P, E>(
+        &self,
+        generator: &G,
+        payoff: P,
+        discount_factor: f64,
+        control_variate: Option<FallibleControlVariate<E>>,
+    ) -> Result<(f64, f64), E>
+    where
+        G: PathGenerator,
+        P: Fn(&[f64]) -> Result<f64, E> + Send + Sync,
+        E: Send,
+    {
         assert!(self.num_paths > 0, "num_paths must be > 0");
 
         let samples = if self.antithetic {
@@ -376,7 +434,7 @@ impl MonteCarloEngine {
 
         let steps = generator.steps();
         let num_streams = generator.num_normal_streams();
-        let control = self.control_variate.clone();
+        let control = control_variate;
         let rng_kind = self.rng_kind;
         let reproducible = self.reproducible;
         let base_seed = self.seed;
@@ -397,61 +455,57 @@ impl MonteCarloEngine {
         // A fixed chunk owns one RNG stream. Chunk boundaries and seeds do not
         // depend on the Rayon pool, while map_init reuses path/normal buffers
         // for every chunk handled by a worker.
-        let simulate_chunk = |scratch: &mut Scratch, chunk_index: usize| -> BivariateMoments {
-            let (z1, z2, path) = scratch;
-            let seed = resolve_stream_seed(base_seed, chunk_index, reproducible);
-            let mut rng = FastRng::from_seed(rng_kind, seed);
-            let chunk_start = chunk_index * PATH_SIMULATION_CHUNK_SAMPLES;
-            let chunk_end = (chunk_start + PATH_SIMULATION_CHUNK_SAMPLES).min(samples);
-            let mut stats = BivariateMoments::default();
+        let simulate_chunk =
+            |scratch: &mut Scratch, chunk_index: usize| -> Result<BivariateMoments, E> {
+                let (z1, z2, path) = scratch;
+                let seed = resolve_stream_seed(base_seed, chunk_index, reproducible);
+                let mut rng = FastRng::from_seed(rng_kind, seed);
+                let chunk_start = chunk_index * PATH_SIMULATION_CHUNK_SAMPLES;
+                let chunk_end = (chunk_start + PATH_SIMULATION_CHUNK_SAMPLES).min(samples);
+                let mut stats = BivariateMoments::default();
 
-            for _ in chunk_start..chunk_end {
-                // Only generate as many normal streams as the model needs.
-                // GBM needs 1 stream (skipping z2 halves RNG + inverse-CDF work).
-                for j in 0..steps {
-                    z1[j] = sample_standard_normal(&mut rng);
-                    if num_streams >= 2 {
-                        z2[j] = sample_standard_normal(&mut rng);
+                for _ in chunk_start..chunk_end {
+                    // Only generate as many normal streams as the model needs.
+                    // GBM needs 1 stream (skipping z2 halves RNG + inverse-CDF work).
+                    for j in 0..steps {
+                        z1[j] = sample_standard_normal(&mut rng);
+                        if num_streams >= 2 {
+                            z2[j] = sample_standard_normal(&mut rng);
+                        }
                     }
-                }
 
-                generator.generate_into(z1, z2, path);
-                let x = payoff(path);
-                let y = if has_cv {
-                    (control.as_ref().unwrap().evaluator)(path)
-                } else {
-                    0.0
-                };
-
-                let (x, y) = if antithetic {
-                    for value in z1.iter_mut() {
-                        *value = -*value;
-                    }
-                    for value in z2.iter_mut() {
-                        *value = -*value;
-                    }
                     generator.generate_into(z1, z2, path);
-                    let xa = payoff(path);
-                    let ya = if has_cv {
-                        (control.as_ref().unwrap().evaluator)(path)
+                    let x = payoff(path)?;
+                    let y = if has_cv {
+                        (control.as_ref().unwrap().evaluator)(path)?
                     } else {
                         0.0
                     };
-                    (0.5 * (x + xa), 0.5 * (y + ya))
-                } else {
-                    (x, y)
-                };
 
-                stats.record(x, y);
-            }
+                    let (x, y) = if antithetic {
+                        for value in z1.iter_mut() {
+                            *value = -*value;
+                        }
+                        for value in z2.iter_mut() {
+                            *value = -*value;
+                        }
+                        generator.generate_into(z1, z2, path);
+                        let xa = payoff(path)?;
+                        let ya = if has_cv {
+                            (control.as_ref().unwrap().evaluator)(path)?
+                        } else {
+                            0.0
+                        };
+                        (0.5 * (x + xa), 0.5 * (y + ya))
+                    } else {
+                        (x, y)
+                    };
 
-            stats
-        };
+                    stats.record(x, y);
+                }
 
-        let reduce_fn = |mut a: BivariateMoments, b: BivariateMoments| {
-            a.merge(b);
-            a
-        };
+                Ok(stats)
+            };
 
         #[cfg(feature = "parallel")]
         let stats = {
@@ -471,28 +525,37 @@ impl MonteCarloEngine {
                     .into_par_iter()
                     .map_init(&make_scratch, &simulate_chunk)
                     .collect::<Vec<_>>();
-                partials
-                    .into_iter()
-                    .fold(BivariateMoments::default(), reduce_fn)
+                let mut stats = BivariateMoments::default();
+                // `Range` is indexed, so Rayon preserves chunk order when
+                // collecting into a Vec. Resolve errors on the calling thread
+                // to avoid scheduler-dependent error selection.
+                for partial in partials {
+                    stats.merge(partial?);
+                }
+                stats
             } else {
                 let mut scratch = make_scratch();
-                (0..chunk_count)
-                    .map(|chunk_index| simulate_chunk(&mut scratch, chunk_index))
-                    .fold(BivariateMoments::default(), reduce_fn)
+                let mut stats = BivariateMoments::default();
+                for chunk_index in 0..chunk_count {
+                    stats.merge(simulate_chunk(&mut scratch, chunk_index)?);
+                }
+                stats
             }
         };
 
         #[cfg(not(feature = "parallel"))]
         let stats = {
             let mut scratch = make_scratch();
-            (0..chunk_count)
-                .map(|chunk_index| simulate_chunk(&mut scratch, chunk_index))
-                .fold(BivariateMoments::default(), reduce_fn)
+            let mut stats = BivariateMoments::default();
+            for chunk_index in 0..chunk_count {
+                stats.merge(simulate_chunk(&mut scratch, chunk_index)?);
+            }
+            stats
         };
 
         let n = stats.count as f64;
 
-        if let Some(cv) = &control {
+        Ok(if let Some(cv) = &control {
             // The common sample-variance denominator cancels in beta.
             let beta = if stats.m2_y.is_finite() && stats.m2_y > 0.0 {
                 stats.co_moment / stats.m2_y
@@ -518,7 +581,7 @@ impl MonteCarloEngine {
             let price = discount_factor * stats.mean_x;
             let stderr = discount_factor * (stats.sample_variance_x() / n).sqrt();
             (price, stderr)
-        }
+        })
     }
 }
 
@@ -663,6 +726,119 @@ mod tests {
             .run(&generator, |_| 0.1, 0.95);
         assert!((price - 0.095).abs() <= f64::EPSILON);
         assert_eq!(stderr, 0.0);
+    }
+
+    #[test]
+    fn fallible_scalar_payoff_stops_on_first_error() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let generator = GbmPathGenerator {
+            model: Gbm {
+                mu: 0.03,
+                sigma: 0.2,
+            },
+            s0: 100.0,
+            maturity: 1.0,
+            steps: 4,
+        };
+        let calls = AtomicUsize::new(0);
+        let error = MonteCarloEngine::new(10_000, 7)
+            .with_antithetic(true)
+            .with_execution_policy(CpuExecutionPolicy::Scalar)
+            .run_fallible(
+                &generator,
+                |_| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err::<f64, _>("payoff failed")
+                },
+                1.0,
+                None,
+            )
+            .unwrap_err();
+
+        assert_eq!(error, "payoff failed");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn fallible_scalar_control_variate_stops_on_first_error() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let generator = GbmPathGenerator {
+            model: Gbm {
+                mu: 0.03,
+                sigma: 0.2,
+            },
+            s0: 100.0,
+            maturity: 1.0,
+            steps: 4,
+        };
+        let payoff_calls = Arc::new(AtomicUsize::new(0));
+        let control_calls = Arc::new(AtomicUsize::new(0));
+        let control_counter = Arc::clone(&control_calls);
+        let control = FallibleControlVariate {
+            expected: 100.0,
+            evaluator: Arc::new(move |_| {
+                control_counter.fetch_add(1, Ordering::SeqCst);
+                Err::<f64, _>("control failed")
+            }),
+        };
+        let error = MonteCarloEngine::new(10_000, 7)
+            .with_execution_policy(CpuExecutionPolicy::Scalar)
+            .run_fallible(
+                &generator,
+                |_| {
+                    payoff_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(1.0)
+                },
+                1.0,
+                Some(control),
+            )
+            .unwrap_err();
+
+        assert_eq!(error, "control failed");
+        assert_eq!(payoff_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(control_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn fallible_parallel_error_selection_is_deterministic_across_pool_sizes() {
+        let generator = GbmPathGenerator {
+            model: Gbm {
+                mu: 0.03,
+                sigma: 0.2,
+            },
+            s0: 100.0,
+            maturity: 1.0,
+            steps: 1,
+        };
+        let engine = MonteCarloEngine::new(3 * PATH_SIMULATION_CHUNK_SAMPLES, 7)
+            .with_execution_policy(CpuExecutionPolicy::Parallel);
+        let run = || {
+            engine
+                .run_fallible(
+                    &generator,
+                    |path| Err::<f64, _>(format!("{:.17e}", path[1])),
+                    1.0,
+                    None,
+                )
+                .unwrap_err()
+        };
+
+        let expected = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(run);
+        for threads in [2, 4] {
+            let actual = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap()
+                .install(run);
+            assert_eq!(actual, expected, "threads={threads}");
+        }
     }
 
     #[test]

--- a/src/pricing/european.rs
+++ b/src/pricing/european.rs
@@ -12,7 +12,6 @@
 use crate::engines::analytic::black_scholes::{
     bs_delta, bs_gamma, bs_price, bs_rho, bs_theta, bs_vega,
 };
-use crate::math::normal_cdf;
 use crate::pricing::OptionType;
 
 #[derive(Debug, Clone, Copy)]
@@ -85,23 +84,7 @@ pub fn black_scholes_price(
 /// assert!(call > 0.0 && put > 0.0);
 /// ```
 pub fn black_76_price(option_type: OptionType, f: f64, k: f64, r: f64, sigma: f64, t: f64) -> f64 {
-    if t <= 0.0 || sigma <= 0.0 {
-        return (-r * t).exp()
-            * match option_type {
-                OptionType::Call => (f - k).max(0.0),
-                OptionType::Put => (k - f).max(0.0),
-            };
-    }
-
-    let vt = sigma * t.sqrt();
-    let d1 = ((f / k).ln() + 0.5 * sigma * sigma * t) / vt;
-    let d2 = d1 - vt;
-    let df = (-r * t).exp();
-
-    match option_type {
-        OptionType::Call => df * (f * normal_cdf(d1) - k * normal_cdf(d2)),
-        OptionType::Put => df * (k * normal_cdf(-d2) - f * normal_cdf(-d1)),
-    }
+    crate::engines::analytic::black76_price(option_type, f, k, r, sigma, t).unwrap_or(f64::NAN)
 }
 
 /// Computes Black-Scholes Greeks with zero dividend yield.

--- a/src/vol/implied.rs
+++ b/src/vol/implied.rs
@@ -9,13 +9,72 @@
 //! Numerical considerations: enforce positivity and no-arbitrage constraints, and guard root-finding with robust brackets for wings or short maturities.
 //!
 //! When to use: use these tools for smile/surface construction and implied-vol inversion; choose local/stochastic-vol models when dynamics, not just static fits, are needed.
-use crate::math::normal_pdf;
+use crate::engines::analytic::black_scholes::bs_vega;
 use crate::pricing::OptionType;
 use crate::pricing::european::black_scholes_price;
 use crate::vol::jaeckel::implied_vol_jaeckel;
 #[cfg(test)]
 use rand::RngExt;
 use std::f64::consts::PI;
+
+#[allow(clippy::too_many_arguments)]
+fn validate_implied_vol_inputs(
+    option_type: OptionType,
+    s: f64,
+    k: f64,
+    r: f64,
+    t: f64,
+    market_price: f64,
+    tol: f64,
+) -> Result<(f64, f64, f64), String> {
+    if !s.is_finite()
+        || !k.is_finite()
+        || !r.is_finite()
+        || !t.is_finite()
+        || !market_price.is_finite()
+        || !tol.is_finite()
+    {
+        return Err("inputs and tol must be finite".to_string());
+    }
+    if s <= 0.0 || k <= 0.0 {
+        return Err("s and k must be > 0".to_string());
+    }
+    if t <= 0.0 {
+        return Err("t must be > 0".to_string());
+    }
+    if market_price < 0.0 {
+        return Err("market_price must be >= 0".to_string());
+    }
+    if tol <= 0.0 {
+        return Err("tol must be > 0".to_string());
+    }
+
+    let df = (-r * t).exp();
+    let intrinsic = match option_type {
+        OptionType::Call => (s - k * df).max(0.0),
+        OptionType::Put => (k * df - s).max(0.0),
+    };
+    let upper = match option_type {
+        OptionType::Call => s,
+        OptionType::Put => k * df,
+    };
+    if !intrinsic.is_finite() || !upper.is_finite() {
+        return Err("discounted no-arbitrage bounds must be finite".to_string());
+    }
+
+    // Bound checks need to tolerate rounding at the scale of the bound, but
+    // convergence and the zero-vol decision must not inherit that potentially
+    // enormous slack.
+    let bounds_slack = 32.0 * f64::EPSILON * (1.0 + intrinsic.abs().max(upper.abs()));
+    if market_price < intrinsic - bounds_slack || market_price > upper + bounds_slack {
+        return Err(format!(
+            "market_price out of no-arbitrage bounds: price={market_price}, intrinsic={intrinsic}, upper={upper}"
+        ));
+    }
+
+    let residual_tolerance = tol.max(32.0 * f64::EPSILON * (1.0 + market_price.abs()));
+    Ok((intrinsic, upper, residual_tolerance))
+}
 
 /// Produces a bounded positive volatility seed from option time value and moneyness.
 ///
@@ -96,40 +155,10 @@ pub fn implied_vol(
     tol: f64,
     max_iter: usize,
 ) -> Result<f64, String> {
-    if !s.is_finite()
-        || !k.is_finite()
-        || !r.is_finite()
-        || !t.is_finite()
-        || !market_price.is_finite()
-    {
-        return Err("inputs must be finite".to_string());
-    }
-    if s <= 0.0 || k <= 0.0 {
-        return Err("s and k must be > 0".to_string());
-    }
-    if t <= 0.0 {
-        return Err("t must be > 0".to_string());
-    }
-    if market_price < 0.0 {
-        return Err("market_price must be >= 0".to_string());
-    }
-
-    let df = (-r * t).exp();
-    let intrinsic = match option_type {
-        OptionType::Call => (s - k * df).max(0.0),
-        OptionType::Put => (k * df - s).max(0.0),
-    };
-    let upper = match option_type {
-        OptionType::Call => s,
-        OptionType::Put => k * df,
-    };
-    let price_tol = 32.0 * f64::EPSILON * (1.0 + upper.abs());
-    if market_price < intrinsic - price_tol || market_price > upper + price_tol {
-        return Err(format!(
-            "market_price out of no-arbitrage bounds: price={market_price}, intrinsic={intrinsic}, upper={upper}"
-        ));
-    }
-    if market_price <= intrinsic + price_tol {
+    let (intrinsic, _, residual_tolerance) =
+        validate_implied_vol_inputs(option_type, s, k, r, t, market_price, tol)?;
+    let zero_vol_tolerance = tol.max(32.0 * f64::EPSILON * (1.0 + intrinsic.abs()));
+    if market_price <= intrinsic + zero_vol_tolerance {
         return Ok(0.0);
     }
 
@@ -142,7 +171,10 @@ pub fn implied_vol(
             && iv.is_finite()
             && iv >= 0.0
         {
-            return Ok(iv);
+            let residual = black_scholes_price(option_type, s, k, r, iv, t) - market_price;
+            if residual.is_finite() && residual.abs() <= residual_tolerance {
+                return Ok(iv);
+            }
         }
     }
 
@@ -175,33 +207,25 @@ pub fn implied_vol_newton(
     tol: f64,
     max_iter: usize,
 ) -> Result<f64, String> {
-    if t <= 0.0 {
-        return Err("t must be > 0".to_string());
-    }
-    if market_price < 0.0 {
-        return Err("market_price must be >= 0".to_string());
-    }
-    if market_price == 0.0 {
+    let (intrinsic, _, residual_tolerance) =
+        validate_implied_vol_inputs(option_type, s, k, r, t, market_price, tol)?;
+    let zero_vol_tolerance = tol.max(32.0 * f64::EPSILON * (1.0 + intrinsic.abs()));
+    if market_price <= intrinsic + zero_vol_tolerance {
         return Ok(0.0);
     }
 
     let mut sigma = lets_be_rational_initial_guess(option_type, s, k, r, t, market_price);
 
-    // Pre-compute loop-invariant values.
-    let sqrt_t = t.sqrt();
-    let ln_sk = (s / k).ln();
     for _ in 0..max_iter {
         let price = black_scholes_price(option_type, s, k, r, sigma, t);
         let diff = price - market_price;
-        if diff.abs() < tol {
+        if diff.is_finite() && diff.abs() <= residual_tolerance {
             return Ok(sigma);
         }
 
-        let sig_sqrt_t = sigma * sqrt_t;
-        let d1 = (ln_sk + (0.5 * sigma).mul_add(sigma, r) * t) / sig_sqrt_t;
-        let vega = s * normal_pdf(d1) * sqrt_t;
+        let vega = bs_vega(s, k, r, 0.0, sigma, t);
 
-        if vega.abs() < 1e-10 {
+        if !vega.is_finite() || vega.abs() < 1e-10 {
             break;
         }
 
@@ -213,7 +237,7 @@ pub fn implied_vol_newton(
     // f(lo) <= 0 <= f(hi); otherwise the market price is unattainable on
     // [lo, hi] (e.g. true vol > 5.0) and returning a midpoint would be
     // silently wrong.
-    let mut lo = 1e-6;
+    let mut lo = 0.0;
     let mut hi = 5.0;
     let mut flo = black_scholes_price(option_type, s, k, r, lo, t) - market_price;
     let fhi = black_scholes_price(option_type, s, k, r, hi, t) - market_price;
@@ -224,7 +248,7 @@ pub fn implied_vol_newton(
     if fhi == 0.0 {
         return Ok(hi);
     }
-    if flo * fhi > 0.0 {
+    if (flo > 0.0) == (fhi > 0.0) {
         return Err(format!(
             "implied vol not bracketed in [{lo}, {hi}]: market_price={market_price} is unattainable"
         ));
@@ -234,11 +258,11 @@ pub fn implied_vol_newton(
         let mid = 0.5 * (lo + hi);
         let fm = black_scholes_price(option_type, s, k, r, mid, t) - market_price;
 
-        if fm.abs() < tol {
+        if fm.is_finite() && fm.abs() <= residual_tolerance {
             return Ok(mid);
         }
 
-        if flo * fm <= 0.0 {
+        if (flo > 0.0) != (fm > 0.0) {
             hi = mid;
         } else {
             lo = mid;
@@ -246,7 +270,15 @@ pub fn implied_vol_newton(
         }
     }
 
-    Ok(0.5 * (lo + hi))
+    let candidate = 0.5 * (lo + hi);
+    let residual = black_scholes_price(option_type, s, k, r, candidate, t) - market_price;
+    if residual.is_finite() && residual.abs() <= residual_tolerance {
+        Ok(candidate)
+    } else {
+        Err(format!(
+            "implied vol did not converge: sigma={candidate}, residual={residual}, tolerance={residual_tolerance}"
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -319,6 +351,66 @@ mod tests {
         let repriced = black_scholes_price(option_type, s, k, r, iv, t);
 
         assert_relative_eq!(repriced, market_price, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn deep_tail_price_round_trips_without_scale_dependent_zero_classification() {
+        // Independent 100-decimal erfc price for S=5e18, K=1e18, sigma=.2.
+        const MARKET_PRICE: f64 = 22.752_884_600_977_636;
+        for solver in [implied_vol, implied_vol_newton] {
+            let iv = solver(
+                OptionType::Put,
+                5.0e18,
+                1.0e18,
+                0.0,
+                1.0,
+                MARKET_PRICE,
+                1.0e-12,
+                100,
+            )
+            .unwrap();
+            assert!((iv - 0.2).abs() <= 2.0e-13, "iv={iv:.17e}");
+            let repriced = black_scholes_price(OptionType::Put, 5.0e18, 1.0e18, 0.0, iv, 1.0);
+            assert!(
+                (repriced - MARKET_PRICE).abs() <= 1.0e-10,
+                "iv={iv:.17e} repriced={repriced:.17e}"
+            );
+        }
+    }
+
+    #[test]
+    fn bisection_and_tolerance_contract_require_a_verified_residual() {
+        let market_price = black_scholes_price(OptionType::Call, 100.0, 105.0, 0.01, 0.37, 2.0);
+        let iv = implied_vol_newton(
+            OptionType::Call,
+            100.0,
+            105.0,
+            0.01,
+            2.0,
+            market_price,
+            1.0e-13,
+            0,
+        )
+        .unwrap();
+        let residual =
+            black_scholes_price(OptionType::Call, 100.0, 105.0, 0.01, iv, 2.0) - market_price;
+        assert!(residual.abs() <= 1.0e-13, "residual={residual}");
+
+        for invalid_tol in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                implied_vol_newton(
+                    OptionType::Call,
+                    100.0,
+                    105.0,
+                    0.01,
+                    2.0,
+                    market_price,
+                    invalid_tol,
+                    10,
+                )
+                .is_err()
+            );
+        }
     }
 
     #[test]

--- a/tests/dsl_examples.rs
+++ b/tests/dsl_examples.rs
@@ -4,7 +4,7 @@
 //! and produces a finite price under standard market conditions.
 
 use openferric::dsl::{AssetMarketData, DslMonteCarloEngine, MultiAssetMarket, parse_and_compile};
-#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+#[cfg(all(feature = "jit", target_arch = "x86_64"))]
 use openferric::dsl::{JitProductEvaluator, eval::evaluate_product};
 
 fn single_asset_market() -> MultiAssetMarket {
@@ -231,7 +231,7 @@ fn example_30_napoleon() {
     test_example("30_napoleon.of", &two_asset_market());
 }
 
-#[cfg(all(feature = "jit", not(target_family = "wasm")))]
+#[cfg(all(feature = "jit", target_arch = "x86_64"))]
 #[test]
 fn every_example_matches_interpreter_with_jit() {
     let mut files = std::fs::read_dir("examples/dsl")

--- a/wasm/src/abi_tests.rs
+++ b/wasm/src/abi_tests.rs
@@ -55,6 +55,116 @@ fn slice_and_vector_exports_preserve_shape_and_values() {
 }
 
 #[wasm_bindgen_test]
+fn scalar_and_batch_pricing_reject_the_same_invalid_domains() {
+    let scalar_error = pricing::bs_price(-1.0, 100.0, 0.03, 0.0, 0.2, 1.0, true)
+        .expect_err("negative scalar spot must be rejected")
+        .as_string()
+        .expect("validation error must contain a JavaScript string");
+    assert!(scalar_error.contains("`spot`"));
+
+    let batch_error = pricing::bs_price_batch_wasm(
+        &[100.0, -1.0],
+        &[100.0, 100.0],
+        &[0.03, 0.03],
+        &[0.0, 0.0],
+        &[0.2, 0.2],
+        &[1.0, 1.0],
+        &[1, 1],
+    )
+    .expect_err("negative batch spot must be rejected")
+    .as_string()
+    .expect("validation error must contain a JavaScript string");
+    assert!(batch_error.contains("`spots[1]`"));
+
+    let uniform_error = pricing::bs_price_uniform_batch_wasm(
+        &[100.0, f64::NAN],
+        &[100.0, 100.0],
+        0.03,
+        0.0,
+        0.2,
+        1.0,
+        true,
+    )
+    .expect_err("non-finite uniform-batch spot must be rejected")
+    .as_string()
+    .expect("validation error must contain a JavaScript string");
+    assert!(uniform_error.contains("`spots[1]`"));
+
+    let flag_error =
+        pricing::bs_price_batch_wasm(&[100.0], &[100.0], &[0.03], &[0.0], &[0.2], &[1.0], &[2])
+            .expect_err("batch option flags outside 0/1 must be rejected")
+            .as_string()
+            .expect("validation error must contain a JavaScript string");
+    assert!(flag_error.contains("`is_calls[0]`"));
+}
+
+#[wasm_bindgen_test]
+fn greek_and_black76_batches_report_the_invalid_element() {
+    let greek_error = pricing::bsm_greeks_batch_wasm(
+        &[100.0, 100.0],
+        &[100.0, 100.0],
+        &[0.03, 0.03],
+        &[0.0, 0.0],
+        &[0.2, f64::NAN],
+        &[1.0, 1.0],
+        &[1, 1],
+    )
+    .expect_err("non-finite batch volatility must be rejected")
+    .as_string()
+    .expect("validation error must contain a JavaScript string");
+    assert!(greek_error.contains("`vols[1]`"));
+
+    let black_price_error = pricing::black76_price_batch_wasm(
+        &[100.0, -1.0],
+        &[100.0, 100.0],
+        &[0.03, 0.03],
+        &[0.2, 0.2],
+        &[1.0, 1.0],
+        &[1, 1],
+    )
+    .expect_err("negative Black-76 forward must be rejected")
+    .as_string()
+    .expect("validation error must contain a JavaScript string");
+    assert!(black_price_error.contains("`forwards[1]`"));
+
+    let black_greek_error = pricing::black76_greeks_batch_wasm(
+        &[100.0, 100.0],
+        &[100.0, 100.0],
+        &[0.03, f64::INFINITY],
+        &[0.2, 0.2],
+        &[1.0, 1.0],
+        &[1, 1],
+    )
+    .expect_err("non-finite Black-76 rate must be rejected")
+    .as_string()
+    .expect("validation error must contain a JavaScript string");
+    assert!(black_greek_error.contains("`rates[1]`"));
+}
+
+#[wasm_bindgen_test]
+fn black76_deep_tail_put_greeks_remain_representable_through_wasm() {
+    let actual =
+        pricing::black76_greeks_batch_wasm(&[5.0e18], &[1.0e18], &[0.0], &[0.2], &[1.0], &[0])
+            .expect("valid deep-tail Black-76 put");
+    let expected = [
+        -1.862_397_753_202_606_3e-16,
+        1.539_548_175_331_966_1e-33,
+        7.697_740_876_659_831e3,
+        -7.697_740_876_659_832e2,
+        -2.275_288_460_097_726_8e1,
+        -6.117_540_594_728_432e-14,
+        2.492_038_143_976_294_4e6,
+    ];
+    for (index, (&actual, expected)) in actual.iter().zip(expected).enumerate() {
+        let relative_error = ((actual - expected) / expected).abs();
+        assert!(
+            relative_error <= 2.0e-11,
+            "Greek {index}: actual={actual:.17e}, expected={expected:.17e}, relative_error={relative_error:.3e}"
+        );
+    }
+}
+
+#[wasm_bindgen_test]
 fn empty_slices_and_invalid_dsl_are_well_defined() {
     let empty = pricing::bs_price_batch_wasm(&[], &[], &[], &[], &[], &[], &[])
         .expect("empty arrays have matching lengths");

--- a/wasm/src/pricing.rs
+++ b/wasm/src/pricing.rs
@@ -4,11 +4,219 @@ use crate::error::{
     check_batch_lengths, js_error, require_finite, require_non_negative, require_positive,
 };
 use openferric::core::types::{BarrierDirection, BarrierStyle, OptionType};
+use openferric::engines::analytic::{
+    black76_greeks as validated_black76_greeks, black76_price as validated_black76_price,
+};
 use openferric::greeks::black_scholes_merton_greeks;
-use openferric::math::{normal_cdf, normal_pdf};
+use openferric::math::normal_pdf;
 use openferric::pricing::barrier::barrier_price_closed_form_with_carry_and_rebate;
-use openferric::pricing::european::{black_76_price, black_scholes_price};
+use openferric::pricing::european::black_scholes_price;
 use openferric::vol::implied::implied_vol;
+
+#[inline]
+fn input_label(scalar_name: &str, batch_name: &str, index: Option<usize>) -> String {
+    match index {
+        Some(index) => format!("{batch_name}[{index}]"),
+        None => scalar_name.to_string(),
+    }
+}
+
+#[inline]
+fn validate_finite_input(
+    scalar_name: &str,
+    batch_name: &str,
+    index: Option<usize>,
+    value: f64,
+) -> Result<(), String> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{}` must be finite",
+            input_label(scalar_name, batch_name, index)
+        ))
+    }
+}
+
+#[inline]
+fn validate_positive_input(
+    scalar_name: &str,
+    batch_name: &str,
+    index: Option<usize>,
+    value: f64,
+) -> Result<(), String> {
+    validate_finite_input(scalar_name, batch_name, index, value)?;
+    if value > 0.0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{}` must be positive",
+            input_label(scalar_name, batch_name, index)
+        ))
+    }
+}
+
+#[inline]
+fn validate_non_negative_input(
+    scalar_name: &str,
+    batch_name: &str,
+    index: Option<usize>,
+    value: f64,
+) -> Result<(), String> {
+    validate_finite_input(scalar_name, batch_name, index, value)?;
+    if value >= 0.0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "`{}` must be non-negative",
+            input_label(scalar_name, batch_name, index)
+        ))
+    }
+}
+
+#[inline]
+fn checked_finite_output(name: &str, index: Option<usize>, value: f64) -> Result<f64, String> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        let output = match index {
+            Some(index) => format!("{name}[{index}]"),
+            None => name.to_string(),
+        };
+        Err(format!("`{output}` is non-finite for the supplied inputs"))
+    }
+}
+
+#[inline]
+fn checked_option_flag(index: usize, value: u8) -> Result<bool, String> {
+    match value {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(format!(
+            "`is_calls[{index}]` must be 0 for a put or 1 for a call"
+        )),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn checked_bs_price(
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    div_yield: f64,
+    vol: f64,
+    maturity: f64,
+    is_call: bool,
+    index: Option<usize>,
+) -> Result<f64, String> {
+    validate_positive_input("spot", "spots", index, spot)?;
+    validate_positive_input("strike", "strikes", index, strike)?;
+    validate_non_negative_input("vol", "vols", index, vol)?;
+    validate_non_negative_input("maturity", "maturities", index, maturity)?;
+    validate_finite_input("rate", "rates", index, rate)?;
+    validate_finite_input("div_yield", "div_yields", index, div_yield)?;
+
+    let option_type = if is_call {
+        OptionType::Call
+    } else {
+        OptionType::Put
+    };
+    let adjusted_spot = spot * (-div_yield * maturity).exp();
+    if !adjusted_spot.is_finite() {
+        let location = index.map_or_else(
+            || "adjusted spot".to_string(),
+            |index| format!("adjusted spot at batch index {index}"),
+        );
+        return Err(format!(
+            "`{location}` is non-finite for the supplied inputs"
+        ));
+    }
+    checked_finite_output(
+        "price",
+        index,
+        black_scholes_price(option_type, adjusted_spot, strike, rate, vol, maturity),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn checked_bsm_greeks(
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    div_yield: f64,
+    vol: f64,
+    expiry: f64,
+    is_call: bool,
+    index: Option<usize>,
+) -> Result<[f64; 7], String> {
+    validate_positive_input("spot", "spots", index, spot)?;
+    validate_positive_input("strike", "strikes", index, strike)?;
+    validate_non_negative_input("vol", "vols", index, vol)?;
+    validate_non_negative_input("expiry", "expiries", index, expiry)?;
+    validate_finite_input("rate", "rates", index, rate)?;
+    validate_finite_input("div_yield", "div_yields", index, div_yield)?;
+
+    let option_type = if is_call {
+        OptionType::Call
+    } else {
+        OptionType::Put
+    };
+    let greeks =
+        black_scholes_merton_greeks(option_type, spot, strike, rate, div_yield, vol, expiry);
+    let values = [
+        greeks.delta,
+        greeks.gamma,
+        greeks.vega,
+        greeks.theta,
+        greeks.rho,
+        greeks.vanna,
+        greeks.volga,
+    ];
+    if let Some((greek_index, _)) = values
+        .iter()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        const NAMES: [&str; 7] = ["delta", "gamma", "vega", "theta", "rho", "vanna", "volga"];
+        let location = index.map_or_else(
+            || format!("greeks.{}", NAMES[greek_index]),
+            |index| format!("greeks[{index}].{}", NAMES[greek_index]),
+        );
+        return Err(format!(
+            "`{location}` is non-finite for the supplied inputs"
+        ));
+    }
+    Ok(values)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn checked_black76_price(
+    forward: f64,
+    strike: f64,
+    rate: f64,
+    vol: f64,
+    maturity: f64,
+    is_call: bool,
+    index: Option<usize>,
+) -> Result<f64, String> {
+    validate_positive_input("forward", "forwards", index, forward)?;
+    validate_positive_input("strike", "strikes", index, strike)?;
+    validate_finite_input("rate", "rates", index, rate)?;
+    validate_non_negative_input("vol", "vols", index, vol)?;
+    validate_non_negative_input("maturity", "maturities", index, maturity)?;
+
+    let option_type = if is_call {
+        OptionType::Call
+    } else {
+        OptionType::Put
+    };
+    let price = validated_black76_price(option_type, forward, strike, rate, vol, maturity)
+        .map_err(|error| match index {
+            Some(index) => format!("Black-76 input at batch index {index} is invalid: {error}"),
+            None => format!("Black-76 input is invalid: {error}"),
+        })?;
+    checked_finite_output("price", index, price)
+}
 
 /// Black-Scholes European option price.
 #[wasm_bindgen]
@@ -21,21 +229,7 @@ pub fn bs_price(
     maturity: f64,
     is_call: bool,
 ) -> Result<f64, JsValue> {
-    require_positive("spot", spot)?;
-    require_positive("strike", strike)?;
-    require_non_negative("vol", vol)?;
-    require_non_negative("maturity", maturity)?;
-    require_finite("rate", rate)?;
-    require_finite("div_yield", div_yield)?;
-
-    let ot = if is_call {
-        OptionType::Call
-    } else {
-        OptionType::Put
-    };
-    // Adjust for continuous dividend yield: S_adj = S * e^{-q*T}
-    let s_adj = spot * (-div_yield * maturity).exp();
-    Ok(black_scholes_price(ot, s_adj, strike, rate, vol, maturity))
+    checked_bs_price(spot, strike, rate, div_yield, vol, maturity, is_call, None).map_err(js_error)
 }
 
 /// Black-Scholes implied volatility.
@@ -77,67 +271,104 @@ pub fn bsm_greeks_wasm(
     expiry: f64,
     is_call: bool,
 ) -> Result<Vec<f64>, JsValue> {
-    require_positive("spot", spot)?;
-    require_positive("strike", strike)?;
-    require_non_negative("vol", vol)?;
-    require_non_negative("expiry", expiry)?;
-    require_finite("rate", rate)?;
-    require_finite("div_yield", div_yield)?;
+    checked_bsm_greeks(spot, strike, rate, div_yield, vol, expiry, is_call, None)
+        .map(Vec::from)
+        .map_err(js_error)
+}
+
+#[inline]
+fn stable_black76_d1_d2(forward: f64, strike: f64, vol: f64, expiry: f64) -> (f64, f64) {
+    let relative_moneyness = (forward - strike) / strike;
+    let log_moneyness = if relative_moneyness.abs() <= 0.5 {
+        relative_moneyness.ln_1p()
+    } else {
+        forward.ln() - strike.ln()
+    };
+    let width = vol * expiry.sqrt();
+    let midpoint = if width != 0.0 {
+        log_moneyness / width
+    } else if log_moneyness == 0.0 {
+        0.0
+    } else {
+        let log_width = vol.ln() + 0.5 * expiry.ln();
+        log_moneyness.signum() * (log_moneyness.abs().ln() - log_width).exp()
+    };
+    let half_width = 0.5 * width;
+    (midpoint + half_width, midpoint - half_width)
+}
+
+#[inline]
+fn black76_vanna_volga(
+    forward: f64,
+    strike: f64,
+    rate: f64,
+    vol: f64,
+    expiry: f64,
+    vega: f64,
+) -> (f64, f64) {
+    if vol <= 0.0 || expiry <= 0.0 {
+        return (0.0, 0.0);
+    }
+
+    let (d1, d2) = stable_black76_d1_d2(forward, strike, vol, expiry);
+    let df = (-rate * expiry).exp();
+    let pdf_d1 = normal_pdf(d1);
+    let vanna = -df * pdf_d1 * d2 / vol;
+    let volga = vega * d1 * d2 / vol;
+    (vanna, volga)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn checked_black76_greeks(
+    forward: f64,
+    strike: f64,
+    rate: f64,
+    vol: f64,
+    expiry: f64,
+    is_call: bool,
+    index: Option<usize>,
+) -> Result<[f64; 7], String> {
+    validate_positive_input("forward", "forwards", index, forward)?;
+    validate_positive_input("strike", "strikes", index, strike)?;
+    validate_finite_input("rate", "rates", index, rate)?;
+    validate_non_negative_input("vol", "vols", index, vol)?;
+    validate_non_negative_input("expiry", "expiries", index, expiry)?;
 
     let option_type = if is_call {
         OptionType::Call
     } else {
         OptionType::Put
     };
-    let g = black_scholes_merton_greeks(option_type, spot, strike, rate, div_yield, vol, expiry);
-    Ok(vec![
-        g.delta, g.gamma, g.vega, g.theta, g.rho, g.vanna, g.volga,
-    ])
-}
-
-#[inline]
-fn black76_greeks_7(
-    option_type: OptionType,
-    forward: f64,
-    strike: f64,
-    rate: f64,
-    vol: f64,
-    expiry: f64,
-) -> [f64; 7] {
-    if forward <= 0.0 || strike <= 0.0 || vol <= 0.0 || expiry <= 0.0 {
-        return [0.0; 7];
+    let greeks = validated_black76_greeks(option_type, forward, strike, rate, vol, expiry)
+        .map_err(|error| match index {
+            Some(index) => format!("Black-76 input at batch index {index} is invalid: {error}"),
+            None => format!("Black-76 input is invalid: {error}"),
+        })?;
+    let (vanna, volga) = black76_vanna_volga(forward, strike, rate, vol, expiry, greeks.vega);
+    let values = [
+        greeks.delta,
+        greeks.gamma,
+        greeks.vega,
+        greeks.theta,
+        greeks.rho,
+        vanna,
+        volga,
+    ];
+    if let Some((greek_index, _)) = values
+        .iter()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        const NAMES: [&str; 7] = ["delta", "gamma", "vega", "theta", "rho", "vanna", "volga"];
+        let location = index.map_or_else(
+            || format!("greeks.{}", NAMES[greek_index]),
+            |index| format!("greeks[{index}].{}", NAMES[greek_index]),
+        );
+        return Err(format!(
+            "`{location}` is non-finite for the supplied inputs"
+        ));
     }
-
-    let sqrt_t = expiry.sqrt();
-    let sig_sqrt_t = vol * sqrt_t;
-    let d1 = ((forward / strike).ln() + 0.5 * vol * vol * expiry) / sig_sqrt_t;
-    let d2 = d1 - sig_sqrt_t;
-
-    let df = (-rate * expiry).exp();
-    let nd1 = normal_cdf(d1);
-    let nd2 = normal_cdf(d2);
-    let pdf_d1 = normal_pdf(d1);
-
-    let call = df * (forward * nd1 - strike * nd2);
-    let put = call - df * (forward - strike);
-    let price = match option_type {
-        OptionType::Call => call,
-        OptionType::Put => put,
-    };
-
-    let delta = match option_type {
-        OptionType::Call => df * nd1,
-        OptionType::Put => df * (nd1 - 1.0),
-    };
-    let gamma = df * pdf_d1 / (forward * vol * sqrt_t);
-    let vega = df * forward * pdf_d1 * sqrt_t;
-    let theta = rate.mul_add(price, -(df * forward * pdf_d1 * vol / (2.0 * sqrt_t)));
-    // Rho here is dV/dr with forward held fixed.
-    let rho = -expiry * price;
-    let vanna = -df * pdf_d1 * d2 / vol;
-    let volga = vega * d1 * d2 / vol;
-
-    [delta, gamma, vega, theta, rho, vanna, volga]
+    Ok(values)
 }
 
 /// Batch Black-Scholes pricing: one WASM call for N options.
@@ -172,20 +403,20 @@ pub fn bs_price_batch_wasm(
 
     let mut out = Vec::with_capacity(n);
     for i in 0..n {
-        let ot = if is_calls[i] != 0 {
-            OptionType::Call
-        } else {
-            OptionType::Put
-        };
-        let s_adj = spots[i] * (-div_yields[i] * maturities[i]).exp();
-        out.push(black_scholes_price(
-            ot,
-            s_adj,
-            strikes[i],
-            rates[i],
-            vols[i],
-            maturities[i],
-        ));
+        let is_call = checked_option_flag(i, is_calls[i]).map_err(js_error)?;
+        out.push(
+            checked_bs_price(
+                spots[i],
+                strikes[i],
+                rates[i],
+                div_yields[i],
+                vols[i],
+                maturities[i],
+                is_call,
+                Some(i),
+            )
+            .map_err(js_error)?,
+        );
     }
     Ok(out)
 }
@@ -212,9 +443,19 @@ pub fn bs_price_uniform_batch_wasm(
     require_non_negative("vol", vol)?;
     require_non_negative("maturity", maturity)?;
 
-    Ok(openferric::engines::analytic::bs_price_batch(
+    for index in 0..spots.len() {
+        validate_positive_input("spot", "spots", Some(index), spots[index]).map_err(js_error)?;
+        validate_positive_input("strike", "strikes", Some(index), strikes[index])
+            .map_err(js_error)?;
+    }
+
+    let prices = openferric::engines::analytic::bs_price_batch(
         spots, strikes, rate, div_yield, vol, maturity, is_call,
-    ))
+    );
+    for (index, &price) in prices.iter().enumerate() {
+        checked_finite_output("price", Some(index), price).map_err(js_error)?;
+    }
+    Ok(prices)
 }
 
 /// Batch Black-Scholes delta, gamma, vega, and theta with uniform parameters.
@@ -238,12 +479,26 @@ pub fn bsm_greeks_uniform_batch_wasm(
     require_non_negative("vol", vol)?;
     require_non_negative("expiry", expiry)?;
 
+    for index in 0..spots.len() {
+        validate_positive_input("spot", "spots", Some(index), spots[index]).map_err(js_error)?;
+        validate_positive_input("strike", "strikes", Some(index), strikes[index])
+            .map_err(js_error)?;
+    }
+
     let (delta, gamma, vega, theta) = openferric::engines::analytic::bs_greeks_batch(
         spots, strikes, rate, div_yield, vol, expiry, is_call,
     );
     let mut out = Vec::with_capacity(spots.len() * 4);
     for index in 0..spots.len() {
-        out.extend_from_slice(&[delta[index], gamma[index], vega[index], theta[index]]);
+        let values = [delta[index], gamma[index], vega[index], theta[index]];
+        for (greek_name, value) in ["delta", "gamma", "vega", "theta"].into_iter().zip(values) {
+            if !value.is_finite() {
+                return Err(js_error(format!(
+                    "`greeks[{index}].{greek_name}` is non-finite for the supplied inputs"
+                )));
+            }
+        }
+        out.extend_from_slice(&values);
     }
     Ok(out)
 }
@@ -278,19 +533,19 @@ pub fn black76_price_batch_wasm(
 
     let mut out = Vec::with_capacity(n);
     for i in 0..n {
-        let ot = if is_calls[i] != 0 {
-            OptionType::Call
-        } else {
-            OptionType::Put
-        };
-        out.push(black_76_price(
-            ot,
-            forwards[i],
-            strikes[i],
-            rates[i],
-            vols[i],
-            maturities[i],
-        ));
+        let is_call = checked_option_flag(i, is_calls[i]).map_err(js_error)?;
+        out.push(
+            checked_black76_price(
+                forwards[i],
+                strikes[i],
+                rates[i],
+                vols[i],
+                maturities[i],
+                is_call,
+                Some(i),
+            )
+            .map_err(js_error)?,
+        );
     }
     Ok(out)
 }
@@ -328,27 +583,19 @@ pub fn bsm_greeks_batch_wasm(
 
     let mut out = Vec::with_capacity(n * 7);
     for i in 0..n {
-        let ot = if is_calls[i] != 0 {
-            OptionType::Call
-        } else {
-            OptionType::Put
-        };
-        let g = black_scholes_merton_greeks(
-            ot,
+        let is_call = checked_option_flag(i, is_calls[i]).map_err(js_error)?;
+        let greeks = checked_bsm_greeks(
             spots[i],
             strikes[i],
             rates[i],
             div_yields[i],
             vols[i],
             expiries[i],
-        );
-        out.push(g.delta);
-        out.push(g.gamma);
-        out.push(g.vega);
-        out.push(g.theta);
-        out.push(g.rho);
-        out.push(g.vanna);
-        out.push(g.volga);
+            is_call,
+            Some(i),
+        )
+        .map_err(js_error)?;
+        out.extend_from_slice(&greeks);
     }
     Ok(out)
 }
@@ -386,13 +633,18 @@ pub fn black76_greeks_batch_wasm(
 
     let mut out = Vec::with_capacity(n * 7);
     for i in 0..n {
-        let ot = if is_calls[i] != 0 {
-            OptionType::Call
-        } else {
-            OptionType::Put
-        };
-        let g = black76_greeks_7(ot, forwards[i], strikes[i], rates[i], vols[i], expiries[i]);
-        out.extend_from_slice(&g);
+        let is_call = checked_option_flag(i, is_calls[i]).map_err(js_error)?;
+        let greeks = checked_black76_greeks(
+            forwards[i],
+            strikes[i],
+            rates[i],
+            vols[i],
+            expiries[i],
+            is_call,
+            Some(i),
+        )
+        .map_err(js_error)?;
+        out.extend_from_slice(&greeks);
     }
     Ok(out)
 }
@@ -442,6 +694,80 @@ pub fn barrier_price(
 }
 
 /// Simple fixed-rate bond dirty price using flat yield discounting.
+fn checked_bond_price(
+    face_value: f64,
+    coupon_rate: f64,
+    maturity_years: f64,
+    yield_rate: f64,
+    frequency: u32,
+) -> Result<f64, String> {
+    validate_positive_input("face_value", "face_values", None, face_value)?;
+    validate_non_negative_input("coupon_rate", "coupon_rates", None, coupon_rate)?;
+    validate_positive_input("maturity_years", "maturities", None, maturity_years)?;
+    validate_finite_input("yield_rate", "yield_rates", None, yield_rate)?;
+    if frequency == 0 {
+        return Err("`frequency` must be positive".to_string());
+    }
+
+    let frequency_f64 = f64::from(frequency);
+    let raw_periods = maturity_years * frequency_f64;
+    if !raw_periods.is_finite() {
+        return Err("`maturity_years * frequency` must be finite".to_string());
+    }
+    let periods = raw_periods.round();
+    if periods < 1.0 {
+        return Err(
+            "`maturity_years * frequency` must produce at least one coupon period".to_string(),
+        );
+    }
+    // Above 2^53, f64 cannot represent every integer period count exactly.
+    if periods > 9_007_199_254_740_992.0 {
+        return Err("coupon period count exceeds the exactly representable range".to_string());
+    }
+    // Allow ordinary multiplication roundoff, but never let a scale-relative
+    // tolerance grow large enough to classify a representable fractional
+    // period as an integer.
+    let period_tolerance = (8.0 * f64::EPSILON * raw_periods.abs().max(1.0)).min(0.25);
+    if (raw_periods - periods).abs() > period_tolerance {
+        return Err(
+            "`maturity_years * frequency` must be a whole number of coupon periods".to_string(),
+        );
+    }
+
+    let rate_per_period = yield_rate / frequency_f64;
+    let discount_base = 1.0 + rate_per_period;
+    if !discount_base.is_finite() || discount_base <= 0.0 {
+        return Err("`1 + yield_rate / frequency` must be finite and positive".to_string());
+    }
+
+    let coupon = face_value * coupon_rate / frequency_f64;
+    if !coupon.is_finite() {
+        return Err("coupon payment is non-finite for the supplied inputs".to_string());
+    }
+
+    let price = if rate_per_period == 0.0 {
+        coupon.mul_add(periods, face_value)
+    } else {
+        // Geometric-series closed form. exp_m1 avoids cancellation when the
+        // per-period yield is close to zero.
+        let discount_exponent = -periods * rate_per_period.ln_1p();
+        let maturity_discount = discount_exponent.exp();
+        let annuity_factor = -discount_exponent.exp_m1() / rate_per_period;
+        let coupon_pv = if coupon == 0.0 {
+            0.0
+        } else {
+            coupon * annuity_factor
+        };
+        face_value.mul_add(maturity_discount, coupon_pv)
+    };
+
+    if !price.is_finite() || price < 0.0 {
+        Err("bond price is non-finite or negative for the supplied inputs".to_string())
+    } else {
+        Ok(price)
+    }
+}
+
 #[wasm_bindgen]
 pub fn bond_price(
     face_value: f64,
@@ -450,25 +776,14 @@ pub fn bond_price(
     yield_rate: f64,
     frequency: u32,
 ) -> Result<f64, JsValue> {
-    require_positive("face_value", face_value)?;
-    require_non_negative("coupon_rate", coupon_rate)?;
-    require_positive("maturity_years", maturity_years)?;
-    require_finite("yield_rate", yield_rate)?;
-    if frequency == 0 {
-        return Err(js_error("`frequency` must be positive"));
-    }
-    let freq = frequency as f64;
-    let coupon = face_value * coupon_rate / freq;
-    let n_periods = (maturity_years * freq).round() as u32;
-    let r_per = yield_rate / freq;
-
-    let mut pv = 0.0;
-    for i in 1..=n_periods {
-        let df = (1.0 + r_per).powi(-(i as i32));
-        pv += coupon * df;
-    }
-    pv += face_value * (1.0 + r_per).powi(-(n_periods as i32));
-    Ok(pv)
+    checked_bond_price(
+        face_value,
+        coupon_rate,
+        maturity_years,
+        yield_rate,
+        frequency,
+    )
+    .map_err(js_error)
 }
 
 #[cfg(test)]
@@ -584,6 +899,41 @@ mod tests {
     }
 
     #[test]
+    fn checked_scalar_and_batch_bs_validation_are_consistent_and_indexed() {
+        let scalar = checked_bs_price(-1.0, 100.0, 0.05, 0.0, 0.2, 1.0, true, None)
+            .expect_err("negative scalar spot must be rejected");
+        let batch = checked_bs_price(-1.0, 100.0, 0.05, 0.0, 0.2, 1.0, true, Some(3))
+            .expect_err("negative batch spot must be rejected");
+        assert!(scalar.contains("`spot`"));
+        assert!(batch.contains("`spots[3]`"));
+
+        let scalar = checked_bsm_greeks(100.0, 100.0, 0.05, 0.0, f64::NAN, 1.0, true, None)
+            .expect_err("non-finite scalar volatility must be rejected");
+        let batch = checked_bsm_greeks(100.0, 100.0, 0.05, 0.0, f64::NAN, 1.0, true, Some(4))
+            .expect_err("non-finite batch volatility must be rejected");
+        assert!(scalar.contains("`vol`"));
+        assert!(batch.contains("`vols[4]`"));
+    }
+
+    #[test]
+    fn batch_option_flags_accept_only_documented_zero_or_one_values() {
+        assert!(!checked_option_flag(0, 0).unwrap());
+        assert!(checked_option_flag(1, 1).unwrap());
+        let error = checked_option_flag(3, 2).unwrap_err();
+        assert!(error.contains("`is_calls[3]`"), "unexpected: {error}");
+    }
+
+    #[test]
+    fn checked_pricing_rejects_non_finite_results() {
+        let bs = checked_bs_price(100.0, 100.0, -f64::MAX, 0.0, 0.2, 1.0, false, None);
+        assert!(bs.is_err());
+
+        let black76 = checked_black76_price(100.0, 100.0, -f64::MAX, 0.2, 1.0, true, Some(2))
+            .expect_err("overflowing discount factor must not cross the WASM ABI");
+        assert!(black76.contains("price[2]"));
+    }
+
+    #[test]
     fn batch_length_mismatch_is_rejected() {
         let err = crate::error::batch_length_error("spots", 2, &[("strikes", 1)]).unwrap_err();
         assert!(err.contains("strikes"));
@@ -635,6 +985,17 @@ mod tests {
         }
     }
 
+    #[test]
+    fn checked_black76_rejects_invalid_domains_with_batch_index() {
+        let price = checked_black76_price(-1.0, 100.0, 0.03, 0.2, 1.0, true, Some(6))
+            .expect_err("negative forward must be rejected");
+        assert!(price.contains("`forwards[6]`"));
+
+        let greeks = checked_black76_greeks(100.0, 100.0, 0.03, -0.2, 1.0, true, Some(7))
+            .expect_err("negative volatility must be rejected");
+        assert!(greeks.contains("`vols[7]`"));
+    }
+
     // -- black76_greeks_batch_wasm --
 
     #[test]
@@ -663,6 +1024,28 @@ mod tests {
         }
         assert!(black[3].is_finite());
         assert!(black[4].is_finite());
+    }
+
+    #[test]
+    fn black76_deep_tail_put_greeks_use_stable_core_values() {
+        let actual = checked_black76_greeks(5.0e18, 1.0e18, 0.0, 0.2, 1.0, false, Some(0)).unwrap();
+        // Independent SciPy ndtr references for the Black-76 formulas.
+        let expected = [
+            -1.862_397_753_202_606_3e-16,
+            1.539_548_175_331_966_1e-33,
+            7.697_740_876_659_831e3,
+            -7.697_740_876_659_832e2,
+            -2.275_288_460_097_726_8e1,
+            -6.117_540_594_728_432e-14,
+            2.492_038_143_976_294_4e6,
+        ];
+        for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+            let relative_error = ((actual - expected) / expected).abs();
+            assert!(
+                relative_error <= 2.0e-11,
+                "Greek {index}: actual={actual:.17e}, expected={expected:.17e}, relative_error={relative_error:.3e}"
+            );
+        }
     }
 
     // -- barrier_price --
@@ -711,5 +1094,52 @@ mod tests {
         // Coupon < yield → discount
         let price = bond_price(1000.0, 0.03, 10.0, 0.05, 2).unwrap();
         assert!(price < 1000.0);
+    }
+
+    #[test]
+    fn bond_price_zero_yield_uses_exact_coupon_sum() {
+        let price = checked_bond_price(1_000.0, 0.06, 10.0, 0.0, 2).unwrap();
+        assert_eq!(price, 1_600.0);
+    }
+
+    #[test]
+    fn bond_price_requires_a_valid_coupon_schedule_and_discount_base() {
+        assert!(
+            checked_bond_price(1_000.0, 0.05, 0.1, 0.05, 2)
+                .unwrap_err()
+                .contains("at least one")
+        );
+        assert!(
+            checked_bond_price(1_000.0, 0.05, 1.25, 0.05, 2)
+                .unwrap_err()
+                .contains("whole number")
+        );
+        assert!(
+            checked_bond_price(1_000.0, 0.05, 1.0, -2.0, 2)
+                .unwrap_err()
+                .contains("positive")
+        );
+
+        let large_half_period = 1_000_000_000_000_000.5_f64;
+        assert_eq!(large_half_period.fract(), 0.5);
+        assert!(
+            checked_bond_price(1_000.0, 0.05, large_half_period, 0.05, 1)
+                .unwrap_err()
+                .contains("whole number")
+        );
+    }
+
+    #[test]
+    fn bond_price_large_period_count_is_finite_without_period_iteration() {
+        let price = checked_bond_price(1_000.0, 0.05, 1_000_000.0, 0.05, 365)
+            .expect("closed-form annuity should handle a large integral period count");
+        assert!(price.is_finite());
+        assert!(price > 0.0);
+    }
+
+    #[test]
+    fn bond_price_rejects_overflowing_result() {
+        let result = checked_bond_price(f64::MAX, f64::MAX, 1.0, 0.0, 1);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Independent follow-up to the pricing/runtime work in #188, based on direct code review plus high-precision, differential, feature-matrix, and binding tests.

- Stabilize Black-Scholes, Black-76, Bachelier, digital, FX, Greek, and implied-volatility calculations in deep tails, subnormal regimes, and deterministic limits.
- Keep scalar and SIMD batch results consistent by routing numerically sensitive lanes through the stable scalar formulas while retaining portable runtime dispatch.
- Validate deserialized DSL IR, market/model inputs, path dimensions, finite values, local/state scope, schedules, JIT platform support, and backend results before evaluation.
- Make Monte Carlo callback failures deterministic and fallible; harden Python GIL/error propagation and reject invalid Python/WASM boundary inputs instead of returning silent NaN/infinity.
- Add focused regression, fuzz, MSRV, cross-platform runtime-test, and benchmark-regression coverage without adopting a machine-specific dispatch threshold.

## Notable failure modes covered

- Deep-tail put cancellation and a midpoint-tail Mills-ratio misclassification.
- Gamma and normal-model Greeks producing NaN through underflowed `0/0`.
- Implied-volatility convergence accepted without verifying the pricing residual.
- Invalid deserialized DSL products bypassing compiler invariants.
- Nondeterministic parallel callback error selection and Python exceptions converted to NaN.
- WASM option flags accepting undocumented values and bond pricing iterating attacker-sized period counts.
- Platform JIT and accelerated paths being compile-checked but not runtime-tested on Windows/macOS.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked -p openferric --no-default-features`
- `cargo test --locked --workspace --features accelerated-native`
- Python release wheel build and `pytest python/tests -q`: 222 passed
- `wasm-pack test --node wasm --locked`: 14 passed
- Portable and SIMD128 WASM compile checks
- Rust 1.92 MSRV checks for no-default, parallel, SIMD, JIT, accelerated-native, GPU, all-features, and the full workspace
- Rust 1.92 x86_64 macOS/Linux cross-checks for portable, SIMD, JIT/parallel, and all-features
- Fuzz workspace and `compiled_product_json` target compile checks
- Workflow YAML parse, actionlint, and benchmark-regression script self-tests
- Repository pre-commit hook: Rust fmt/Clippy, ESLint, TypeScript, Ruff lint/format

## Local hardware limitations

The review host is Apple ARM64. AVX2/AVX-512 and x86 JIT paths were cross-compiled but not executed on x86 hardware; GPU kernels and browser/threaded-WASM execution were not available locally. CI supplies native Linux/Windows/macOS/ARM64 execution, Node WASM coverage, and the hosted ARM64 benchmark sweep.
