### PR TITLE
Fix vol-swap convexity pricing, NEON tail consistency, and hot-path perf regressions

### DIFF
--- a/src/engines/analytic/black_scholes.rs
+++ b/src/engines/analytic/black_scholes.rs
@@ -145,15 +145,18 @@ pub fn bs_price(
         };
     }
     let is_call = matches!(option_type, OptionType::Call);
-    if super::bs_inline::requires_stable_price(
-        spot,
-        strike,
+    // Hoisted guard: reuses the discount factors above and yields the same
+    // d1/d2 the ordinary formula needs, so the stability check costs no extra
+    // transcendentals on the fast path.
+    let invariants = super::bs_inline::StablePriceInvariants::with_discounts(
         rate,
         dividend_yield,
         vol,
         expiry,
-        is_call,
-    ) {
+        df_r,
+        df_q,
+    );
+    let Some((d1, d2)) = invariants.ordinary_d1_d2(spot, strike, is_call) else {
         return super::bs_inline::stable_short_total_vol_price(
             spot,
             strike,
@@ -163,11 +166,11 @@ pub fn bs_price(
             expiry,
             is_call,
         );
-    }
+    };
 
     #[cfg(target_arch = "x86_64")]
     if super::bs_inline::has_fma_bs_kernel() {
-        return super::bs_inline::bs_price_asm(
+        return super::bs_inline::bs_price_asm_prechecked(
             spot,
             strike,
             rate,
@@ -178,7 +181,6 @@ pub fn bs_price(
         );
     }
 
-    let (d1, d2) = d1_d2(spot, strike, rate, dividend_yield, vol, expiry);
     // Compute call, derive put via put-call parity to halve CDF evaluations.
     let nd1 = norm_cdf(d1);
     let nd2 = norm_cdf(d2);
@@ -421,10 +423,24 @@ fn bs_price_greeks_with_dividend(
 
     // Shared intermediates — computed exactly once.
     let sqrt_t = expiry.sqrt();
-    let (d1, d2) = d1_d2(spot, strike, rate, dividend_yield, vol, expiry);
-
     let df_r = (-rate * expiry).exp();
     let df_q = (-dividend_yield * expiry).exp();
+    let is_call = matches!(option_type, OptionType::Call);
+
+    // Hoisted guard: shares the discount factors above and hands back the
+    // ordinary d1/d2 directly, falling back to the log-domain form only for
+    // sensitive elements.
+    let invariants = super::bs_inline::StablePriceInvariants::with_discounts(
+        rate,
+        dividend_yield,
+        vol,
+        expiry,
+        df_r,
+        df_q,
+    );
+    let ordinary = invariants.ordinary_d1_d2(spot, strike, is_call);
+    let (d1, d2) =
+        ordinary.unwrap_or_else(|| d1_d2(spot, strike, rate, dividend_yield, vol, expiry));
 
     let nd1 = norm_cdf(d1);
     let nd2 = norm_cdf(d2);
@@ -435,17 +451,7 @@ fn bs_price_greeks_with_dividend(
     let s_df_q = spot * df_q;
     let k_df_r = strike * df_r;
     let call = s_df_q.mul_add(nd1, -(k_df_r * nd2));
-    let is_call = matches!(option_type, OptionType::Call);
-    let sensitive_price = super::bs_inline::requires_stable_price(
-        spot,
-        strike,
-        rate,
-        dividend_yield,
-        vol,
-        expiry,
-        is_call,
-    )
-    .then(|| {
+    let sensitive_price = ordinary.is_none().then(|| {
         super::bs_inline::stable_short_total_vol_price(
             spot,
             strike,

--- a/src/engines/analytic/bs_inline.rs
+++ b/src/engines/analytic/bs_inline.rs
@@ -113,6 +113,144 @@ pub(crate) fn stable_theta_diffusion(scale: f64, vol: f64, sqrt_expiry: f64) -> 
     }
 }
 
+/// Batch-invariant terms of [`requires_stable_price`], hoisted so a loop over
+/// options sharing `(rate, dividend_yield, vol, expiry)` pays the sqrt, exp,
+/// and carry setup once and each element only one log-moneyness evaluation.
+pub(crate) struct StablePriceInvariants {
+    width: f64,
+    carry: f64,
+    pub(crate) df_r: f64,
+    pub(crate) df_q: f64,
+    always_stable: bool,
+    /// `S/K` at the call-side tail boundary `midpoint == -8`; spot/strike
+    /// ratios safely above it cannot be a call deep tail.
+    call_tail_bound: f64,
+    /// `S/K` at the put-side tail boundary `midpoint == +8`.
+    put_tail_bound: f64,
+    /// Both ratio bounds are finite and positive, so the multiply-and-compare
+    /// fast pass is usable.
+    tail_bounds_usable: bool,
+}
+
+/// Relative margin around the ratio bounds inside which the guard falls back
+/// to the exact log-domain test, so fast-pass conclusions are always certain
+/// despite rounding differences between `exp`-bound and `ln`-based forms.
+const TAIL_BOUND_MARGIN: f64 = 1.0e-9;
+
+impl StablePriceInvariants {
+    #[inline]
+    pub(crate) fn new(rate: f64, dividend_yield: f64, vol: f64, expiry: f64) -> Self {
+        Self::with_discounts(
+            rate,
+            dividend_yield,
+            vol,
+            expiry,
+            (-rate * expiry).exp(),
+            (-dividend_yield * expiry).exp(),
+        )
+    }
+
+    /// Variant for callers that already hold the discount factors.
+    #[inline]
+    pub(crate) fn with_discounts(
+        rate: f64,
+        dividend_yield: f64,
+        vol: f64,
+        expiry: f64,
+        df_r: f64,
+        df_q: f64,
+    ) -> Self {
+        let width = vol * expiry.sqrt();
+        Self {
+            width,
+            carry: stable_carry(rate, dividend_yield, expiry),
+            df_r,
+            df_q,
+            always_stable: width <= ACCURATE_CDF_TOTAL_VOL,
+            call_tail_bound: f64::NAN,
+            put_tail_bound: f64::NAN,
+            tail_bounds_usable: false,
+        }
+    }
+
+    /// Enables the multiply-and-compare tail fast pass in
+    /// [`Self::requires_stable`]. Costs two `exp` evaluations, so it pays for
+    /// itself only when the guard runs over a batch; single-shot callers that
+    /// consume [`Self::ordinary_d1_d2`] should skip it.
+    #[inline]
+    pub(crate) fn with_ratio_fast_pass(mut self) -> Self {
+        let call_tail_bound = ((-LOG_DOMAIN_TAIL_MIDPOINT) * self.width - self.carry).exp();
+        let put_tail_bound = (LOG_DOMAIN_TAIL_MIDPOINT * self.width - self.carry).exp();
+        self.call_tail_bound = call_tail_bound;
+        self.put_tail_bound = put_tail_bound;
+        self.tail_bounds_usable = call_tail_bound.is_finite()
+            && call_tail_bound > 0.0
+            && put_tail_bound.is_finite()
+            && put_tail_bound > 0.0;
+        self
+    }
+
+    #[inline]
+    pub(crate) fn requires_stable(&self, spot: f64, strike: f64, is_call: bool) -> bool {
+        if self.always_stable
+            || !(spot * self.df_q).is_finite()
+            || !(strike * self.df_r).is_finite()
+        {
+            return true;
+        }
+        // Fast pass: a spot/strike ratio safely inside the tail bounds cannot
+        // be a deep tail, decided with one multiply and compare instead of a
+        // log evaluation. Only certain conclusions short-circuit; ratios near
+        // or beyond a bound (and unusable bounds) take the exact test, so the
+        // routing decision is always identical to the log-domain form.
+        if self.tail_bounds_usable {
+            if is_call {
+                if spot > strike * (self.call_tail_bound * (1.0 + TAIL_BOUND_MARGIN)) {
+                    return false;
+                }
+            } else if spot < strike * (self.put_tail_bound * (1.0 - TAIL_BOUND_MARGIN)) {
+                return false;
+            }
+        }
+        let midpoint = (stable_log_spot_strike(spot, strike) + self.carry) / self.width;
+        if is_call {
+            midpoint <= -LOG_DOMAIN_TAIL_MIDPOINT
+        } else {
+            midpoint >= LOG_DOMAIN_TAIL_MIDPOINT
+        }
+    }
+
+    /// `Some((d1, d2))` when the ordinary two-CDF formula is safe for this
+    /// element, computed with the same operation order as [`stable_d1_d2`]'s
+    /// nonzero-width branch so results are bit-identical; `None` when the
+    /// element must take the stable scalar path.
+    #[inline]
+    pub(crate) fn ordinary_d1_d2(
+        &self,
+        spot: f64,
+        strike: f64,
+        is_call: bool,
+    ) -> Option<(f64, f64)> {
+        if self.always_stable
+            || !(spot * self.df_q).is_finite()
+            || !(strike * self.df_r).is_finite()
+        {
+            return None;
+        }
+        let midpoint = (stable_log_spot_strike(spot, strike) + self.carry) / self.width;
+        let deep_tail = if is_call {
+            midpoint <= -LOG_DOMAIN_TAIL_MIDPOINT
+        } else {
+            midpoint >= LOG_DOMAIN_TAIL_MIDPOINT
+        };
+        if deep_tail {
+            return None;
+        }
+        let half_width = 0.5 * self.width;
+        Some((midpoint + half_width, midpoint - half_width))
+    }
+}
+
 /// Whether the ordinary two-CDF formula would lose a representable option
 /// value through cancellation, or cannot safely form its discounted scales.
 #[allow(clippy::too_many_arguments)]
@@ -126,22 +264,8 @@ pub(crate) fn requires_stable_price(
     expiry: f64,
     is_call: bool,
 ) -> bool {
-    let width = vol * expiry.sqrt();
-    if width <= ACCURATE_CDF_TOTAL_VOL
-        || !(spot * (-dividend_yield * expiry).exp()).is_finite()
-        || !(strike * (-rate * expiry).exp()).is_finite()
-    {
-        return true;
-    }
-
-    let log_forward_moneyness =
-        stable_log_spot_strike(spot, strike) + stable_carry(rate, dividend_yield, expiry);
-    let midpoint = log_forward_moneyness / width;
-    if is_call {
-        midpoint <= -LOG_DOMAIN_TAIL_MIDPOINT
-    } else {
-        midpoint >= LOG_DOMAIN_TAIL_MIDPOINT
-    }
+    StablePriceInvariants::new(rate, dividend_yield, vol, expiry)
+        .requires_stable(spot, strike, is_call)
 }
 
 #[inline]
@@ -544,6 +668,26 @@ pub fn bs_price_asm(
     bs_price_scalar_reference(spot, strike, rate, dividend_yield, vol, expiry, is_call)
 }
 
+/// x86 kernel entry for inputs already validated and tail-routed by
+/// [`crate::engines::analytic::black_scholes::bs_price`]; skips the duplicate
+/// guard in [`bs_price_asm`]. The caller must have checked
+/// [`has_fma_bs_kernel`].
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::too_many_arguments)]
+#[inline]
+pub(crate) fn bs_price_asm_prechecked(
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    dividend_yield: f64,
+    vol: f64,
+    expiry: f64,
+    is_call: bool,
+) -> f64 {
+    // SAFETY: the caller verified AVX/FMA support via `has_fma_bs_kernel`.
+    unsafe { bs_price_asm_impl(spot, strike, rate, dividend_yield, vol, expiry, is_call) }
+}
+
 #[cfg(target_arch = "x86_64")]
 #[allow(clippy::too_many_arguments)]
 #[target_feature(enable = "avx,fma")]
@@ -607,6 +751,47 @@ unsafe fn bs_price_asm_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ratio_fast_pass_matches_log_domain_tail_decision() {
+        let (r, q, t) = (0.02_f64, 0.01_f64, 1.5_f64);
+        for vol in [0.05_f64, 0.2, 0.8] {
+            let plain = StablePriceInvariants::new(r, q, vol, t);
+            let invariants = StablePriceInvariants::new(r, q, vol, t).with_ratio_fast_pass();
+            let width = vol * t.sqrt();
+            let carry = stable_carry(r, q, t);
+            // Midpoints across and tightly around the ±8 tail boundary.
+            for midpoint_target in [
+                -12.0_f64, -8.001, -8.0, -7.999, -4.0, 0.0, 4.0, 7.999, 8.0, 8.001, 12.0,
+            ] {
+                let strike = 100.0_f64;
+                let spot = strike * (midpoint_target * width - carry).exp();
+                let midpoint = (stable_log_spot_strike(spot, strike) + carry) / width;
+                for is_call in [true, false] {
+                    let exact = if is_call {
+                        midpoint <= -LOG_DOMAIN_TAIL_MIDPOINT
+                    } else {
+                        midpoint >= LOG_DOMAIN_TAIL_MIDPOINT
+                    };
+                    assert_eq!(
+                        invariants.requires_stable(spot, strike, is_call),
+                        exact,
+                        "fast-pass mismatch vol={vol} midpoint={midpoint} is_call={is_call}"
+                    );
+                    assert_eq!(
+                        plain.requires_stable(spot, strike, is_call),
+                        exact,
+                        "plain-guard mismatch vol={vol} midpoint={midpoint} is_call={is_call}"
+                    );
+                    assert_eq!(
+                        invariants.ordinary_d1_d2(spot, strike, is_call).is_none(),
+                        exact,
+                        "ordinary_d1_d2 mismatch vol={vol} midpoint={midpoint} is_call={is_call}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn asm_wrapper_matches_reference_price_within_1e14() {

--- a/src/engines/analytic/bs_simd.rs
+++ b/src/engines/analytic/bs_simd.rs
@@ -82,8 +82,12 @@ fn batch_requires_scalar(
     t: f64,
     is_call: bool,
 ) -> bool {
-    let df_r = (-r * t).exp();
-    let df_q = (-q * t).exp();
+    // Hoist the guard's sqrt/exp/carry setup out of the per-element scan; the
+    // ratio fast pass then decides most elements with a multiply and compare.
+    let invariants =
+        super::bs_inline::StablePriceInvariants::new(r, q, vol, t).with_ratio_fast_pass();
+    let df_r = invariants.df_r;
+    let df_q = invariants.df_q;
     let vector_drift = (0.5 * vol).mul_add(vol, r - q) * t;
     !r.is_finite()
         || !q.is_finite()
@@ -98,7 +102,7 @@ fn batch_requires_scalar(
                 || !(spot * df_q).is_finite()
                 || !(strike * df_r).is_finite()
                 || !(spot / strike).is_finite()
-                || super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call)
+                || invariants.requires_stable(spot, strike, is_call)
         })
 }
 
@@ -266,8 +270,9 @@ pub fn bs_price_batch_into(
     assert_eq!(spots.len(), out.len(), "output length must match input");
     let backend = selected_price_backend(spots, strikes, r, q, vol, t, is_call);
     if matches!(backend, BatchSimdBackend::Scalar) {
+        let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
         for i in 0..spots.len() {
-            out[i] = bs_price_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+            out[i] = bs_price_scalar_with(&invariants, spots[i], strikes[i], r, q, vol, t, is_call);
         }
         return;
     }
@@ -303,8 +308,9 @@ pub fn bs_price_batch_into(
         _ => {}
     }
 
+    let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
     for i in 0..spots.len() {
-        out[i] = bs_price_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+        out[i] = bs_price_scalar_with(&invariants, spots[i], strikes[i], r, q, vol, t, is_call);
     }
 }
 
@@ -366,8 +372,10 @@ pub fn bs_greeks_batch_into(
         || !simd_is_worthwhile(n, backend)
         || batch_requires_scalar(spots, strikes, r, q, vol, t, is_call)
     {
+        let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
         for i in 0..n {
-            let (d, g, v, th) = bs_greeks_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+            let (d, g, v, th) =
+                bs_greeks_scalar_with(&invariants, spots[i], strikes[i], r, q, vol, t, is_call);
             delta[i] = d;
             gamma[i] = g;
             vega[i] = v;
@@ -417,8 +425,10 @@ pub fn bs_greeks_batch_into(
         _ => {}
     }
 
+    let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
     for i in 0..n {
-        let (d, g, v, th) = bs_greeks_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+        let (d, g, v, th) =
+            bs_greeks_scalar_with(&invariants, spots[i], strikes[i], r, q, vol, t, is_call);
         delta[i] = d;
         gamma[i] = g;
         vega[i] = v;
@@ -426,8 +436,38 @@ pub fn bs_greeks_batch_into(
     }
 }
 
+// Shared by every batch backend's scalar route and tail loop (including the
+// NEON path in `math::simd_neon`): tails must use the same `normal_cdf_approx`
+// family as the vector bodies, or odd-length batches price their last element
+// with a different CDF than the lanes.
 #[inline]
-fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_call: bool) -> f64 {
+pub(crate) fn bs_price_scalar(
+    spot: f64,
+    strike: f64,
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> f64 {
+    let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
+    bs_price_scalar_with(&invariants, spot, strike, r, q, vol, t, is_call)
+}
+
+/// Core of [`bs_price_scalar`] taking hoisted batch invariants, so scalar
+/// loops over a homogeneous batch pay the sqrt/exp/carry setup once.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn bs_price_scalar_with(
+    invariants: &super::bs_inline::StablePriceInvariants,
+    spot: f64,
+    strike: f64,
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> f64 {
     if !spot.is_finite()
         || !strike.is_finite()
         || !r.is_finite()
@@ -449,8 +489,8 @@ fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_
         };
     }
 
-    let df_r = (-r * t).exp();
-    let df_q = (-q * t).exp();
+    let df_r = invariants.df_r;
+    let df_q = invariants.df_q;
     if spot == 0.0 {
         return if is_call { 0.0 } else { strike * df_r };
     }
@@ -464,10 +504,9 @@ fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_
             (strike * df_r - spot * df_q).max(0.0)
         };
     }
-    if super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call) {
+    let Some((d1, d2)) = invariants.ordinary_d1_d2(spot, strike, is_call) else {
         return super::bs_inline::stable_short_total_vol_price(spot, strike, r, q, vol, t, is_call);
-    }
-    let (d1, d2) = super::bs_inline::stable_d1_d2(spot, strike, r, q, vol, t);
+    };
 
     let s_df_q = spot * df_q;
     let k_df_r = strike * df_r;
@@ -493,6 +532,23 @@ fn bs_greeks_scalar(
     t: f64,
     is_call: bool,
 ) -> (f64, f64, f64, f64) {
+    let invariants = super::bs_inline::StablePriceInvariants::new(r, q, vol, t);
+    bs_greeks_scalar_with(&invariants, spot, strike, r, q, vol, t, is_call)
+}
+
+/// Core of [`bs_greeks_scalar`] taking hoisted batch invariants.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn bs_greeks_scalar_with(
+    invariants: &super::bs_inline::StablePriceInvariants,
+    spot: f64,
+    strike: f64,
+    r: f64,
+    q: f64,
+    vol: f64,
+    t: f64,
+    is_call: bool,
+) -> (f64, f64, f64, f64) {
     if !spot.is_finite()
         || !strike.is_finite()
         || !r.is_finite()
@@ -510,8 +566,8 @@ fn bs_greeks_scalar(
         return (0.0, 0.0, 0.0, 0.0);
     }
 
-    let df_r = (-r * t).exp();
-    let df_q = (-q * t).exp();
+    let df_r = invariants.df_r;
+    let df_q = invariants.df_q;
     if spot == 0.0 {
         return if is_call {
             (0.0, 0.0, 0.0, 0.0)
@@ -547,14 +603,14 @@ fn bs_greeks_scalar(
 
     let sqrt_t = t.sqrt();
     let sig_sqrt_t = vol * sqrt_t;
-    let (d1, d2) = super::bs_inline::stable_d1_d2(spot, strike, r, q, vol, t);
+    let ordinary = invariants.ordinary_d1_d2(spot, strike, is_call);
+    let (d1, d2) =
+        ordinary.unwrap_or_else(|| super::bs_inline::stable_d1_d2(spot, strike, r, q, vol, t));
 
     let pdf = normal_pdf_scalar(d1);
 
     // Only 2 CDF evaluations; derive N(-d) = 1 - N(d) for puts.
-    let cdf = if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL
-        || super::bs_inline::requires_stable_price(spot, strike, r, q, vol, t, is_call)
-    {
+    let cdf = if sig_sqrt_t <= ACCURATE_CDF_TOTAL_VOL || ordinary.is_none() {
         accurate_norm_cdf
     } else {
         normal_cdf_approx

--- a/src/engines/analytic/variance_swap.rs
+++ b/src/engines/analytic/variance_swap.rs
@@ -192,8 +192,8 @@ pub fn volatility_swap_mtm(
 
     let expected_realized_vol = instrument
         .observed_realized_var
-        .unwrap_or(fair_variance)
-        .sqrt();
+        .map(f64::sqrt)
+        .unwrap_or(fair_volatility);
     let payoff = instrument.notional_vega * (expected_realized_vol - instrument.strike_vol);
 
     Ok((-rate * instrument.expiry).exp() * payoff)
@@ -304,5 +304,29 @@ mod tests {
 
         assert_relative_eq!(fair_variance, 0.04, epsilon = 2e-4);
         assert_relative_eq!(fair_volatility, 0.20, epsilon = 5e-4);
+    }
+
+    #[test]
+    fn volatility_swap_at_convexity_adjusted_strike_marks_to_zero() {
+        let fair_variance = 0.04;
+        let var_of_var = 1.0e-4;
+        let fair_volatility =
+            fair_volatility_strike_from_variance(fair_variance, var_of_var).unwrap();
+        assert!(fair_volatility < fair_variance.sqrt());
+
+        let quotes = flat_surface_quotes(100.0, 0.01, 0.20, 1.0);
+        let swap = VolatilitySwap::new(1_000.0, fair_volatility, 1.0, quotes, var_of_var);
+        let mtm = volatility_swap_mtm(&swap, fair_variance, fair_volatility, 0.01).unwrap();
+        assert_relative_eq!(mtm, 0.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn volatility_swap_seasoned_mtm_uses_observed_realized_vol() {
+        let quotes = flat_surface_quotes(100.0, 0.02, 0.20, 0.5);
+        let swap =
+            VolatilitySwap::new(100.0, 0.25, 0.5, quotes, 1.0e-4).with_observed_realized_var(0.09);
+        let mtm = volatility_swap_mtm(&swap, 0.04, 0.19, 0.02).unwrap();
+        let expected = (-0.02_f64 * 0.5).exp() * 100.0 * (0.3 - 0.25);
+        assert_relative_eq!(mtm, expected, epsilon = 1e-12);
     }
 }

--- a/src/market/market.rs
+++ b/src/market/market.rs
@@ -50,17 +50,58 @@ impl VolSurface for crate::vol::surface::VolSurface {
 }
 
 /// Serializable sampled volatility surface using bilinear interpolation.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+///
+/// Grid validation is cached: the first successful [`validate`] marks the
+/// surface so later calls (one per engine `price` boundary) are O(1) instead
+/// of rescanning the whole grid. The token is skipped by serde and reset by
+/// `clone`, so deserialized, hand-built, and cloned-then-modified surfaces
+/// are always re-checked. Mutating the public fields of an already-validated
+/// surface in place is not detected — build a new surface (or clone first)
+/// instead.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct SampledVolSurface {
     pub strikes: Vec<f64>,
     pub expiries: Vec<f64>,
     pub vols: Vec<Vec<f64>>,
+    #[serde(skip)]
+    validated: std::sync::atomic::AtomicBool,
+}
+
+impl Clone for SampledVolSurface {
+    fn clone(&self) -> Self {
+        // Reset the token: bump-and-reprice flows clone then mutate, and a
+        // carried token would let the mutation skip validation.
+        Self {
+            strikes: self.strikes.clone(),
+            expiries: self.expiries.clone(),
+            vols: self.vols.clone(),
+            validated: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+impl PartialEq for SampledVolSurface {
+    fn eq(&self, other: &Self) -> bool {
+        self.strikes == other.strikes && self.expiries == other.expiries && self.vols == other.vols
+    }
 }
 
 impl SampledVolSurface {
     /// Validates a sampled surface, including values that may have entered
     /// through deserialization rather than [`SampledVolSurface::new`].
     pub fn validate(&self) -> Result<(), String> {
+        use std::sync::atomic::Ordering;
+        if self.validated.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        self.validate_grid()?;
+        // Racing validators recompute the same deterministic result; Relaxed
+        // is enough for a monotonic set-once flag.
+        self.validated.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn validate_grid(&self) -> Result<(), String> {
         if self.strikes.len() < 2 || self.expiries.len() < 2 {
             return Err("sampled surface requires >= 2 strikes and >= 2 expiries".to_string());
         }
@@ -107,6 +148,7 @@ impl SampledVolSurface {
             strikes,
             expiries,
             vols,
+            validated: std::sync::atomic::AtomicBool::new(false),
         };
         surface.validate()?;
         Ok(surface)
@@ -161,6 +203,7 @@ impl SampledVolSurface {
             strikes,
             expiries,
             vols,
+            validated: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -655,12 +698,28 @@ mod tests {
 
     #[test]
     fn deserialized_sampled_surface_shape_and_finiteness_are_revalidated() {
-        let surface = SampledVolSurface {
-            strikes: vec![90.0, f64::NAN],
-            expiries: vec![0.5, 1.0],
-            vols: vec![vec![0.2, 0.21], vec![0.22, 0.23]],
-        };
+        let json =
+            r#"{"strikes":[90.0,100.0],"expiries":[0.5,1.0],"vols":[[0.2,0.21],[0.22,-0.23]]}"#;
+        let surface: SampledVolSurface = serde_json::from_str(json).unwrap();
         assert!(surface.validate().is_err());
+    }
+
+    #[test]
+    fn sampled_surface_validation_cache_is_reset_on_clone() {
+        let surface = SampledVolSurface::new(
+            vec![90.0, 100.0],
+            vec![0.5, 1.0],
+            vec![vec![0.2, 0.21], vec![0.22, 0.23]],
+        )
+        .unwrap();
+        // Cached fast path stays Ok on repeat validation.
+        assert!(surface.validate().is_ok());
+        assert!(surface.validate().is_ok());
+
+        // A clone must re-check, so mutations after cloning are caught.
+        let mut mutated = surface.clone();
+        mutated.vols[1][0] = -0.5;
+        assert!(mutated.validate().is_err());
     }
 
     #[test]

--- a/src/math/simd_neon.rs
+++ b/src/math/simd_neon.rs
@@ -381,19 +381,11 @@ pub unsafe fn norm_cdf_f64x2(x: float64x2_t) -> float64x2_t {
 
 #[inline]
 fn bs_price_scalar(spot: f64, strike: f64, r: f64, q: f64, vol: f64, t: f64, is_call: bool) -> f64 {
-    crate::engines::analytic::black_scholes::bs_price(
-        if is_call {
-            crate::core::OptionType::Call
-        } else {
-            crate::core::OptionType::Put
-        },
-        spot,
-        strike,
-        r,
-        q,
-        vol,
-        t,
-    )
+    // Must stay CDF-consistent with the NEON vector body (A&S
+    // `normal_cdf_approx`), like the AVX2/AVX-512 tails: routing the tail
+    // through the accurate-CDF pricer makes the last element of an odd-length
+    // batch differ from the lane-computed value by ~1e-5.
+    crate::engines::analytic::bs_simd::bs_price_scalar(spot, strike, r, q, vol, t, is_call)
 }
 
 /// Prices a homogeneous Black-Scholes batch with AArch64 NEON where safe.
@@ -454,14 +446,14 @@ pub unsafe fn bs_price_neon_batch_into(
     );
 
     let vector_drift = (r - q + 0.5 * vol * vol) * t;
+    // Hoisted guard: the sqrt/exp/carry terms are uniform across the batch.
+    let invariants = crate::engines::analytic::bs_inline::StablePriceInvariants::new(r, q, vol, t)
+        .with_ratio_fast_pass();
     let requires_scalar = t <= 0.0
         || vol <= 0.0
         || !vector_drift.is_finite()
         || spots.iter().zip(strikes.iter()).any(|(&spot, &strike)| {
-            !(spot / strike).is_finite()
-                || crate::engines::analytic::bs_inline::requires_stable_price(
-                    spot, strike, r, q, vol, t, is_call,
-                )
+            !(spot / strike).is_finite() || invariants.requires_stable(spot, strike, is_call)
         });
     if requires_scalar {
         for i in 0..spots.len() {

--- a/tests/simd_test.rs
+++ b/tests/simd_test.rs
@@ -1721,4 +1721,28 @@ mod neon_tests {
             }
         }
     }
+
+    #[test]
+    fn neon_odd_length_tail_matches_vector_lanes() {
+        use openferric::engines::analytic::bs_simd::bs_price_batch;
+
+        let (s, k, r, q, vol, t) = (100.0_f64, 105.0_f64, 0.02, 0.0, 0.2, 1.0);
+        for &is_call in &[true, false] {
+            for n in [9usize, 17, 33] {
+                let spots = vec![s; n];
+                let strikes = vec![k; n];
+                let out = bs_price_batch(&spots, &strikes, r, q, vol, t, is_call);
+                let lane = out[0];
+                for (i, &price) in out.iter().enumerate() {
+                    // The scalar tail shares the vector body's A&S CDF family;
+                    // only ULP-level ln/FMA grouping differences remain.
+                    assert!(
+                        (price - lane).abs() <= 1e-12 * lane.abs(),
+                        "n={n} is_call={is_call} idx {i}: tail={price} lane={lane} diff={}",
+                        (price - lane).abs()
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the four highest-impact findings from the independent audit of the #188–#190 hardening series.

### Correctness

- **Volatility-swap MTM used `sqrt(fair_variance)` instead of the convexity-adjusted `fair_volatility`** it validated and then discarded (`variance_swap.rs`). Long vol swaps with `var_of_var > 0` were systematically overpriced by `df·N_vega·var_of_var/(8·K_var^1.5)` while diagnostics reported the adjusted strike. Seasoned swaps still use `sqrt(observed_realized_var)`.
- **NEON batch-price tail lane priced with a different CDF than the vector lanes** (introduced in #190): the odd-length tail routed through the accurate Cody CDF while lanes used the A&S approximation, making the last element of a length-9 batch differ from identical-input lanes by ~1.15e-5. The tail now shares `bs_simd::bs_price_scalar` like the AVX2/AVX-512 tails; measured divergence is now ~2.8e-14 (ULP-level ln grouping).

### Performance (measured on Apple M4 vs pre-hardening baseline `2c81207`)

- **`StablePriceInvariants`** hoists the stability guard's sqrt/exp/carry setup out of per-element loops and returns the ordinary d1/d2 directly, so `bs_price`, `bs_price_greeks_with_dividend`, and the batch scalar routes validate once per call/batch; the x86 FMA path skips its duplicated guard via a prechecked kernel entry. Routing decisions are bit-identical (boundary-sweep consistency test).
- **Ratio fast pass** (opt-in) for batch guards: the deep-tail test compares `S/K` against precomputed `exp(±8·width − carry)` bounds — one multiply+compare per element — falling back to the exact log-domain test near the boundary so decisions never change.
- **`SampledVolSurface` caches successful grid validation** in a serde-skipped, clone-reset `AtomicBool`, so repeated `Market::validate()` calls are O(1). Deserialized, hand-built, and cloned-then-mutated surfaces are still fully re-checked; only in-place mutation of an already-validated surface's public fields is undetected (documented).

| Benchmark | Baseline `2c81207` | Before | After |
|---|---|---|---|
| `Market::validate`, 30×30 grid | — | 971 ns | 7.6 ns |
| `engine.price`, sampled-surface market | — | 991 ns | 38 ns |
| batch SIMD `bs_price`, n=100k | 1.66 ms | 2.60 ms | 2.07 ms |
| batch scalar `bs_price`, n=1k | 15.7 µs | 28.8 µs | 23.4 µs |
| auto-dispatch batch, n=7 | — | 242 ns | 153 ns |

Remaining gap to the pre-hardening baseline is the cost of the added validation semantics themselves plus the NEON per-vector subnormal repair (separate audit finding, untouched here).

## Tests

- Vol swap at the convexity-adjusted strike marks to zero (fails on the old code); seasoned swaps use observed realized vol.
- NEON odd-length batches (9/17/33, calls and puts) match vector lanes to 1e-12 relative.
- Ratio fast pass, plain guard, and `ordinary_d1_d2` agree across ±8-midpoint boundary sweeps.
- Sampled-vol validation cache: repeat-Ok, reset on clone (mutated clone fails), deserialized invalid surface fails.

## Validation

- `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets --all-features` — clean
- `cargo test --locked --workspace --features accelerated-native` — all 55 suites pass
- `cargo test --locked -p openferric --no-default-features` — all 50 suites pass
- `cargo test --locked -p openferric --all-features` (Metal GPU + JIT) — all 50 suites pass
- Criterion before/after runs for `pricing_bench`, `hot_paths_bench`, `simd_bench` plus a sampled-surface micro-bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)