### PR TITLE
Fix seven pricing correctness bugs found in a full asset-class audit

### DIFF
--- a/python/src/instruments.rs
+++ b/python/src/instruments.rs
@@ -3180,6 +3180,28 @@ impl Tarf {
         }
     }
 
+    /// Decumulator TARF: `ko_barrier` is a downside barrier and must be below
+    /// the strike (or `float('inf')` for no barrier).
+    #[staticmethod]
+    fn decumulator(
+        strike: f64,
+        notional_per_fixing: f64,
+        ko_barrier: f64,
+        target_profit: f64,
+        downside_leverage: f64,
+        fixing_times: Vec<f64>,
+    ) -> Self {
+        Self {
+            strike,
+            notional_per_fixing,
+            ko_barrier,
+            target_profit,
+            downside_leverage,
+            fixing_times,
+            tarf_type: "decumulator".to_string(),
+        }
+    }
+
     fn validate(&self) -> PyResult<()> {
         self.to_core()?.validate().map_err(map_err_string)
     }

--- a/python/src/rates.rs
+++ b/python/src/rates.rs
@@ -1127,6 +1127,10 @@ impl FixedRateBond {
         self.to_core().dirty_price(&curve.inner)
     }
 
+    fn dirty_price_at(&self, curve: &YieldCurve, settlement: f64) -> f64 {
+        self.to_core().dirty_price_at(&curve.inner, settlement)
+    }
+
     fn clean_price(&self, curve: &YieldCurve, settlement: f64) -> f64 {
         self.to_core().clean_price(&curve.inner, settlement)
     }

--- a/src/credit/cdo.rs
+++ b/src/credit/cdo.rs
@@ -29,7 +29,8 @@ pub struct CdoTranche {
 pub struct SyntheticCdo {
     /// Number of names in the reference pool.
     pub num_names: usize,
-    /// Flat pool spread proxy used as a constant hazard level in this LHP approximation.
+    /// Flat pool par spread in decimal (e.g. 0.01 for 100 bps). Converted to a
+    /// constant hazard rate via the credit triangle `h = s / (1 - R)`.
     pub pool_spread: f64,
     /// Recovery rate.
     pub recovery_rate: f64,
@@ -79,8 +80,13 @@ impl CdoTranche {
 }
 
 impl SyntheticCdo {
+    /// Constant pool hazard rate implied by the pool par spread via the credit
+    /// triangle `h = s / (1 - R)`, matching `credit::isda::hazard_from_par_spread`.
+    ///
+    /// Guards recovery internally (returns 0 unless `0 <= R < 1`) because this
+    /// method is public and callable without validation having run.
     pub fn hazard_rate(&self) -> f64 {
-        self.pool_spread.max(0.0)
+        crate::credit::isda::hazard_from_par_spread(self.pool_spread, self.recovery_rate)
     }
 
     pub fn default_probability(&self, t: f64) -> f64 {
@@ -183,7 +189,8 @@ impl SyntheticCdo {
     }
 
     fn discount_factor(&self, t: f64) -> f64 {
-        (-self.risk_free_rate.max(0.0) * t.max(0.0)).exp()
+        // Any finite (including negative) flat rate is admissible.
+        (-self.risk_free_rate * t.max(0.0)).exp()
     }
 
     fn is_valid(&self) -> bool {
@@ -356,22 +363,78 @@ mod tests {
         let spread_senior_bps = cdo.fair_spread(&senior) * 1.0e4;
         assert!(spread_equity_bps > spread_mezz_bps);
         assert!(spread_mezz_bps > spread_senior_bps);
+        // Ranges recentred after fixing hazard_rate() to use the credit
+        // triangle h = s/(1-R). With s=100bp, R=0.4, rho=0.30, r=5%, 5y
+        // quarterly the fair spreads are approximately equity 2490 bps,
+        // mezz 780 bps, senior 29 bps.
         assert!(
-            (500.0..=1700.0).contains(&spread_equity_bps),
+            (2000.0..=3000.0).contains(&spread_equity_bps),
             "equity spread: {spread_equity_bps:.2} bps"
         );
         assert!(
-            (100.0..=450.0).contains(&spread_mezz_bps),
+            (550.0..=1000.0).contains(&spread_mezz_bps),
             "mezz spread: {spread_mezz_bps:.2} bps"
         );
         assert!(
-            (10.0..=60.0).contains(&spread_senior_bps),
+            (15.0..=60.0).contains(&spread_senior_bps),
             "senior spread: {spread_senior_bps:.2} bps"
         );
 
         let tranche_sum = el_equity + el_mezz + el_senior;
         let portfolio_el = cdo.portfolio_expected_loss(t);
         assert_relative_eq!(tranche_sum, portfolio_el, epsilon = 4.0e-3);
+    }
+
+    fn audit_cdo() -> SyntheticCdo {
+        SyntheticCdo {
+            num_names: 125,
+            pool_spread: 0.01,
+            recovery_rate: 0.4,
+            correlation: 0.30,
+            risk_free_rate: 0.05,
+            maturity: 5.0,
+            payment_freq: 4,
+        }
+    }
+
+    #[test]
+    fn hazard_rate_uses_credit_triangle() {
+        let cdo = audit_cdo();
+        // Credit triangle (O'Kane 2008, Ch. 5): h = s / (1 - R) = 0.01 / 0.6.
+        assert_relative_eq!(cdo.hazard_rate(), 0.01 / 0.6, epsilon = 1.0e-15);
+        // Must agree exactly with the crate's canonical conversion.
+        assert_relative_eq!(
+            cdo.hazard_rate(),
+            crate::credit::isda::hazard_from_par_spread(cdo.pool_spread, cdo.recovery_rate),
+            epsilon = 0.0
+        );
+    }
+
+    #[test]
+    fn hazard_rate_guards_degenerate_recovery() {
+        let mut cdo = audit_cdo();
+        cdo.recovery_rate = 1.0;
+        assert_eq!(cdo.hazard_rate(), 0.0);
+        cdo.recovery_rate = -0.1;
+        assert_eq!(cdo.hazard_rate(), 0.0);
+        // Negative spread floors at zero hazard.
+        cdo.recovery_rate = 0.4;
+        cdo.pool_spread = -0.01;
+        assert_eq!(cdo.hazard_rate(), 0.0);
+    }
+
+    #[test]
+    fn discount_factor_honours_negative_rates() {
+        let mut cdo = audit_cdo();
+        cdo.risk_free_rate = -0.02;
+        // DF(t) = exp(-r t) = exp(0.02 * 2) for r = -2%; the old code floored
+        // the rate at 0 and returned exp(0) = 1.
+        assert_relative_eq!(
+            cdo.discount_factor(2.0),
+            (0.02_f64 * 2.0).exp(),
+            epsilon = 1.0e-15
+        );
+        assert!(cdo.discount_factor(2.0) > 1.0);
     }
 
     #[test]

--- a/src/engines/fft/carr_madan.rs
+++ b/src/engines/fft/carr_madan.rs
@@ -26,6 +26,18 @@ pub const DEFAULT_ALPHA: f64 = 1.5;
 /// Default Carr-Madan frequency spacing.
 pub const DEFAULT_ETA: f64 = 0.25;
 const REAL_FFT_EPS: f64 = 1e-14;
+/// Smallest damping alpha the automatic admissibility fallback will accept.
+const MIN_ADMISSIBLE_ALPHA: f64 = 0.1;
+/// Relative safety margin on the damping moment when auto-selecting a
+/// fallback alpha. A moment that exists only marginally (e.g. VG with the
+/// quadratic denominator barely positive) makes `E[S_T^(alpha+1)]` blow up
+/// and the trapezoid quadrature cannot resolve the resulting integrand peak,
+/// so fallback alphas must sit safely inside the admissible region.
+const FALLBACK_MOMENT_MARGIN: f64 = 1.05;
+/// Upper bound on the FFT size the admissibility fallback may grow to when it
+/// refines the frequency grid alongside a reduced alpha (2^18 complex samples
+/// = 4 MiB per buffer).
+const MAX_FALLBACK_FFT_N: usize = 1 << 18;
 
 /// Carr-Madan FFT configuration.
 #[derive(Debug, Clone, Copy)]
@@ -102,6 +114,12 @@ pub struct CarrMadanContext {
 
 impl CarrMadanContext {
     /// Builds a reusable pricing context for a fixed model/market configuration.
+    ///
+    /// The requested damping `params.alpha` is validated against the model's
+    /// exponential moments: if `E[S_T^(alpha+1)]` is not finite the context
+    /// automatically falls back to the largest admissible smaller alpha and
+    /// errors when none exists. The effective parameters are reported by
+    /// [`CarrMadanContext::params`].
     pub fn new<C: CharacteristicFunction>(
         cf: &C,
         rate: f64,
@@ -109,7 +127,6 @@ impl CarrMadanContext {
         spot: f64,
         params: CarrMadanParams,
     ) -> Result<Self, String> {
-        params.validate()?;
         if !spot.is_finite() || spot <= 0.0 {
             return Err("carr-madan context requires spot > 0".to_string());
         }
@@ -117,7 +134,8 @@ impl CarrMadanContext {
             return Err("carr-madan context requires maturity >= 0".to_string());
         }
 
-        let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params);
+        let params = resolve_admissible_params(cf, params)?;
+        let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params)?;
         Ok(Self {
             rate,
             maturity,
@@ -190,20 +208,100 @@ fn quadrature_weight(index: usize, eta: f64) -> f64 {
 /// Re-sync interval for accumulated phase rotation to bound floating-point drift.
 const PHASE_RESYNC_INTERVAL: usize = 128;
 
+/// Resolves damping-admissible Carr-Madan parameters for the given model.
+///
+/// Carr-Madan damping with `alpha` requires `E[S_T^(alpha+1)]` to be finite
+/// (Carr & Madan 1999); an inadmissible alpha makes the damped integrand
+/// non-integrable and the transform returns garbage (zero or below-intrinsic
+/// calls) rather than failing. When the requested alpha is inadmissible this
+/// halves alpha until an admissible value is found (floor
+/// `MIN_ADMISSIBLE_ALPHA`) and errors out when none exists.
+///
+/// A reduced alpha sharpens the damped integrand's peak near `v = 0` (the
+/// denominator `alpha^2 + alpha - v^2 + i(2alpha+1)v` has magnitude
+/// `~alpha(alpha+1)` at the origin, so the peak width scales with alpha).
+/// The requested eta was chosen for the requested alpha and under-resolves
+/// that sharper peak — with the default eta = 0.25 an alpha of 0.1875 leaves
+/// a strike-independent quadrature error of ~0.9 currency units (a 10x error
+/// on OTM puts recovered via parity). Fallback params therefore refine eta by
+/// the same factor alpha was reduced by and grow n to preserve the frequency
+/// range, capped at [`MAX_FALLBACK_FFT_N`].
+pub(crate) fn resolve_admissible_params<C: CharacteristicFunction>(
+    cf: &C,
+    params: CarrMadanParams,
+) -> Result<CarrMadanParams, String> {
+    params.validate()?;
+    if cf.moment_exists(params.alpha + 1.0) {
+        return Ok(params);
+    }
+
+    // Auto-selected alphas demand a small moment margin so the fallback never
+    // lands razor-thin against the model's moment-explosion boundary.
+    let fallback_admissible = |alpha: f64| cf.moment_exists((alpha + 1.0) * FALLBACK_MOMENT_MARGIN);
+
+    // Refines the frequency grid for a fallback alpha: eta shrinks by the
+    // alpha-reduction factor and n grows to keep the integration range
+    // `n * eta` unchanged. n stays a power of two; if the cap binds, eta is
+    // only refined by the granted factor so the range never shrinks.
+    let refine_grid = |alpha: f64| -> CarrMadanParams {
+        let factor = (params.alpha / alpha).ceil() as usize;
+        let factor = factor.next_power_of_two().max(1);
+        let n = params
+            .n
+            .saturating_mul(factor)
+            .min(MAX_FALLBACK_FFT_N)
+            .max(params.n);
+        let granted = (n / params.n).max(1);
+        CarrMadanParams {
+            n,
+            eta: params.eta / granted as f64,
+            alpha,
+        }
+    };
+
+    let mut alpha = 0.5 * params.alpha;
+    while alpha > MIN_ADMISSIBLE_ALPHA {
+        if fallback_admissible(alpha) {
+            return Ok(refine_grid(alpha));
+        }
+        alpha *= 0.5;
+    }
+    if params.alpha > MIN_ADMISSIBLE_ALPHA && fallback_admissible(MIN_ADMISSIBLE_ALPHA) {
+        return Ok(refine_grid(MIN_ADMISSIBLE_ALPHA));
+    }
+
+    Err(format!(
+        "carr-madan damping alpha={} is inadmissible: E[S_T^{}] is not finite for this model \
+         and no fallback alpha down to {} is admissible; the model's exponential moments \
+         explode, so FFT call prices would be meaningless",
+        params.alpha,
+        params.alpha + 1.0,
+        MIN_ADMISSIBLE_ALPHA
+    ))
+}
+
 pub(crate) fn build_weighted_frequency_samples<C: CharacteristicFunction>(
     cf: &C,
     rate: f64,
     maturity: f64,
     params: CarrMadanParams,
-) -> Vec<Complex<f64>> {
+) -> Result<Vec<Complex<f64>>, String> {
     let mut out = vec![Complex::new(0.0, 0.0); params.n];
     for (j, out_j) in out.iter_mut().enumerate() {
         let vj = j as f64 * params.eta;
         let uj = Complex::new(vj, -(params.alpha + 1.0));
         let psi = modified_cf(cf, uj, rate, maturity, params.alpha);
+        if !psi.is_finite() {
+            return Err(format!(
+                "carr-madan integrand is non-finite at frequency v={vj} (alpha={}): the \
+                 characteristic function overflowed or is undefined on the damping contour; \
+                 check model parameters",
+                params.alpha
+            ));
+        }
         *out_j = psi * quadrature_weight(j, params.eta);
     }
-    out
+    Ok(out)
 }
 
 #[inline]
@@ -250,7 +348,7 @@ fn decode_fft_output(
     transformed: Vec<Complex<f64>>,
     params: CarrMadanParams,
     k0: f64,
-) -> Vec<(f64, f64)> {
+) -> Result<Vec<(f64, f64)>, String> {
     let lambda = params.lambda();
     // Pre-compute the exponential decay exp(-alpha * k) via accumulation.
     // k = k0 + m * lambda, so exp(-alpha * k) = exp(-alpha * k0) * exp(-alpha * lambda)^m.
@@ -262,11 +360,20 @@ fn decode_fft_output(
     let mut out = Vec::with_capacity(params.n);
     for (m, z) in transformed.into_iter().enumerate() {
         let strike = (k0 + m as f64 * lambda).exp();
-        let call = (exp_alpha_k * z.re * inv_pi).max(0.0);
-        out.push((strike, call));
+        let call = exp_alpha_k * z.re * inv_pi;
+        if !call.is_finite() {
+            return Err(format!(
+                "carr-madan FFT produced a non-finite call price at strike {strike}: \
+                 characteristic function values overflowed on the damping contour"
+            ));
+        }
+        // Only small negative truncation noise in the far wings is clamped;
+        // non-finite values are propagated as errors above instead of being
+        // masked to zero.
+        out.push((strike, call.max(0.0)));
         exp_alpha_k *= exp_step;
     }
-    out
+    Ok(out)
 }
 
 fn carr_madan_fft_from_weighted_samples(
@@ -290,7 +397,7 @@ fn carr_madan_fft_from_weighted_samples(
     let mut fft_input = weighted_samples.to_vec();
     apply_phase_in_place(&mut fft_input, params.eta, k0);
     let transformed = transform_fft_input(fft_input, allow_real_fft);
-    Ok(decode_fft_output(transformed, params, k0))
+    decode_fft_output(transformed, params, k0)
 }
 
 fn carr_madan_fft_impl<C: CharacteristicFunction>(
@@ -301,14 +408,14 @@ fn carr_madan_fft_impl<C: CharacteristicFunction>(
     params: CarrMadanParams,
     allow_real_fft: bool,
 ) -> Result<Vec<(f64, f64)>, String> {
-    params.validate()?;
     if !spot.is_finite() || spot <= 0.0 {
         return Err("carr-madan requires spot > 0".to_string());
     }
     if !maturity.is_finite() || maturity < 0.0 {
         return Err("carr-madan requires maturity >= 0".to_string());
     }
-    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params);
+    let params = resolve_admissible_params(cf, params)?;
+    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params)?;
     carr_madan_fft_from_weighted_samples(&weighted_samples, spot, params, allow_real_fft)
 }
 
@@ -390,13 +497,13 @@ pub fn carr_madan_fft_greeks<C: CharacteristicFunction>(
     spot: f64,
     params: CarrMadanParams,
 ) -> Result<Vec<CarrMadanGreeksPoint>, String> {
-    params.validate()?;
     if !spot.is_finite() || spot <= 0.0 {
         return Err("carr-madan greeks require spot > 0".to_string());
     }
     if !maturity.is_finite() || maturity < 0.0 {
         return Err("carr-madan greeks require maturity >= 0".to_string());
     }
+    let params = resolve_admissible_params(cf, params)?;
 
     let lambda = params.lambda();
     let b = 0.5 * params.n as f64 * lambda;
@@ -460,6 +567,19 @@ pub fn carr_madan_fft_greeks<C: CharacteristicFunction>(
             x_dvol[j] = common * cf.dcf_dvol(uj).expect("dcf_dvol should be available");
         }
 
+        if !x_price[j].is_finite()
+            || !x_d1[j].is_finite()
+            || !x_d2[j].is_finite()
+            || !x_dvol[j].is_finite()
+        {
+            return Err(format!(
+                "carr-madan greeks integrand is non-finite at frequency v={vj} (alpha={}): the \
+                 characteristic function overflowed or is undefined on the damping contour; \
+                 check model parameters",
+                params.alpha
+            ));
+        }
+
         phase *= phase_step;
     }
 
@@ -485,7 +605,14 @@ pub fn carr_madan_fft_greeks<C: CharacteristicFunction>(
         let strike = (k0 + m as f64 * lambda).exp();
         let pref = exp_alpha_k * inv_pi;
 
-        let call = (pref * x_price[m].re).max(0.0);
+        let raw_call = pref * x_price[m].re;
+        if !raw_call.is_finite() {
+            return Err(format!(
+                "carr-madan greeks FFT produced a non-finite call price at strike {strike}"
+            ));
+        }
+        // Clamp only finite negative truncation noise; non-finite values error above.
+        let call = raw_call.max(0.0);
 
         let dcdx = if supports_d1 {
             pref * x_d1[m].re
@@ -526,6 +653,11 @@ pub fn carr_madan_fft_greeks<C: CharacteristicFunction>(
 }
 
 /// Fallible Heston FFT API.
+///
+/// When the default damping alpha is inadmissible for the given parameters
+/// (the `(alpha+1)`-th spot moment explodes), a smaller admissible alpha is
+/// selected automatically; if none exists this returns an error instead of
+/// silently producing zero or below-intrinsic call prices.
 #[allow(clippy::too_many_arguments)]
 pub fn try_heston_price_fft(
     spot: f64,
@@ -558,7 +690,9 @@ pub fn try_heston_price_fft(
 
 /// Heston FFT convenience API.
 ///
-/// Prices all strikes simultaneously. Invalid inputs return an empty vector.
+/// Prices all strikes simultaneously. Invalid inputs — including parameter
+/// sets whose damping moment explodes and admits no fallback alpha — return
+/// an empty vector; use [`try_heston_price_fft`] for the error message.
 #[allow(clippy::too_many_arguments)]
 pub fn heston_price_fft(
     spot: f64,

--- a/src/engines/fft/char_fn.rs
+++ b/src/engines/fft/char_fn.rs
@@ -13,10 +13,39 @@ use num_complex::Complex;
 
 use crate::math::gamma::gamma;
 
+/// Relative imaginary-part tolerance for the default numerical moment probe.
+///
+/// When `E[S_T^m]` exists, `phi(-i*m)` is a positive real; legitimate models
+/// evaluate it with imaginary contamination on the order of f64 rounding
+/// (observed <= 1e-12 relative), while moment explosions and principal-branch
+/// crossings produce imaginary parts comparable to the real part.
+const MOMENT_PROBE_IM_TOL: f64 = 1e-8;
+
 /// Characteristic function interface for log-spot models.
 pub trait CharacteristicFunction {
     /// Returns the characteristic function value `phi(u)`.
     fn cf(&self, u: Complex<f64>) -> Complex<f64>;
+
+    /// Returns `true` when the exponential moment `E[S_T^order] = phi(-i*order)` is finite.
+    ///
+    /// Carr-Madan damping with parameter `alpha` requires the `(alpha + 1)`-th
+    /// moment of the underlying to be finite (Carr & Madan 1999, Section 2);
+    /// otherwise the damped integrand is not integrable and the transform
+    /// silently produces garbage prices.
+    ///
+    /// The default implementation probes the characteristic function at
+    /// `u = -i * order`. A finite moment evaluates to a positive real number;
+    /// a non-finite value, a non-positive real part, or a significant
+    /// imaginary part signals a moment explosion or a principal-branch
+    /// crossing on the damping contour. Models with closed-form moment bounds
+    /// should override this with the exact condition.
+    fn moment_exists(&self, order: f64) -> bool {
+        if !order.is_finite() {
+            return false;
+        }
+        let probe = self.cf(Complex::new(0.0, -order));
+        probe.is_finite() && probe.re > 0.0 && probe.im.abs() <= MOMENT_PROBE_IM_TOL * probe.re
+    }
 
     /// Optional derivative wrt log-spot (`x = ln(S0)`).
     fn dcf_dlog_spot(&self, _u: Complex<f64>) -> Option<Complex<f64>> {
@@ -63,6 +92,11 @@ impl CharacteristicFunction for BlackScholesCharFn {
         let drift = self.ln_spot + (self.rate - self.dividend_yield - 0.5 * sigma2) * self.maturity;
         let exponent = i * u * drift - 0.5 * sigma2 * u * u * self.maturity;
         exponent.exp()
+    }
+
+    fn moment_exists(&self, order: f64) -> bool {
+        // The lognormal distribution has finite moments of every order.
+        order.is_finite()
     }
 
     fn dcf_dlog_spot(&self, u: Complex<f64>) -> Option<Complex<f64>> {
@@ -221,6 +255,18 @@ impl CharacteristicFunction for VarianceGammaCharFn {
         drift_term * vg_term
     }
 
+    fn moment_exists(&self, order: f64) -> bool {
+        // E[S_T^m] is finite iff the CF denominator stays positive at u = -i*m:
+        // 1 - theta*nu*m - 0.5*sigma^2*nu*m^2 > 0 (Madan, Carr & Chang 1998).
+        // When it is negative, denom^(-T/nu) continues onto the principal branch
+        // and returns finite but meaningless values.
+        order.is_finite()
+            && 1.0
+                - self.theta * self.nu * order
+                - 0.5 * self.sigma * self.sigma * self.nu * order * order
+                > 0.0
+    }
+
     fn dcf_dlog_spot(&self, u: Complex<f64>) -> Option<Complex<f64>> {
         let i = Complex::new(0.0, 1.0);
         Some(i * u * self.cf(u))
@@ -317,6 +363,14 @@ impl CharacteristicFunction for CgmyCharFn {
         log_phi.exp()
     }
 
+    fn moment_exists(&self, order: f64) -> bool {
+        // Tempered-stable exponential moments: E[e^{m*X}] < inf iff -G < m < M
+        // (Carr, Geman, Madan & Yor 2002). At m >= M the base of
+        // (M - i*u)^Y turns negative real on the contour and powc crosses the
+        // principal branch cut.
+        order.is_finite() && order < self.m && order > -self.g
+    }
+
     fn dcf_dlog_spot(&self, u: Complex<f64>) -> Option<Complex<f64>> {
         let i = Complex::new(0.0, 1.0);
         Some(i * u * self.cf(u))
@@ -402,6 +456,14 @@ impl CharacteristicFunction for NigCharFn {
         log_phi.exp()
     }
 
+    fn moment_exists(&self, order: f64) -> bool {
+        // NIG exponential moments: E[e^{m*X}] < inf iff |beta + m| < alpha
+        // (Barndorff-Nielsen 1997). The risk-neutral constructor only enforces
+        // the martingale condition |beta + 1| < alpha, which does not cover
+        // higher damping moments.
+        order.is_finite() && (self.beta + order).abs() < self.alpha
+    }
+
     fn dcf_dlog_spot(&self, u: Complex<f64>) -> Option<Complex<f64>> {
         let i = Complex::new(0.0, 1.0);
         Some(i * u * self.cf(u))
@@ -439,5 +501,51 @@ mod tests {
 
         let bad = VarianceGammaCharFn::risk_neutral(100.0, 0.02, 0.0, 1.0, 1.0, 2.0, 2.0);
         assert!(bad.is_err());
+    }
+
+    #[test]
+    fn heston_moment_probe_flags_exploding_parameterization() {
+        // Moment-exploding set from the FFT admissibility audit: rho=+0.7,
+        // xi=1.5, T=5 has Andersen-Piterbarg discriminant
+        // beta^2 + xi^2*(m - m^2) = (-2.125)^2 + 2.25*(2.5 - 6.25) < 0 at
+        // m = 2.5 and the explosion time is below T=5.
+        let bad = HestonCharFn::new(100.0, 0.02, 0.0, 5.0, 0.04, 0.5, 0.04, 1.5, 0.7);
+        assert!(!bad.moment_exists(2.5));
+
+        // Healthy set (rho=-0.7, xi=0.4): discriminant 4.84 - 0.6 > 0, so the
+        // 2.5-th moment is finite for every maturity.
+        let good = HestonCharFn::new(100.0, 0.02, 0.0, 1.0, 0.04, 1.5, 0.04, 0.4, -0.7);
+        assert!(good.moment_exists(2.5));
+        assert!(good.moment_exists(1.0));
+    }
+
+    #[test]
+    fn vg_moment_bound_matches_quadratic_condition() {
+        // sigma=0.3, theta=0.3, nu=1.5: quadratic root at m = 1.7584..., so
+        // the Carr-Madan default damping moment 2.5 must be rejected
+        // (denominator 1 - 0.45*2.5 - 0.0675*6.25 = -0.546875).
+        let cf = VarianceGammaCharFn::risk_neutral(100.0, 0.02, 0.0, 1.0, 0.3, 0.3, 1.5)
+            .expect("martingale condition holds (0.4825 > 0)");
+        assert!(!cf.moment_exists(2.5));
+        assert!(cf.moment_exists(1.75));
+        assert!(!cf.moment_exists(1.76));
+    }
+
+    #[test]
+    fn cgmy_moment_bound_requires_order_below_m() {
+        let cf = CgmyCharFn::risk_neutral(100.0, 0.02, 0.0, 1.0, 0.5, 5.0, 1.2, 0.5)
+            .expect("constructor only requires M > 1");
+        assert!(!cf.moment_exists(2.5));
+        assert!(!cf.moment_exists(1.2));
+        assert!(cf.moment_exists(1.1));
+    }
+
+    #[test]
+    fn nig_moment_bound_requires_shifted_beta_inside_alpha() {
+        let cf = NigCharFn::risk_neutral(100.0, 0.02, 0.0, 1.0, 2.0, 0.5, 0.5)
+            .expect("constructor only requires |beta + 1| < alpha");
+        assert!(!cf.moment_exists(2.5));
+        assert!(!cf.moment_exists(1.5));
+        assert!(cf.moment_exists(1.4));
     }
 }

--- a/src/engines/fft/frft.rs
+++ b/src/engines/fft/frft.rs
@@ -13,7 +13,9 @@ use std::f64::consts::PI;
 
 use num_complex::Complex;
 
-use super::carr_madan::{CarrMadanParams, build_weighted_frequency_samples};
+use super::carr_madan::{
+    CarrMadanParams, build_weighted_frequency_samples, resolve_admissible_params,
+};
 use super::char_fn::CharacteristicFunction;
 use super::fft_core::{fft_forward, fft_inverse};
 
@@ -65,6 +67,10 @@ pub fn frft(input: &[Complex<f64>], beta: f64) -> Vec<Complex<f64>> {
 }
 
 /// Carr-Madan with FRFT on a uniform log-strike grid.
+///
+/// The damping alpha is validated against the model's exponential moments and
+/// automatically reduced to an admissible value when necessary; errors when
+/// no admissible alpha exists.
 pub fn carr_madan_frft_grid<C: CharacteristicFunction>(
     cf: &C,
     rate: f64,
@@ -73,7 +79,8 @@ pub fn carr_madan_frft_grid<C: CharacteristicFunction>(
     log_strike_spacing: f64,
     params: CarrMadanParams,
 ) -> Result<Vec<(f64, f64)>, String> {
-    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params);
+    let params = resolve_admissible_params(cf, params)?;
+    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params)?;
     carr_madan_frft_grid_from_weighted_samples(
         &weighted_samples,
         log_strike_start,
@@ -124,8 +131,15 @@ fn carr_madan_frft_grid_from_weighted_samples(
     for (m, z) in transformed.into_iter().enumerate() {
         let k = log_strike_start + m as f64 * log_strike_spacing;
         let strike = k.exp();
-        let call = ((-params.alpha * k).exp() * z.re / PI).max(0.0);
-        out.push((strike, call));
+        let call = (-params.alpha * k).exp() * z.re / PI;
+        if !call.is_finite() {
+            return Err(format!(
+                "carr-madan FRFT produced a non-finite call price at strike {strike}: \
+                 characteristic function values overflowed on the damping contour"
+            ));
+        }
+        // Clamp only finite negative truncation noise; non-finite values error above.
+        out.push((strike, call.max(0.0)));
     }
 
     Ok(out)
@@ -136,7 +150,7 @@ fn direct_carr_madan_at_log_strike(
     eta: f64,
     alpha: f64,
     log_strike: f64,
-) -> f64 {
+) -> Result<f64, String> {
     let i = Complex::new(0.0, 1.0);
     let mut sum = Complex::new(0.0, 0.0);
 
@@ -145,7 +159,15 @@ fn direct_carr_madan_at_log_strike(
         sum += *sample * (-i * vj * log_strike).exp();
     }
 
-    ((-alpha * log_strike).exp() * sum.re / PI).max(0.0)
+    let call = (-alpha * log_strike).exp() * sum.re / PI;
+    if !call.is_finite() {
+        return Err(format!(
+            "carr-madan direct summation produced a non-finite call price at log-strike \
+             {log_strike}: characteristic function values overflowed on the damping contour"
+        ));
+    }
+    // Clamp only finite negative truncation noise; non-finite values error above.
+    Ok(call.max(0.0))
 }
 
 fn has_uniform_spacing(values: &[f64], tol: f64) -> Option<f64> {
@@ -172,6 +194,10 @@ fn has_uniform_spacing(values: &[f64], tol: f64) -> Option<f64> {
 ///
 /// - Uses FRFT when strikes are uniformly spaced in log-strike.
 /// - Falls back to direct Carr-Madan summation otherwise.
+///
+/// The damping alpha is validated against the model's exponential moments and
+/// automatically reduced to an admissible value when necessary; errors when
+/// no admissible alpha exists.
 pub fn carr_madan_price_at_strikes<C: CharacteristicFunction>(
     cf: &C,
     rate: f64,
@@ -180,7 +206,8 @@ pub fn carr_madan_price_at_strikes<C: CharacteristicFunction>(
     strikes: &[f64],
     params: CarrMadanParams,
 ) -> Result<Vec<(f64, f64)>, String> {
-    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params);
+    let params = resolve_admissible_params(cf, params)?;
+    let weighted_samples = build_weighted_frequency_samples(cf, rate, maturity, params)?;
     carr_madan_price_at_strikes_with_samples(&weighted_samples, strikes, params)
 }
 
@@ -233,7 +260,7 @@ pub fn carr_madan_price_at_strikes_with_samples(
 
     for (orig_idx, strike, log_k) in indexed {
         let price =
-            direct_carr_madan_at_log_strike(weighted_samples, params.eta, params.alpha, log_k);
+            direct_carr_madan_at_log_strike(weighted_samples, params.eta, params.alpha, log_k)?;
         out[orig_idx] = (strike, price);
     }
 

--- a/src/engines/lsm/longstaff_schwartz.rs
+++ b/src/engines/lsm/longstaff_schwartz.rs
@@ -20,8 +20,9 @@ use crate::core::{
 };
 use crate::engines::monte_carlo::mc_engine::RunningMoments;
 use crate::engines::monte_carlo::simulate_gbm_paths_soa;
+use crate::engines::tree::binomial::{escrowed_exercise_adjustments, escrowed_root_spot};
 use crate::instruments::{BarrierOption, BermudanOption, VanillaOption};
-use crate::market::Market;
+use crate::market::{DividendEvent, Market};
 use crate::math::fast_norm::beasley_springer_moro_inv_cdf;
 use crate::math::fast_rng::{Xoshiro256PlusPlus, uniform_open01};
 use crate::models::Heston;
@@ -185,14 +186,19 @@ impl QuadraticRegressionSums {
     }
 }
 
+/// Regression sums over in-the-money paths.
+///
+/// `filter_strike` decides moneyness on the simulated (possibly escrowed)
+/// path level, while `scale` normalizes the regression basis; the two differ
+/// when discrete dividends shift the effective exercise strike per step.
 fn regression_sums(
     spots: &[f64],
     values: &[f64],
     option_type: OptionType,
-    strike: f64,
+    filter_strike: f64,
+    scale: f64,
 ) -> QuadraticRegressionSums {
     debug_assert_eq!(spots.len(), values.len());
-    let scale = strike;
 
     #[cfg(feature = "parallel")]
     if spots.len() >= 8_192 {
@@ -205,7 +211,7 @@ fn regression_sums(
             .map(|(spot_chunk, value_chunk)| {
                 let mut sums = QuadraticRegressionSums::default();
                 for (&spot, &value) in spot_chunk.iter().zip(value_chunk) {
-                    if intrinsic(option_type, spot, strike) > 0.0 {
+                    if intrinsic(option_type, spot, filter_strike) > 0.0 {
                         sums.add(spot / scale, value / scale);
                     }
                 }
@@ -221,7 +227,7 @@ fn regression_sums(
 
     let mut sums = QuadraticRegressionSums::default();
     for (&spot, &value) in spots.iter().zip(values) {
-        if intrinsic(option_type, spot, strike) > 0.0 {
+        if intrinsic(option_type, spot, filter_strike) > 0.0 {
             sums.add(spot / scale, value / scale);
         }
     }
@@ -280,6 +286,25 @@ fn boundary_from_exercised(option_type: OptionType, exercised_spots: &[f64]) -> 
 }
 
 impl LongstaffSchwartzEngine {
+    /// Escrowed-model reconstruction table `(prop, cash)` per uniform time
+    /// step, or `None` when the market carries no discrete dividends.
+    ///
+    /// Simulated Bermudan paths hold the escrowed spot `S*`; the observed
+    /// spot at step `ti` is `S = (S* + cash) / prop`.
+    fn escrowed_recon_table(&self, market: &Market, expiry: f64) -> Option<Vec<(f64, f64)>> {
+        if !market.has_discrete_dividends() {
+            return None;
+        }
+        Some(
+            (0..=self.num_steps)
+                .map(|ti| {
+                    let t = expiry * ti as f64 / self.num_steps as f64;
+                    market.escrowed_reconstruction(t, expiry)
+                })
+                .collect(),
+        )
+    }
+
     fn simulate_bermudan_paths(
         &self,
         instrument: &BermudanOption,
@@ -288,8 +313,10 @@ impl LongstaffSchwartzEngine {
     ) -> Result<(Vec<f64>, usize), PricingError> {
         let dt = instrument.expiry / self.num_steps as f64;
         let sqrt_dt = dt.sqrt();
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let drift_rn = market.rate - effective_dividend_yield;
+        // Escrowed discrete-dividend model: simulate the escrowed spot S*
+        // with the true continuous yield only (no dividend smear).
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let drift_rn = market.rate - market.dividend_yield;
         let raw_stride = self.num_steps + 1;
         let stride = (raw_stride + 7) & !7;
         let mut paths = vec![0.0_f64; self.num_paths * stride];
@@ -302,7 +329,7 @@ impl LongstaffSchwartzEngine {
                 let step_vol = vol * sqrt_dt;
                 for pi in 0..self.num_paths {
                     let base = pi * stride;
-                    paths[base] = market.spot;
+                    paths[base] = spot0;
                     for ti in 1..=self.num_steps {
                         let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
                         paths[base + ti] = paths[base + ti - 1] * step_vol.mul_add(z, drift).exp();
@@ -310,13 +337,23 @@ impl LongstaffSchwartzEngine {
                 }
             }
             LsmDynamics::LocalVolEuler => {
+                // The local-vol surface is quoted in observed-spot space, so
+                // reconstruct S from the escrowed state for lookups.
+                let recon = self.escrowed_recon_table(market, instrument.expiry);
                 for pi in 0..self.num_paths {
                     let base = pi * stride;
-                    let mut s = market.spot;
+                    let mut s = spot0;
                     paths[base] = s;
                     for ti in 1..=self.num_steps {
                         let t = (ti as f64 * dt).max(1.0e-8);
-                        let sigma = market.checked_vol_for(s.max(1.0e-8), t)?;
+                        let s_obs = match &recon {
+                            Some(table) => {
+                                let (prop, cash) = table[ti - 1];
+                                (s + cash) / prop
+                            }
+                            None => s,
+                        };
+                        let sigma = market.checked_vol_for(s_obs.max(1.0e-8), t)?;
                         let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
                         let drift = (drift_rn - 0.5 * sigma * sigma) * dt;
                         s *= (drift + sigma * sqrt_dt * z).exp();
@@ -347,7 +384,7 @@ impl LongstaffSchwartzEngine {
                 }
                 for pi in 0..self.num_paths {
                     let base = pi * stride;
-                    let mut s = market.spot;
+                    let mut s = spot0;
                     let mut v = v0;
                     paths[base] = s;
                     for ti in 1..=self.num_steps {
@@ -397,6 +434,9 @@ impl LongstaffSchwartzEngine {
             PricingError::InvalidInput("bermudan schedule cannot be empty".to_string())
         })?;
         let (paths, stride) = self.simulate_bermudan_paths(instrument, market, terminal_strike)?;
+        // Paths hold the escrowed spot S*; exercise decisions reconstruct the
+        // observed spot per step (identity without discrete dividends).
+        let recon = self.escrowed_recon_table(market, instrument.expiry);
 
         let dt = instrument.expiry / self.num_steps as f64;
         let disc = (-market.rate * dt).exp();
@@ -437,9 +477,16 @@ impl LongstaffSchwartzEngine {
                 continue;
             };
 
+            // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P.
+            // The regression keeps S* as its basis variable — the observed
+            // spot is an affine map of S*, so the quadratic space is the same.
+            let (prop, cash) = recon.as_ref().map_or((1.0, 0.0), |table| table[ti]);
+            let ex_strike = strike.mul_add(prop, -cash);
+            let ex_scale = 1.0 / prop;
+
             itm.clear();
             itm.extend((0..self.num_paths).filter(|&idx| {
-                intrinsic(instrument.option_type, paths[idx * stride + ti], strike) > 0.0
+                intrinsic(instrument.option_type, paths[idx * stride + ti], ex_strike) > 0.0
             }));
 
             if itm.len() < 3 {
@@ -462,10 +509,11 @@ impl LongstaffSchwartzEngine {
                     * (beta[0]
                         + beta[1] * normalized_spot
                         + beta[2] * normalized_spot * normalized_spot);
-                let exercise = intrinsic(instrument.option_type, s, strike);
+                let exercise = intrinsic(instrument.option_type, s, ex_strike) * ex_scale;
                 if exercise > continuation {
                     values[idx] = exercise;
-                    exercised_spots.push(s);
+                    // Report boundary diagnostics in observed-spot units.
+                    exercised_spots.push((s + cash) / prop);
                 }
             }
 
@@ -537,17 +585,27 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
         let vol = market.checked_vol_for(instrument.strike, instrument.expiry)?;
 
         let dt = instrument.expiry / self.num_steps as f64;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
         let disc = (-market.rate * dt).exp();
+
+        // Escrowed discrete-dividend model: simulate the escrowed spot S*
+        // with the true continuous yield only, and strike-adjust exercise
+        // payoffs per step (identity without a schedule).
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let exercise_adj = escrowed_exercise_adjustments(
+            market,
+            instrument.strike,
+            instrument.expiry,
+            self.num_steps,
+        );
 
         // LSM regression reads one exercise date across every path. Store the
         // paths time-major so those scans are contiguous and let the shared SoA
         // simulator select AVX-512, AVX2/FMA, NEON, or scalar generation at
         // runtime.
         let paths = simulate_gbm_paths_soa(
-            market.spot,
+            spot0,
             market.rate,
-            effective_dividend_yield,
+            market.dividend_yield,
             vol,
             instrument.expiry,
             self.num_paths,
@@ -590,8 +648,19 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
                 continue;
             }
 
+            // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P.
+            let (ex_strike, ex_scale) = exercise_adj
+                .as_ref()
+                .map_or((instrument.strike, 1.0), |adj| adj[ti]);
+
             let spots = &paths.levels[ti];
-            let sums = regression_sums(spots, &values, instrument.option_type, instrument.strike);
+            let sums = regression_sums(
+                spots,
+                &values,
+                instrument.option_type,
+                ex_strike,
+                instrument.strike,
+            );
             if sums.count < 3 {
                 continue;
             }
@@ -604,7 +673,8 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
                     .par_iter_mut()
                     .zip(spots.par_iter())
                     .for_each(|(value, &spot)| {
-                        let exercise = intrinsic(instrument.option_type, spot, instrument.strike);
+                        let exercise =
+                            intrinsic(instrument.option_type, spot, ex_strike) * ex_scale;
                         if exercise > 0.0 {
                             let normalized_spot = spot / instrument.strike;
                             let continuation = instrument.strike
@@ -620,7 +690,7 @@ impl PricingEngine<VanillaOption> for LongstaffSchwartzEngine {
             }
 
             for (value, &spot) in values.iter_mut().zip(spots) {
-                let exercise = intrinsic(instrument.option_type, spot, instrument.strike);
+                let exercise = intrinsic(instrument.option_type, spot, ex_strike) * ex_scale;
                 if exercise > 0.0 {
                     let normalized_spot = spot / instrument.strike;
                     let continuation = instrument.strike
@@ -684,8 +754,18 @@ impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
         let vol = market.checked_vol_for(instrument.strike, instrument.expiry)?;
 
         let dt = instrument.expiry / self.num_steps as f64;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let drift = (market.rate - effective_dividend_yield - 0.5 * vol * vol) * dt;
+        // Barrier monitoring depends on the observed spot path, so discrete
+        // dividends are applied as true ex-date drops on the simulated path
+        // (spot model, matching the vanilla Monte Carlo barrier engine)
+        // instead of being smeared into an effective continuous yield.
+        let drift = (market.rate - market.dividend_yield - 0.5 * vol * vol) * dt;
+        let div_events: Vec<DividendEvent> = market
+            .dividends()
+            .events()
+            .iter()
+            .copied()
+            .filter(|ev| ev.time <= instrument.expiry + 1.0e-12)
+            .collect();
         let step_vol = vol * dt.sqrt();
         let discount = (-market.rate * instrument.expiry).exp();
 
@@ -707,6 +787,7 @@ impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
 
         for _ in 0..self.num_paths {
             path[0] = market.spot;
+            let mut ev_idx = 0usize;
 
             if use_simd {
                 #[cfg(all(feature = "simd", target_arch = "x86_64"))]
@@ -717,12 +798,24 @@ impl PricingEngine<BarrierOption> for LongstaffSchwartzEngine {
                     );
                 }
                 for ti in 0..self.num_steps {
-                    path[ti + 1] = path[ti] * step_vol.mul_add(normal_buf[ti], drift).exp();
+                    let mut s = path[ti] * step_vol.mul_add(normal_buf[ti], drift).exp();
+                    let t = (ti + 1) as f64 * dt;
+                    while ev_idx < div_events.len() && div_events[ev_idx].time <= t + 1.0e-12 {
+                        s = div_events[ev_idx].apply_jump(s);
+                        ev_idx += 1;
+                    }
+                    path[ti + 1] = s;
                 }
             } else {
                 for ti in 0..self.num_steps {
                     let z = beasley_springer_moro_inv_cdf(uniform_open01(rng.next_f64()));
-                    path[ti + 1] = path[ti] * step_vol.mul_add(z, drift).exp();
+                    let mut s = path[ti] * step_vol.mul_add(z, drift).exp();
+                    let t = (ti + 1) as f64 * dt;
+                    while ev_idx < div_events.len() && div_events[ev_idx].time <= t + 1.0e-12 {
+                        s = div_events[ev_idx].apply_jump(s);
+                        ev_idx += 1;
+                    }
+                    path[ti + 1] = s;
                 }
             }
 

--- a/src/engines/numerical/american_binomial.rs
+++ b/src/engines/numerical/american_binomial.rs
@@ -12,6 +12,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, PricingResult};
+use crate::engines::tree::binomial::{escrowed_exercise_adjustments, escrowed_root_spot};
 use crate::instruments::vanilla::VanillaOption;
 use crate::market::Market;
 use crate::math::arena::PricingArena;
@@ -66,6 +67,7 @@ fn rollback_american_binomial(
     d: f64,
     p: f64,
     disc: f64,
+    exercise_adj: Option<&[(f64, f64)]>,
 ) -> f64 {
     debug_assert!(values.len() > steps);
 
@@ -75,6 +77,8 @@ fn rollback_american_binomial(
     let one_minus_p = 1.0 - p;
 
     // Terminal payoffs: start at spot0 * d^steps, multiply by ratio each step.
+    // With discrete dividends the lattice carries the escrowed spot S*; no
+    // dividends remain at expiry, so the terminal payoff needs no adjustment.
     {
         let mut st = spot0 * d.powi(steps as i32);
         for value in values.iter_mut().take(steps + 1) {
@@ -86,10 +90,12 @@ fn rollback_american_binomial(
     // Rollback: maintain base = spot0 * d^i via multiplicative update.
     let mut base = spot0 * d.powi((steps - 1) as i32);
     for i in (0..steps).rev() {
+        // Escrowed model: intrinsic((S* + A)/P, K) == intrinsic(S*, K*P - A) / P.
+        let (ex_strike, ex_scale) = exercise_adj.map_or((strike, 1.0), |adj| adj[i]);
         let mut st = base;
         for j in 0..=i {
             let continuation = disc * (p * values[j + 1] + one_minus_p * values[j]);
-            let exercise = intrinsic(option_type, st, strike);
+            let exercise = intrinsic(option_type, st, ex_strike) * ex_scale;
             values[j] = continuation.max(exercise);
             st *= ratio;
         }
@@ -134,8 +140,12 @@ impl PricingEngine<VanillaOption> for AmericanBinomialEngine {
         let dt = instrument.expiry / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
+        // Escrowed discrete-dividend model: diffuse S* with the true
+        // continuous yield only and strike-adjust the exercise payoffs.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let exercise_adj =
+            escrowed_exercise_adjustments(market, instrument.strike, instrument.expiry, self.steps);
+        let growth = ((market.rate - market.dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(
@@ -150,26 +160,28 @@ impl PricingEngine<VanillaOption> for AmericanBinomialEngine {
             rollback_american_binomial(
                 values,
                 self.steps,
-                market.spot,
+                spot0,
                 instrument.strike,
                 instrument.option_type,
                 u,
                 d,
                 p,
                 disc,
+                exercise_adj.as_deref(),
             )
         } else {
             let mut values = vec![0.0_f64; self.steps + 1];
             rollback_american_binomial(
                 &mut values,
                 self.steps,
-                market.spot,
+                spot0,
                 instrument.strike,
                 instrument.option_type,
                 u,
                 d,
                 p,
                 disc,
+                exercise_adj.as_deref(),
             )
         };
 

--- a/src/engines/pde/crank_nicolson.rs
+++ b/src/engines/pde/crank_nicolson.rs
@@ -13,6 +13,8 @@ use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, Pricin
 use crate::instruments::{BermudanOption, vanilla::VanillaOption};
 use crate::market::Market;
 
+use super::fd_common::{EscrowedStep, escrowed_root_spot, escrowed_steps};
+
 /// Exercise-boundary estimate at a Bermudan decision time from Crank-Nicolson.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PdeExerciseBoundaryPoint {
@@ -126,6 +128,7 @@ fn boundary_values(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn bermudan_boundary_values(
     option_type: OptionType,
     step: usize,
@@ -134,6 +137,7 @@ fn bermudan_boundary_values(
     rate: f64,
     dividend_yield: f64,
     s_max: f64,
+    div_steps: Option<&[EscrowedStep]>,
 ) -> (f64, f64) {
     let future = step_schedule
         .iter()
@@ -141,12 +145,19 @@ fn bermudan_boundary_values(
         .skip(step)
         .filter_map(|(j, e)| e.map(|(_, k)| (j, k)));
 
+    // With discrete dividends the grid carries the escrowed spot S*, so a
+    // future exercise at step j pays intrinsic on the reconstructed spot:
+    // strike becomes k*P_j - A_j scaled by 1/P_j (identity without a schedule).
     match option_type {
         OptionType::Put => {
             let mut lower = 0.0_f64;
             for (j, k) in future {
                 let tau = (j - step) as f64 * dt;
-                lower = lower.max(k * (-rate * tau).exp());
+                let (k_ex, ex_scale) = match div_steps {
+                    Some(adj) => (adj[j].adjusted_strike(k), adj[j].scale()),
+                    None => (k, 1.0),
+                };
+                lower = lower.max(k_ex.max(0.0) * ex_scale * (-rate * tau).exp());
             }
             (lower, 0.0)
         }
@@ -154,8 +165,14 @@ fn bermudan_boundary_values(
             let mut upper = 0.0_f64;
             for (j, k) in future {
                 let tau = (j - step) as f64 * dt;
+                let (k_ex, ex_scale) = match div_steps {
+                    Some(adj) => (adj[j].adjusted_strike(k), adj[j].scale()),
+                    None => (k, 1.0),
+                };
                 upper = upper.max(
-                    (s_max * (-dividend_yield * tau).exp() - k * (-rate * tau).exp()).max(0.0),
+                    ((s_max * (-dividend_yield * tau).exp() - k_ex * (-rate * tau).exp())
+                        * ex_scale)
+                        .max(0.0),
                 );
             }
             (0.0, upper)
@@ -289,8 +306,13 @@ impl CrankNicolsonEngine {
         let n_t = self.time_steps;
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
+        // Escrowed discrete-dividend model: the grid carries S*, diffused with
+        // the true continuous yield only; exercise projections reconstruct the
+        // observed spot per decision date.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let div_steps = escrowed_steps(market, instrument.expiry, n_t);
         let max_strike = schedule.iter().map(|(_, k)| *k).fold(0.0_f64, f64::max);
-        let s_anchor = market.spot.max(max_strike).max(1.0e-8);
+        let s_anchor = spot0.max(max_strike).max(1.0e-8);
         let s_max = self.s_max_multiplier * s_anchor;
         let ds = s_max / n_s as f64;
 
@@ -326,8 +348,8 @@ impl CrankNicolsonEngine {
         let half_dt = 0.5 * dt;
         let inv_2ds = 1.0 / (2.0 * ds);
         let inv_ds2 = 1.0 / (ds * ds);
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let drift = market.rate - effective_dividend_yield;
+        let dividend_yield = market.dividend_yield;
+        let drift = market.rate - dividend_yield;
 
         let mut boundary_rev = vec![PdeExerciseBoundaryPoint {
             time: instrument.expiry,
@@ -343,8 +365,9 @@ impl CrankNicolsonEngine {
                 &step_schedule,
                 dt,
                 market.rate,
-                effective_dividend_yield,
+                dividend_yield,
                 s_max,
+                div_steps.as_deref(),
             );
 
             for k in 0..interior_n {
@@ -396,33 +419,44 @@ impl CrankNicolsonEngine {
             )?;
 
             if let Some((time, strike)) = step_schedule[n] {
+                // Escrowed model: exercise compares against the reconstructed
+                // spot, i.e. adjusted strike K*P - A and payoff scale 1/P.
+                let (ex_strike, ex_scale) = match &div_steps {
+                    Some(adj) => (adj[n].adjusted_strike(strike), adj[n].scale()),
+                    None => (strike, 1.0),
+                };
                 for (i, v) in next_values.iter_mut().enumerate() {
                     let s = i as f64 * ds;
                     let continuation = *v;
-                    let exercise = intrinsic(instrument.option_type, s, strike);
+                    let exercise = intrinsic(instrument.option_type, s, ex_strike) * ex_scale;
                     diff_buf[i] = exercise - continuation;
                     *v = continuation.max(exercise);
                 }
+                // The estimated boundary lives on the S* grid; report it in
+                // observed-spot units via S = (S* + A) / P.
+                let boundary_spot =
+                    estimate_exercise_boundary(instrument.option_type, &diff_buf, ds).map(|b| {
+                        match &div_steps {
+                            Some(adj) => (b + adj[n].cash) / adj[n].prop,
+                            None => b,
+                        }
+                    });
                 boundary_rev.push(PdeExerciseBoundaryPoint {
                     time,
                     strike,
-                    boundary_spot: estimate_exercise_boundary(
-                        instrument.option_type,
-                        &diff_buf,
-                        ds,
-                    ),
+                    boundary_spot,
                 });
             }
 
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = if market.spot <= 0.0 {
+        let price = if spot0 <= 0.0 {
             values[0]
-        } else if market.spot >= s_max {
+        } else if spot0 >= s_max {
             values[n_s]
         } else {
-            let x = market.spot / ds;
+            let x = spot0 / ds;
             let i = x.floor() as usize;
             let w = x - i as f64;
             (1.0 - w) * values[i] + w * values[i + 1]
@@ -514,8 +548,13 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
         let inv_ds2 = 1.0 / (ds * ds);
         let inv_2ds = 1.0 / (2.0 * ds);
         let half_vol2 = 0.5 * vol * vol;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let drift = market.rate - effective_dividend_yield;
+        // Escrowed discrete-dividend model: the grid carries S*, diffused
+        // with the true continuous yield only; exercise obstacles are
+        // reconstructed per step below.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let div_steps = escrowed_steps(market, instrument.expiry, n_t);
+        let dividend_yield = market.dividend_yield;
+        let drift = market.rate - dividend_yield;
         let half_dt = 0.5 * dt;
 
         for k in 0..interior_n {
@@ -557,15 +596,31 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
 
         for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
-            let (lower_new, upper_new) = boundary_values(
+            let (mut lower_new, mut upper_new) = boundary_values(
                 instrument.option_type,
                 is_american,
                 instrument.strike,
                 market.rate,
-                effective_dividend_yield,
+                dividend_yield,
                 s_max,
                 tau_new,
             );
+            if is_american && let Some(adj) = &div_steps {
+                let sa = &adj[n];
+                match instrument.option_type {
+                    OptionType::Put => {
+                        lower_new =
+                            sa.put_floor_at_zero(instrument.strike, market.rate, n as f64 * dt);
+                    }
+                    OptionType::Call => {
+                        upper_new = upper_new.max(sa.exercise_value(
+                            OptionType::Call,
+                            s_max,
+                            instrument.strike,
+                        ));
+                    }
+                }
+            }
 
             // RHS = B * values; use FMA chains for the tridiagonal multiply.
             // SIMD path when available, otherwise scalar FMA.
@@ -634,12 +689,18 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
             if can_exercise {
                 // Branchless early-exercise: the match on is_call is hoisted
                 // out of the loop by the compiler; inner body is just maxsd ops.
+                // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P,
+                // so the per-step adjustment is a strike shift plus a scale.
+                let (ex_strike, ex_scale) = match &div_steps {
+                    Some(adj) => (adj[n].adjusted_strike(strike), adj[n].scale()),
+                    None => (strike, 1.0),
+                };
                 for (i, v) in next_values.iter_mut().enumerate() {
                     let s = i as f64 * ds;
                     let exercise_value = if is_call {
-                        (s - strike).max(0.0)
+                        (s - ex_strike).max(0.0) * ex_scale
                     } else {
-                        (strike - s).max(0.0)
+                        (ex_strike - s).max(0.0) * ex_scale
                     };
                     *v = v.max(exercise_value);
                 }
@@ -649,12 +710,12 @@ impl PricingEngine<VanillaOption> for CrankNicolsonEngine {
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = if market.spot <= 0.0 {
+        let price = if spot0 <= 0.0 {
             values[0]
-        } else if market.spot >= s_max {
+        } else if spot0 >= s_max {
             values[n_s]
         } else {
-            let x = market.spot / ds;
+            let x = spot0 / ds;
             let i = x.floor() as usize;
             let w = x - i as f64;
             (1.0 - w) * values[i] + w * values[i + 1]

--- a/src/engines/pde/explicit_fd.rs
+++ b/src/engines/pde/explicit_fd.rs
@@ -9,8 +9,10 @@ use crate::market::Market;
 
 use super::fd_common::{
     bermudan_exercise_steps, boundary_values, build_operator_coefficients,
-    build_stretched_spot_grid, explicit_cfl_dt_max, interpolate_on_grid, intrinsic,
+    build_stretched_spot_grid, escrowed_root_spot, escrowed_steps, explicit_cfl_dt_max,
+    interpolate_on_grid, intrinsic,
 };
+use crate::core::OptionType;
 
 /// Forward-Euler explicit finite-difference engine for the Black-Scholes PDE.
 ///
@@ -121,11 +123,17 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
 
-        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        // Escrowed discrete-dividend model: the grid carries S*, diffused
+        // with the true continuous yield only; exercise obstacles are
+        // reconstructed per step below.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let div_steps = escrowed_steps(market, instrument.expiry, n_t);
+
+        let s_anchor = spot0.max(instrument.strike).max(1.0e-8);
         let s_max = self.s_max_multiplier * s_anchor;
         let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
 
-        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let dividend_yield = market.dividend_yield;
         let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
 
         let dt_max = explicit_cfl_dt_max(&a, &b, &c, self.cfl_safety_factor)?;
@@ -152,7 +160,7 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
 
         for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
-            let (lower_bv, upper_bv) = boundary_values(
+            let (mut lower_bv, mut upper_bv) = boundary_values(
                 instrument.option_type,
                 is_american,
                 instrument.strike,
@@ -161,6 +169,22 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
                 s_max,
                 tau_new,
             );
+            if is_american && let Some(adj) = &div_steps {
+                let sa = &adj[n];
+                match instrument.option_type {
+                    OptionType::Put => {
+                        lower_bv =
+                            sa.put_floor_at_zero(instrument.strike, market.rate, n as f64 * dt);
+                    }
+                    OptionType::Call => {
+                        upper_bv = upper_bv.max(sa.exercise_value(
+                            OptionType::Call,
+                            s_max,
+                            instrument.strike,
+                        ));
+                    }
+                }
+            }
 
             next_values[0] = lower_bv;
             next_values[n_s] = upper_bv;
@@ -179,19 +203,23 @@ impl PricingEngine<VanillaOption> for ExplicitFdEngine {
                 }
             };
             if can_exercise {
+                // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P.
+                let (ex_strike, ex_scale) = match &div_steps {
+                    Some(adj) => {
+                        let sa = &adj[n];
+                        (sa.adjusted_strike(instrument.strike), sa.scale())
+                    }
+                    None => (instrument.strike, 1.0),
+                };
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    *v = v.max(intrinsic(
-                        instrument.option_type,
-                        grid[i],
-                        instrument.strike,
-                    ));
+                    *v = v.max(intrinsic(instrument.option_type, grid[i], ex_strike) * ex_scale);
                 }
             }
 
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = interpolate_on_grid(market.spot, &grid, &values);
+        let price = interpolate_on_grid(spot0, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
         diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);

--- a/src/engines/pde/fd_common.rs
+++ b/src/engines/pde/fd_common.rs
@@ -1,4 +1,5 @@
 use crate::core::{OptionType, PricingError};
+use crate::market::Market;
 
 #[inline]
 pub(super) fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 {
@@ -6,6 +7,103 @@ pub(super) fn intrinsic(option_type: OptionType, spot: f64, strike: f64) -> f64 
         OptionType::Call => (spot - strike).max(0.0),
         OptionType::Put => (strike - spot).max(0.0),
     }
+}
+
+/// Per-time-step escrowed discrete-dividend data for PDE engines.
+///
+/// With a discrete schedule the finite-difference grid carries the escrowed
+/// spot `S*`; the observed spot at time `t` is `S = (S* + cash) / prop`, so
+/// exercise payoffs on grid nodes use `intrinsic(S*, K*prop - cash) / prop`.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct EscrowedStep {
+    /// Proportional factor `P(t)` of the remaining schedule events.
+    pub prop: f64,
+    /// Additive cash adjustment `A(t)` of the remaining schedule events.
+    pub cash: f64,
+    /// Ex-date of the last remaining discrete event, if any.
+    pub last_event_time: Option<f64>,
+}
+
+impl EscrowedStep {
+    /// Strike equivalent on the escrowed grid: `K * P(t) - A(t)`.
+    #[inline]
+    pub fn adjusted_strike(&self, strike: f64) -> f64 {
+        strike.mul_add(self.prop, -self.cash)
+    }
+
+    /// Payoff scale `1 / P(t)`.
+    #[inline]
+    pub fn scale(&self) -> f64 {
+        1.0 / self.prop
+    }
+
+    /// Exercise payoff at escrowed grid level `s_star`.
+    #[inline]
+    pub fn exercise_value(&self, option_type: OptionType, s_star: f64, strike: f64) -> f64 {
+        intrinsic(option_type, s_star, self.adjusted_strike(strike)) / self.prop
+    }
+
+    /// American put Dirichlet value at `S* = 0`.
+    ///
+    /// The spot path at `S* = 0` is the deterministic dividend stream, so the
+    /// holder either exercises now (`K - A/P`) or waits until just after the
+    /// last remaining ex-date and receives `~K` discounted. Without remaining
+    /// events this degenerates to `K`, the standard American put boundary.
+    #[inline]
+    pub fn put_floor_at_zero(&self, strike: f64, rate: f64, time: f64) -> f64 {
+        let exercise_now = self.adjusted_strike(strike).max(0.0) / self.prop;
+        match self.last_event_time {
+            Some(t_last) if t_last > time => {
+                exercise_now.max(strike * (-rate * (t_last - time)).exp())
+            }
+            _ => exercise_now,
+        }
+    }
+}
+
+/// Builds the per-step escrowed adjustments on a uniform time grid, or `None`
+/// when the market has no discrete dividends (identity, hot path untouched).
+pub(super) fn escrowed_steps(
+    market: &Market,
+    expiry: f64,
+    time_steps: usize,
+) -> Option<Vec<EscrowedStep>> {
+    if !market.has_discrete_dividends() {
+        return None;
+    }
+    let events = market.dividends().events();
+    Some(
+        (0..=time_steps)
+            .map(|n| {
+                let t = expiry * n as f64 / time_steps as f64;
+                let (prop, cash) = market.escrowed_reconstruction(t, expiry);
+                let last_event_time = events
+                    .iter()
+                    .rev()
+                    .find(|ev| ev.time <= expiry && ev.time > t)
+                    .map(|ev| ev.time);
+                EscrowedStep {
+                    prop,
+                    cash,
+                    last_event_time,
+                }
+            })
+            .collect(),
+    )
+}
+
+/// Escrowed-model root spot `S*(0)`; errors when dividends exceed spot value.
+pub(super) fn escrowed_root_spot(market: &Market, expiry: f64) -> Result<f64, PricingError> {
+    if !market.has_discrete_dividends() {
+        return Ok(market.spot);
+    }
+    let s_star = market.escrowed_spot(expiry);
+    if !s_star.is_finite() || s_star <= 0.0 {
+        return Err(PricingError::InvalidInput(
+            "discrete dividend schedule exceeds spot under the escrowed model".to_string(),
+        ));
+    }
+    Ok(s_star)
 }
 
 pub(super) fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool> {

--- a/src/engines/pde/hopscotch.rs
+++ b/src/engines/pde/hopscotch.rs
@@ -9,8 +9,9 @@ use crate::market::Market;
 
 use super::fd_common::{
     bermudan_exercise_steps, boundary_values, build_operator_coefficients,
-    build_stretched_spot_grid, interpolate_on_grid, intrinsic,
+    build_stretched_spot_grid, escrowed_root_spot, escrowed_steps, interpolate_on_grid, intrinsic,
 };
+use crate::core::OptionType;
 
 /// Gourlay-McKee hopscotch finite-difference engine for Black-Scholes PDE pricing.
 #[derive(Debug, Clone)]
@@ -101,11 +102,17 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
 
-        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        // Escrowed discrete-dividend model: the grid carries S*, diffused
+        // with the true continuous yield only; exercise obstacles are
+        // reconstructed per step below.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let div_steps = escrowed_steps(market, instrument.expiry, n_t);
+
+        let s_anchor = spot0.max(instrument.strike).max(1.0e-8);
         let s_max = self.s_max_multiplier * s_anchor;
         let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
 
-        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let dividend_yield = market.dividend_yield;
         let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
@@ -124,7 +131,7 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
 
         for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
-            let (lower_bv, upper_bv) = boundary_values(
+            let (mut lower_bv, mut upper_bv) = boundary_values(
                 instrument.option_type,
                 is_american,
                 instrument.strike,
@@ -133,6 +140,22 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
                 s_max,
                 tau_new,
             );
+            if is_american && let Some(adj) = &div_steps {
+                let sa = &adj[n];
+                match instrument.option_type {
+                    OptionType::Put => {
+                        lower_bv =
+                            sa.put_floor_at_zero(instrument.strike, market.rate, n as f64 * dt);
+                    }
+                    OptionType::Call => {
+                        upper_bv = upper_bv.max(sa.exercise_value(
+                            OptionType::Call,
+                            s_max,
+                            instrument.strike,
+                        ));
+                    }
+                }
+            }
 
             next_values.copy_from_slice(&values);
             next_values[0] = lower_bv;
@@ -168,19 +191,23 @@ impl PricingEngine<VanillaOption> for HopscotchEngine {
                 }
             };
             if can_exercise {
+                // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P.
+                let (ex_strike, ex_scale) = match &div_steps {
+                    Some(adj) => {
+                        let sa = &adj[n];
+                        (sa.adjusted_strike(instrument.strike), sa.scale())
+                    }
+                    None => (instrument.strike, 1.0),
+                };
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    *v = v.max(intrinsic(
-                        instrument.option_type,
-                        grid[i],
-                        instrument.strike,
-                    ));
+                    *v = v.max(intrinsic(instrument.option_type, grid[i], ex_strike) * ex_scale);
                 }
             }
 
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = interpolate_on_grid(market.spot, &grid, &values);
+        let price = interpolate_on_grid(spot0, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
         diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);

--- a/src/engines/pde/implicit_fd.rs
+++ b/src/engines/pde/implicit_fd.rs
@@ -9,8 +9,10 @@ use crate::market::Market;
 
 use super::fd_common::{
     bermudan_exercise_steps, boundary_values, build_operator_coefficients,
-    build_stretched_spot_grid, interpolate_on_grid, intrinsic, solve_tridiagonal_inplace,
+    build_stretched_spot_grid, escrowed_root_spot, escrowed_steps, interpolate_on_grid, intrinsic,
+    solve_tridiagonal_inplace,
 };
+use crate::core::OptionType;
 
 /// Backward-Euler implicit finite-difference engine for the Black-Scholes PDE.
 ///
@@ -104,11 +106,17 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
         let n_s = self.space_steps;
         let dt = instrument.expiry / n_t as f64;
 
-        let s_anchor = market.spot.max(instrument.strike).max(1.0e-8);
+        // Escrowed discrete-dividend model: the grid carries S*, diffused
+        // with the true continuous yield only; exercise obstacles are
+        // reconstructed per step below.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let div_steps = escrowed_steps(market, instrument.expiry, n_t);
+
+        let s_anchor = spot0.max(instrument.strike).max(1.0e-8);
         let s_max = self.s_max_multiplier * s_anchor;
         let grid = build_stretched_spot_grid(n_s, s_max, instrument.strike, self.grid_stretch)?;
 
-        let dividend_yield = market.effective_dividend_yield(instrument.expiry);
+        let dividend_yield = market.dividend_yield;
         let (a, b, c) = build_operator_coefficients(&grid, market.rate, dividend_yield, vol);
 
         let is_american = matches!(instrument.exercise, ExerciseStyle::American);
@@ -147,7 +155,7 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
 
         for n in (0..n_t).rev() {
             let tau_new = instrument.expiry - n as f64 * dt;
-            let (lower_bv, upper_bv) = boundary_values(
+            let (mut lower_bv, mut upper_bv) = boundary_values(
                 instrument.option_type,
                 is_american,
                 instrument.strike,
@@ -156,6 +164,22 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
                 s_max,
                 tau_new,
             );
+            if is_american && let Some(adj) = &div_steps {
+                let sa = &adj[n];
+                match instrument.option_type {
+                    OptionType::Put => {
+                        lower_bv =
+                            sa.put_floor_at_zero(instrument.strike, market.rate, n as f64 * dt);
+                    }
+                    OptionType::Call => {
+                        upper_bv = upper_bv.max(sa.exercise_value(
+                            OptionType::Call,
+                            s_max,
+                            instrument.strike,
+                        ));
+                    }
+                }
+            }
 
             rhs.copy_from_slice(&values[1..n_s]);
             rhs[0] -= lhs_lower[0] * lower_bv;
@@ -183,19 +207,23 @@ impl PricingEngine<VanillaOption> for ImplicitFdEngine {
                 }
             };
             if can_exercise {
+                // Escrowed model: intrinsic((S*+A)/P, K) == intrinsic(S*, K*P-A)/P.
+                let (ex_strike, ex_scale) = match &div_steps {
+                    Some(adj) => {
+                        let sa = &adj[n];
+                        (sa.adjusted_strike(instrument.strike), sa.scale())
+                    }
+                    None => (instrument.strike, 1.0),
+                };
                 for (i, v) in next_values.iter_mut().enumerate() {
-                    *v = v.max(intrinsic(
-                        instrument.option_type,
-                        grid[i],
-                        instrument.strike,
-                    ));
+                    *v = v.max(intrinsic(instrument.option_type, grid[i], ex_strike) * ex_scale);
                 }
             }
 
             std::mem::swap(&mut values, &mut next_values);
         }
 
-        let price = interpolate_on_grid(market.spot, &grid, &values);
+        let price = interpolate_on_grid(spot0, &grid, &values);
 
         let mut diagnostics = crate::core::Diagnostics::new();
         diagnostics.insert_key(DiagKey::NumTimeSteps, n_t as f64);

--- a/src/engines/tree/binomial.rs
+++ b/src/engines/tree/binomial.rs
@@ -48,6 +48,46 @@ fn bermudan_exercise_steps(dates: &[f64], expiry: f64, steps: usize) -> Vec<bool
     flags
 }
 
+/// Escrowed-model per-step exercise adjustment `(adjusted_strike, scale)`.
+///
+/// The lattice diffuses the escrowed spot `S*`; the observed spot at step `i`
+/// is `S = (S* + A_i) / P_i`, so the exercise payoff on lattice nodes is
+/// `intrinsic(S*, K * P_i - A_i) / P_i`. Returns `None` when the market has
+/// no discrete dividends (identity adjustment, hot path untouched).
+pub(crate) fn escrowed_exercise_adjustments(
+    market: &Market,
+    strike: f64,
+    expiry: f64,
+    steps: usize,
+) -> Option<Vec<(f64, f64)>> {
+    if !market.has_discrete_dividends() {
+        return None;
+    }
+    Some(
+        (0..=steps)
+            .map(|i| {
+                let t = expiry * i as f64 / steps as f64;
+                let (prop, cash) = market.escrowed_reconstruction(t, expiry);
+                (strike.mul_add(prop, -cash), 1.0 / prop)
+            })
+            .collect(),
+    )
+}
+
+/// Escrowed-model root spot `S*(0)`; errors when dividends exceed spot value.
+pub(crate) fn escrowed_root_spot(market: &Market, expiry: f64) -> Result<f64, PricingError> {
+    if !market.has_discrete_dividends() {
+        return Ok(market.spot);
+    }
+    let s_star = market.escrowed_spot(expiry);
+    if !s_star.is_finite() || s_star <= 0.0 {
+        return Err(PricingError::InvalidInput(
+            "discrete dividend schedule exceeds spot under the escrowed model".to_string(),
+        ));
+    }
+    Ok(s_star)
+}
+
 impl PricingEngine<VanillaOption> for BinomialTreeEngine {
     fn price(
         &self,
@@ -77,8 +117,14 @@ impl PricingEngine<VanillaOption> for BinomialTreeEngine {
         let dt = instrument.expiry / self.steps as f64;
         let u = (vol * dt.sqrt()).exp();
         let d = 1.0 / u;
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let growth = ((market.rate - effective_dividend_yield) * dt).exp();
+        // Discrete dividends use the escrowed model: the lattice diffuses the
+        // escrowed spot S* with the true continuous yield only, and exercise
+        // payoffs reconstruct the observed spot per step. Smearing the
+        // schedule into an effective yield misprices early exercise.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let exercise_adj =
+            escrowed_exercise_adjustments(market, instrument.strike, instrument.expiry, self.steps);
+        let growth = ((market.rate - market.dividend_yield) * dt).exp();
         let p = (growth - d) / (u - d);
         if !(0.0..=1.0).contains(&p) || !p.is_finite() {
             return Err(PricingError::NumericalError(
@@ -110,14 +156,15 @@ impl PricingEngine<VanillaOption> for BinomialTreeEngine {
 
         let mut values = vec![0.0_f64; self.steps + 1];
         {
-            let mut st = market.spot * d.powi(self.steps as i32);
+            // No remaining dividends at expiry: payoff on S* equals payoff on S.
+            let mut st = spot0 * d.powi(self.steps as i32);
             for value in values.iter_mut().take(self.steps + 1) {
                 *value = intrinsic(instrument.option_type, st, instrument.strike);
                 st *= ratio;
             }
         }
 
-        let mut base = market.spot * d.powi((self.steps - 1) as i32);
+        let mut base = spot0 * d.powi((self.steps - 1) as i32);
         for i in (0..self.steps).rev() {
             let can_exercise = if let Some(flags) = &bermudan_flags {
                 flags[i]
@@ -126,10 +173,14 @@ impl PricingEngine<VanillaOption> for BinomialTreeEngine {
             };
 
             if can_exercise {
+                // intrinsic((S* + A)/P, K) == intrinsic(S*, K*P - A) / P.
+                let (ex_strike, ex_scale) = exercise_adj
+                    .as_ref()
+                    .map_or((instrument.strike, 1.0), |adj| adj[i]);
                 let mut st = base;
                 for j in 0..=i {
                     let continuation = disc_p.mul_add(values[j + 1], disc_1mp * values[j]);
-                    let exercise = intrinsic(instrument.option_type, st, instrument.strike);
+                    let exercise = intrinsic(instrument.option_type, st, ex_strike) * ex_scale;
                     values[j] = continuation.max(exercise);
                     st *= ratio;
                 }

--- a/src/engines/tree/convertible.rs
+++ b/src/engines/tree/convertible.rs
@@ -14,6 +14,24 @@ use crate::instruments::convertible::ConvertibleBond;
 use crate::market::Market;
 
 /// CRR-style binomial engine for convertible bonds.
+///
+/// # Model conventions
+///
+/// - **Always callable / always puttable:** `call_price` and `put_price` are
+///   flat levels modeled as exercisable at *every* interior time step; there
+///   is no call-protection (hard/soft no-call) schedule. In particular, a
+///   `call_price` below `face_value` means the issuer may redeem below par at
+///   any time, so a straight (zero-conversion-ratio) bond collapses to the
+///   present value of the call price rather than of face.
+/// - **Maturity redemption:** at maturity the bond redeems at `face_value`
+///   (best of redemption, conversion, and any put floor). The issuer call
+///   does not cap the terminal payoff: a call right is meaningless once the
+///   bond has matured.
+/// - **Flat credit spread:** `credit_spread` is applied uniformly when
+///   discounting the hold (continuation) value. This is a simplification
+///   relative to Tsiveriotis-Fernandes, which splits the node value into
+///   equity and debt components discounted at different rates; bond-like
+///   convertibles will therefore price differently from a TF model.
 #[derive(Debug, Clone)]
 pub struct ConvertibleBinomialEngine {
     /// Number of time steps.
@@ -91,13 +109,14 @@ impl PricingEngine<ConvertibleBond> for ConvertibleBinomialEngine {
 
         let conversion_value = instrument.conversion_ratio * market.spot;
         if instrument.maturity <= 0.0 {
-            let redemption = instrument.face_value;
-            let price = apply_embedded_features(
-                redemption,
-                conversion_value,
-                instrument.put_price,
-                instrument.call_price,
-            );
+            // A matured bond redeems at face value: the issuer call right is
+            // meaningless at expiry and must not cap redemption. The holder
+            // still takes the best of redemption, immediate conversion, and
+            // the put floor.
+            let mut price = instrument.face_value.max(conversion_value);
+            if let Some(put) = instrument.put_price {
+                price = price.max(put);
+            }
             let mut diagnostics = crate::core::Diagnostics::new();
             diagnostics.insert("npv", price);
             diagnostics.insert("conversion_value", conversion_value);
@@ -148,14 +167,17 @@ impl PricingEngine<ConvertibleBond> for ConvertibleBinomialEngine {
         {
             let mut st = market.spot * d.powi(self.steps as i32);
             for value in values.iter_mut() {
-                let continuation = instrument.face_value;
+                // Terminal payoff: redemption at face vs conversion (plus the
+                // put floor). The issuer call is not applied at maturity — the
+                // bond redeems at face, so a call price below face cannot cap
+                // the terminal payoff. The always-exercisable call still binds
+                // at every interior step, so this affects the price only at
+                // O(dt). Note the final coupon is paid regardless and enters
+                // through the continuation value one step earlier.
+                let redemption = instrument.face_value;
                 let conversion = instrument.conversion_ratio * st;
-                *value = apply_embedded_features(
-                    continuation,
-                    conversion,
-                    instrument.put_price,
-                    instrument.call_price,
-                );
+                *value =
+                    apply_embedded_features(redemption, conversion, instrument.put_price, None);
                 st *= ratio;
             }
         }
@@ -277,6 +299,33 @@ mod tests {
         // Without forced conversion the call caps the hold value.
         let value = apply_embedded_features(130.0, 80.0, None, Some(110.0));
         assert_eq!(value, 110.0);
+    }
+
+    #[test]
+    fn expired_bond_with_call_below_face_redeems_at_face() {
+        // A matured bond redeems at face; an issuer call at 90 < face 100 is
+        // meaningless at expiry and must not cap redemption. Previously this
+        // returned min(face, call) = 90.
+        let market = ql_test_market();
+        let engine = ConvertibleBinomialEngine::new(0.0);
+
+        let bond = ConvertibleBond::new(100.0, 0.0, 0.0, 0.0, Some(90.0), None);
+        let price = engine.price(&bond, &market).unwrap().price;
+        assert_eq!(price, 100.0, "matured bond must redeem at face");
+    }
+
+    #[test]
+    fn expired_bond_takes_best_of_face_conversion_and_put() {
+        let market = ql_test_market(); // spot = 100
+        let engine = ConvertibleBinomialEngine::new(0.0);
+
+        // Conversion value 1.5 * 100 = 150 dominates face 100.
+        let converting = ConvertibleBond::new(100.0, 0.0, 0.0, 1.5, Some(90.0), None);
+        assert_eq!(engine.price(&converting, &market).unwrap().price, 150.0);
+
+        // Put floor 120 dominates face 100 when conversion is worthless.
+        let puttable = ConvertibleBond::new(100.0, 0.0, 0.0, 0.0, None, Some(120.0));
+        assert_eq!(engine.price(&puttable, &market).unwrap().price, 120.0);
     }
 
     #[test]

--- a/src/engines/tree/trinomial.rs
+++ b/src/engines/tree/trinomial.rs
@@ -13,6 +13,8 @@ use crate::core::{ExerciseStyle, OptionType, PricingEngine, PricingError, Pricin
 use crate::instruments::vanilla::VanillaOption;
 use crate::market::Market;
 
+use super::binomial::{escrowed_exercise_adjustments, escrowed_root_spot};
+
 /// Recombining trinomial tree engine for vanilla options.
 #[derive(Debug, Clone)]
 pub struct TrinomialTreeEngine {
@@ -78,8 +80,12 @@ impl PricingEngine<VanillaOption> for TrinomialTreeEngine {
         let u = (vol * (2.0 * dt).sqrt()).exp();
         let d = 1.0 / u;
 
-        let effective_dividend_yield = market.effective_dividend_yield(instrument.expiry);
-        let nu = market.rate - effective_dividend_yield;
+        // Escrowed discrete-dividend model: diffuse S* with the true
+        // continuous yield only; exercise payoffs are strike-adjusted below.
+        let spot0 = escrowed_root_spot(market, instrument.expiry)?;
+        let exercise_adj =
+            escrowed_exercise_adjustments(market, instrument.strike, instrument.expiry, self.steps);
+        let nu = market.rate - market.dividend_yield;
         let a = (nu * dt / 2.0).exp();
         let b = (vol * (dt / 2.0).sqrt()).exp();
         let denom = b - 1.0 / b;
@@ -124,7 +130,7 @@ impl PricingEngine<VanillaOption> for TrinomialTreeEngine {
         // multiply by u at each step.
         let mut values = vec![0.0_f64; 2 * self.steps + 1];
         {
-            let mut st = market.spot * d.powi(self.steps as i32);
+            let mut st = spot0 * d.powi(self.steps as i32);
             for value in values.iter_mut().take(2 * self.steps + 1) {
                 *value = intrinsic(instrument.option_type, st, instrument.strike);
                 st *= u;
@@ -151,14 +157,18 @@ impl PricingEngine<VanillaOption> for TrinomialTreeEngine {
             let cur_width = 2 * i + 1;
 
             if can_exercise {
-                let mut st = market.spot * d.powi(i as i32);
+                // intrinsic((S* + A)/P, K) == intrinsic(S*, K*P - A) / P.
+                let (ex_strike, ex_scale) = exercise_adj
+                    .as_ref()
+                    .map_or((instrument.strike, 1.0), |adj| adj[i]);
+                let mut st = spot0 * d.powi(i as i32);
                 for k in 0..cur_width {
                     // FMA chain: disc_pu * up + disc_pm * mid + disc_pd * down
                     let continuation = disc_pu.mul_add(
                         values[k + 2],
                         disc_pm.mul_add(values[k + 1], disc_pd * values[k]),
                     );
-                    let exercise = intrinsic(instrument.option_type, st, instrument.strike);
+                    let exercise = intrinsic(instrument.option_type, st, ex_strike) * ex_scale;
                     values[k] = continuation.max(exercise);
                     st *= u;
                 }

--- a/src/instruments/convertible.rs
+++ b/src/instruments/convertible.rs
@@ -23,8 +23,16 @@ pub struct ConvertibleBond {
     /// Shares received per bond when converted.
     pub conversion_ratio: f64,
     /// Optional issuer call price cap.
+    ///
+    /// Engines model this as a flat call level exercisable at every time step
+    /// before maturity (no call-protection schedule). A value below
+    /// `face_value` therefore lets the issuer redeem below par at any time;
+    /// it never caps the redemption of an already-matured bond.
     pub call_price: Option<f64>,
     /// Optional holder put floor.
+    ///
+    /// Modeled as a flat put level exercisable at every time step (no put
+    /// schedule).
     pub put_price: Option<f64>,
 }
 

--- a/src/instruments/tarf.rs
+++ b/src/instruments/tarf.rs
@@ -21,22 +21,48 @@
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TarfType {
     /// Standard TARF: accumulate on upside, leverage on downside.
+    /// The spot KO barrier is an *upside* barrier: the structure knocks out
+    /// when spot fixes at or above `ko_barrier`.
     Standard,
-    /// Decumulator: sell (rather than buy) at each fixing.
+    /// Decumulator: sell (rather than buy) at each fixing, gaining when spot
+    /// falls below the strike. The spot KO barrier is a *downside* barrier:
+    /// the structure knocks out when spot fixes at or below `ko_barrier`.
     Decumulator,
 }
 
 /// Accumulator / TARF instrument.
+///
+/// # Conventions
+///
+/// - **KO direction is type-aware.** For [`TarfType::Standard`] the KO barrier
+///   is an upside barrier (`spot >= ko_barrier` terminates); for
+///   [`TarfType::Decumulator`] it is a downside barrier (`spot <= ko_barrier`
+///   terminates). A finite barrier must lie strictly on the correct side of the
+///   strike (above for `Standard`, below for `Decumulator`); `validate()`
+///   enforces this.
+/// - **No-barrier sentinel.** `f64::INFINITY` means "no KO barrier" for *both*
+///   types (the pricing loop guards the direction check with `is_finite()`, so
+///   an infinite barrier never triggers a decumulator downside KO).
+/// - **KO precedes the fixing P&L.** On a KO breach the breaching fixing pays
+///   nothing and all remaining fixings are cancelled.
+/// - **Full-gain target convention.** On the fixing that reaches
+///   `target_profit`, the full uncapped fixing gain is paid before termination
+///   (as opposed to no-gain or capped-gain conventions, which are not
+///   currently representable).
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tarf {
     /// Forward strike.
     pub strike: f64,
     /// Notional per fixing period.
     pub notional_per_fixing: f64,
-    /// Knock-out barrier (if spot breaches this on upside, structure terminates).
-    /// Set to `f64::INFINITY` for no KO barrier.
+    /// Spot knock-out barrier; the structure terminates when spot breaches it
+    /// at a fixing. Direction depends on `tarf_type`: upside
+    /// (`spot >= ko_barrier`) for `Standard`, downside (`spot <= ko_barrier`)
+    /// for `Decumulator`. Set to `f64::INFINITY` for no KO barrier (both
+    /// types). The breaching fixing itself pays nothing.
     pub ko_barrier: f64,
-    /// Target profit level for early termination.
+    /// Target profit level for early termination. The fixing that reaches the
+    /// target pays its full uncapped gain (full-gain convention).
     pub target_profit: f64,
     /// Leverage ratio on downside (typically 2x).
     pub downside_leverage: f64,
@@ -63,6 +89,31 @@ impl Tarf {
         if self.ko_barrier.is_nan() || self.ko_barrier <= 0.0 {
             return Err("ko_barrier must be > 0 and not NaN".to_string());
         }
+        // A finite barrier must sit strictly on the KO side of the strike for
+        // the product type; `f64::INFINITY` is the "no barrier" sentinel for
+        // both types.
+        if self.ko_barrier.is_finite() {
+            match self.tarf_type {
+                TarfType::Standard => {
+                    if self.ko_barrier <= self.strike {
+                        return Err(
+                            "ko_barrier must be > strike for a standard TARF (upside KO); \
+                             use f64::INFINITY for no barrier"
+                                .to_string(),
+                        );
+                    }
+                }
+                TarfType::Decumulator => {
+                    if self.ko_barrier >= self.strike {
+                        return Err(
+                            "ko_barrier must be < strike for a decumulator TARF (downside KO); \
+                             use f64::INFINITY for no barrier"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
         if self.fixing_times.is_empty() {
             return Err("fixing_times must be non-empty".to_string());
         }
@@ -79,7 +130,8 @@ impl Tarf {
         Ok(())
     }
 
-    /// Standard TARF with common defaults.
+    /// Standard TARF with common defaults. `ko_barrier` is an upside barrier
+    /// and must be above the strike (or `f64::INFINITY` for no barrier).
     pub fn standard(
         strike: f64,
         notional_per_fixing: f64,
@@ -96,6 +148,28 @@ impl Tarf {
             downside_leverage,
             fixing_times,
             tarf_type: TarfType::Standard,
+        }
+    }
+
+    /// Decumulator TARF with common defaults. `ko_barrier` is a downside
+    /// barrier and must be below the strike (or `f64::INFINITY` for no
+    /// barrier).
+    pub fn decumulator(
+        strike: f64,
+        notional_per_fixing: f64,
+        ko_barrier: f64,
+        target_profit: f64,
+        downside_leverage: f64,
+        fixing_times: Vec<f64>,
+    ) -> Self {
+        Self {
+            strike,
+            notional_per_fixing,
+            ko_barrier,
+            target_profit,
+            downside_leverage,
+            fixing_times,
+            tarf_type: TarfType::Decumulator,
         }
     }
 }
@@ -178,8 +252,54 @@ mod tests {
 
     #[test]
     fn validate_allows_infinite_ko_barrier() {
+        // INFINITY is the universal "no KO barrier" sentinel for both types.
         let mut tarf = valid_tarf();
         tarf.ko_barrier = f64::INFINITY;
         assert!(tarf.validate().is_ok());
+        tarf.tarf_type = TarfType::Decumulator;
+        assert!(tarf.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_decumulator_with_downside_barrier() {
+        let tarf = Tarf::decumulator(
+            100.0,
+            1000.0,
+            80.0,
+            50_000.0,
+            2.0,
+            vec![0.25, 0.5, 0.75, 1.0],
+        );
+        assert!(tarf.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_barrier_on_wrong_side_of_strike() {
+        // Standard KO is an upside barrier: must be strictly above strike.
+        let mut standard = valid_tarf();
+        standard.ko_barrier = 80.0;
+        assert!(
+            standard.validate().is_err(),
+            "downside barrier must be rejected for a standard TARF"
+        );
+        standard.ko_barrier = standard.strike;
+        assert!(
+            standard.validate().is_err(),
+            "barrier equal to strike must be rejected for a standard TARF"
+        );
+
+        // Decumulator KO is a downside barrier: must be strictly below strike.
+        let mut dec = valid_tarf();
+        dec.tarf_type = TarfType::Decumulator;
+        dec.ko_barrier = 120.0;
+        assert!(
+            dec.validate().is_err(),
+            "upside barrier must be rejected for a decumulator TARF"
+        );
+        dec.ko_barrier = dec.strike;
+        assert!(
+            dec.validate().is_err(),
+            "barrier equal to strike must be rejected for a decumulator TARF"
+        );
     }
 }

--- a/src/market/dividends.rs
+++ b/src/market/dividends.rs
@@ -200,6 +200,70 @@ impl DividendSchedule {
         self.prepaid_forward_spot(spot, rate, 0.0, maturity)
     }
 
+    /// Escrowed-model reconstruction coefficients at time `t` for maturity `T`.
+    ///
+    /// Under the escrowed (Haug-Haug-Lewis) dividend model the tradable
+    /// component `S*` diffuses as a jump-free GBM with carry `r - q` and the
+    /// observed spot is recovered as `S(t) = (S*(t) + A(t)) / P(t)`, where
+    /// this method returns `(P(t), A(t))`:
+    ///
+    /// - `P(t) = prod (1 - p_i)` over proportional events with `t < t_i <= T`,
+    /// - `A(t) = sum D_i * exp(-(r - q) (t_i - t)) * P(t_i)` over cash events
+    ///   with `t < t_i <= T` (each cash amount is scaled by the proportional
+    ///   factor of the events after it, matching [`Self::forward_price`]).
+    ///
+    /// At `t = 0` this gives `S*(0) = S(0) * P(0) - A(0)` with
+    /// `E[S*(T)] = forward_price(T)`, so European prices under this transform
+    /// reproduce the escrowed analytic (prepaid-forward) values exactly. With
+    /// an empty schedule the result is the identity `(1, 0)`.
+    pub fn escrowed_reconstruction(
+        &self,
+        time: f64,
+        rate: f64,
+        continuous_dividend_yield: f64,
+        maturity: f64,
+    ) -> (f64, f64) {
+        let carry = rate - continuous_dividend_yield;
+        let mut prop = 1.0_f64;
+        let mut cash = 0.0_f64;
+        // Reverse order so `prop` holds the proportional factor of the events
+        // strictly after the cash event currently being accumulated.
+        for event in self.events.iter().rev() {
+            if event.time > maturity {
+                continue;
+            }
+            if event.time <= time {
+                break;
+            }
+            match event.kind {
+                DividendKind::Cash(amount) => {
+                    cash += amount * (-carry * (event.time - time)).exp() * prop;
+                }
+                DividendKind::Proportional(ratio) => prop *= 1.0 - ratio,
+            }
+        }
+        (prop, cash)
+    }
+
+    /// Escrowed-model tradable spot `S*(0) = S(0) * P(0) - A(0)` for maturity `T`.
+    ///
+    /// This equals `prepaid_forward_spot(T) * exp(q T)`: the discrete-dividend
+    /// impact is stripped out while the continuous yield `q` stays in the
+    /// diffusion carry, so lattice/PDE engines can diffuse `S*` with drift
+    /// `r - q` and recover forward-matching prices.
+    #[inline]
+    pub fn escrowed_spot(
+        &self,
+        spot: f64,
+        rate: f64,
+        continuous_dividend_yield: f64,
+        maturity: f64,
+    ) -> f64 {
+        let (prop, cash) =
+            self.escrowed_reconstruction(0.0, rate, continuous_dividend_yield, maturity);
+        spot * prop - cash
+    }
+
     /// Equivalent continuous dividend yield implied by the schedule up to `T`.
     pub fn effective_dividend_yield(
         &self,
@@ -466,6 +530,47 @@ mod tests {
         assert!(prepaid < spot);
         assert!(q_eff > 0.0);
         assert_relative_eq!(prepaid * (r * t).exp(), fwd, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn escrowed_reconstruction_is_forward_consistent_for_mixed_schedules() {
+        let schedule = DividendSchedule::new(vec![
+            DividendEvent::cash(0.25, 1.0).expect("valid cash event"),
+            DividendEvent::proportional(0.5, 0.02).expect("valid proportional event"),
+            DividendEvent::cash(0.75, 0.5).expect("valid cash event"),
+        ])
+        .expect("valid schedule");
+
+        let spot = 100.0;
+        let r = 0.03;
+        let q = 0.01;
+        let t = 1.0;
+
+        // S*(0) grown at carry must reproduce the mixed-schedule forward.
+        let s_star = schedule.escrowed_spot(spot, r, q, t);
+        let fwd = schedule.forward_price(spot, r, q, t);
+        assert_relative_eq!(s_star * ((r - q) * t).exp(), fwd, epsilon = 1e-12);
+
+        // Equivalent characterization: S*(0) = prepaid forward * e^{qT}.
+        assert_relative_eq!(
+            s_star,
+            schedule.prepaid_forward_spot(spot, r, q, t) * (q * t).exp(),
+            epsilon = 1e-12
+        );
+
+        // Reconstruction at t=0 is the identity on observed spot.
+        let (p0, a0) = schedule.escrowed_reconstruction(0.0, r, q, t);
+        assert_relative_eq!((s_star + a0) / p0, spot, epsilon = 1e-12);
+
+        // After all ex-dates the transform degenerates to the identity.
+        let (p_late, a_late) = schedule.escrowed_reconstruction(0.9, r, q, t);
+        assert_relative_eq!(p_late, 1.0, epsilon = 1e-15);
+        assert_relative_eq!(a_late, 0.0, epsilon = 1e-15);
+
+        // Empty schedule: identity everywhere.
+        let empty = DividendSchedule::empty();
+        assert_eq!(empty.escrowed_reconstruction(0.3, r, q, t), (1.0, 0.0));
+        assert_relative_eq!(empty.escrowed_spot(spot, r, q, t), spot, epsilon = 1e-15);
     }
 
     #[test]

--- a/src/market/market.rs
+++ b/src/market/market.rs
@@ -388,6 +388,32 @@ impl Market {
             .escrowed_spot_adjustment(self.spot, self.rate, maturity)
     }
 
+    /// Escrowed-model tradable spot `S*(0)` for an option expiring at `maturity`.
+    ///
+    /// Early-exercise engines diffuse this component with carry
+    /// `rate - dividend_yield` (no discrete-dividend smear) and reconstruct
+    /// the observed spot for exercise payoffs via
+    /// [`Market::escrowed_reconstruction`].
+    #[inline]
+    pub fn escrowed_spot(&self, maturity: f64) -> f64 {
+        self.dividend_schedule
+            .escrowed_spot(self.spot, self.rate, self.dividend_yield, maturity)
+    }
+
+    /// Escrowed-model reconstruction coefficients `(P(t), A(t))` at `time`.
+    ///
+    /// Observed spot is `S(t) = (S*(t) + A(t)) / P(t)`; see
+    /// [`crate::market::DividendSchedule::escrowed_reconstruction`].
+    #[inline]
+    pub fn escrowed_reconstruction(&self, time: f64, maturity: f64) -> (f64, f64) {
+        self.dividend_schedule.escrowed_reconstruction(
+            time,
+            self.rate,
+            self.dividend_yield,
+            maturity,
+        )
+    }
+
     /// Resolves volatility for strike and expiry.
     #[inline]
     pub fn vol(&self, strike: f64, expiry: f64) -> f64 {

--- a/src/models/hw_calibration.rs
+++ b/src/models/hw_calibration.rs
@@ -2,6 +2,13 @@
 //!
 //! Implements hw calibration workflows with concrete routines such as `hw_atm_swaption_vol_approx`, `calibrate_hull_white_params`.
 //!
+//! Volatility convention: every swaption volatility in this module is an ATM
+//! **normal (Bachelier)** volatility of the forward swap rate, in absolute
+//! rate terms (Hull-White `sigma` scale, e.g. `0.0080` = 80 bp/yr). Lognormal
+//! (Black) volatilities (e.g. `0.20` at 4% rates) are a different unit and
+//! must be converted first; at the money
+//! `sigma_normal ~= sigma_black * forward_swap_rate`.
+//!
 //! References: Hull and White (1990), Brigo and Mercurio (2006) Ch. 3, short-rate calibration relations around Eq. (3.28).
 //!
 //! Key types and purpose: `AtmSwaptionVolQuote` define the core data contracts for this module.
@@ -9,9 +16,13 @@
 //! Numerical considerations: parameter admissibility constraints are essential (positivity/integrability/stationarity) to avoid unstable simulation or invalid characteristic functions.
 //!
 //! When to use: select this model module when its dynamics match observed skew/tail/term-structure behavior; prefer simpler models for calibration speed or interpretability.
-use crate::math::normal_cdf;
 
 /// Market ATM swaption volatility quote `(expiry, tenor, market_vol)`.
+///
+/// `market_vol` is an ATM **normal (Bachelier)** volatility of the forward
+/// swap rate in absolute rate terms (e.g. `0.0080` = 80 bp/yr). It is *not* a
+/// lognormal (Black) volatility; convert Black quotes first, using
+/// `sigma_normal ~= sigma_black * forward_swap_rate` at the money.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AtmSwaptionVolQuote {
     pub expiry: f64,
@@ -19,7 +30,35 @@ pub struct AtmSwaptionVolQuote {
     pub market_vol: f64,
 }
 
-/// Approximate ATM Black volatility implied by one-factor Hull-White `(a, sigma)`.
+/// Largest admissible quoted ATM normal volatility (500 bp/yr).
+///
+/// The model vol satisfies `hw_atm_swaption_vol_approx(..) <= sigma` and the
+/// coarse calibration grid caps `sigma` at this level (the fine grid may
+/// extend somewhat above it around the coarse optimum), so materially larger
+/// quotes cannot be matched and would only pin the optimizer at the grid
+/// boundary.
+/// Realistic ATM normal vols for rates are O(0.005-0.02); quotes above this
+/// bound are almost always lognormal (Black) vols passed in the wrong unit,
+/// and [`calibrate_hull_white_params`] rejects them.
+pub const MAX_QUOTED_NORMAL_VOL: f64 = 0.05;
+
+/// Approximate ATM **normal (Bachelier)** swaption volatility implied by
+/// one-factor Hull-White `(a, sigma)`.
+///
+/// Freezing the swap-rate weights, the swap rate is approximately Gaussian
+/// under Hull-White with instantaneous absolute volatility
+/// `sigma * exp(-a * (expiry - t)) * B(0, tenor) / tenor`, where
+/// `B(0, tau) = (1 - exp(-a * tau)) / a` is the frozen duration ratio.
+/// Averaging that variance over `[0, expiry]` gives
+///
+/// ```text
+/// sigma_n = sigma * sqrt((1 - exp(-2 a T)) / (2 a T)) * (1 - exp(-a tau)) / (a tau)
+/// ```
+///
+/// The result is an absolute rate volatility at the Hull-White `sigma` scale
+/// (e.g. `~0.01`) with no dependence on the rate level. It is **not** a
+/// lognormal (Black) volatility (`~0.20` at 4% rates); at the money the two
+/// are related by `sigma_black ~= sigma_n / forward_swap_rate`.
 pub fn hw_atm_swaption_vol_approx(a: f64, sigma: f64, expiry: f64, tenor: f64) -> f64 {
     if !a.is_finite()
         || !sigma.is_finite()
@@ -44,20 +83,34 @@ pub fn hw_atm_swaption_vol_approx(a: f64, sigma: f64, expiry: f64, tenor: f64) -
     sigma * expiry_factor * tenor_factor
 }
 
-/// Calibrates Hull-White `(a, sigma)` by minimizing ATM swaption pricing errors.
+/// Calibrates Hull-White `(a, sigma)` by minimizing squared differences of
+/// ATM swaption prices per unit annuity under the Bachelier (normal) model.
 ///
-/// Input quotes are `(expiry, tenor, market_vol)` tuples.
+/// Input quotes are `(expiry, tenor, market_vol)` tuples, where `market_vol`
+/// is an ATM **normal (Bachelier)** volatility in absolute rate terms (see
+/// [`AtmSwaptionVolQuote`]). Returns `None` when any quote is non-finite,
+/// non-positive, or larger than [`MAX_QUOTED_NORMAL_VOL`]: such quotes lie
+/// outside the search domain (model vols satisfy `model_vol <= sigma`) and
+/// are almost always lognormal Black vols (e.g. `0.20`) passed in the wrong
+/// unit, so they are rejected loudly instead of silently producing a
+/// boundary-pinned degenerate fit.
 pub fn calibrate_hull_white_params(quotes: &[(f64, f64, f64)]) -> Option<(f64, f64)> {
     if quotes.is_empty() {
         return None;
     }
     if quotes.iter().any(|(e, t, v)| {
-        !e.is_finite() || !t.is_finite() || !v.is_finite() || *e <= 0.0 || *t <= 0.0 || *v <= 0.0
+        !e.is_finite()
+            || !t.is_finite()
+            || !v.is_finite()
+            || *e <= 0.0
+            || *t <= 0.0
+            || *v <= 0.0
+            || *v > MAX_QUOTED_NORMAL_VOL
     }) {
         return None;
     }
 
-    let coarse = grid_search(quotes, 0.001, 0.30, 0.001, 0.05, 81, 81);
+    let coarse = grid_search(quotes, 0.001, 0.30, 0.001, MAX_QUOTED_NORMAL_VOL, 81, 81);
     let (a0, sigma0, _) = coarse?;
 
     let fine_a_lo = (a0 * 0.4).max(1.0e-4);
@@ -113,24 +166,28 @@ fn calibration_objective(quotes: &[(f64, f64, f64)], a: f64, sigma: f64) -> f64 
         .iter()
         .map(|(expiry, tenor, market_vol)| {
             let model_vol = hw_atm_swaption_vol_approx(a, sigma, *expiry, *tenor);
-            let market_price = normalized_atm_black_price(*market_vol, *expiry);
-            let model_price = normalized_atm_black_price(model_vol, *expiry);
+            let market_price = normalized_atm_bachelier_price(*market_vol, *expiry);
+            let model_price = normalized_atm_bachelier_price(model_vol, *expiry);
             let err = model_price - market_price;
             err * err
         })
         .sum()
 }
 
-fn normalized_atm_black_price(vol: f64, expiry: f64) -> f64 {
+/// ATM payer swaption price per unit annuity under the Bachelier model.
+///
+/// With normal volatility `sigma_n`, the ATM forward price is
+/// `E[(S_T - F)^+] = sigma_n * sqrt(T) * phi(0) = sigma_n * sqrt(T / (2*pi))`
+/// (Bachelier ATM formula; see e.g. Hull, "Options, Futures, and Other
+/// Derivatives", normal-model appendix). Both the market quote and the
+/// Hull-White approximation are normal vols, so this keeps the objective
+/// unit-consistent; the annuity factor is common to both sides and cancels.
+fn normalized_atm_bachelier_price(vol: f64, expiry: f64) -> f64 {
     if !vol.is_finite() || vol < 0.0 || !expiry.is_finite() || expiry <= 0.0 {
         return f64::NAN;
     }
-    if vol == 0.0 {
-        return 0.0;
-    }
 
-    let x = 0.5 * vol * expiry.sqrt();
-    2.0 * normal_cdf(x) - 1.0
+    vol * (expiry / (2.0 * std::f64::consts::PI)).sqrt()
 }
 
 #[cfg(test)]
@@ -142,6 +199,10 @@ mod tests {
         let true_a = 0.05;
         let true_sigma = 0.01;
 
+        // Self-consistency round trip: quotes generated from the model's own
+        // normal-vol approximation must be recovered. This cannot detect unit
+        // mismatches by construction; the external-anchor coverage lives in
+        // tests/audit_hw_calibration.rs.
         let mut market_quotes = Vec::new();
         for expiry in [1.0, 2.0, 3.0, 5.0] {
             for tenor in [2.0, 5.0] {
@@ -160,5 +221,24 @@ mod tests {
             "sigma calibration error too high: {}",
             rel_sigma
         );
+    }
+
+    #[test]
+    fn lognormal_scale_quotes_are_rejected() {
+        // 0.20 is a typical ATM *Black* (lognormal) vol at ~4% rates. As a
+        // normal vol it would be 2000 bp/yr, far beyond MAX_QUOTED_NORMAL_VOL
+        // and unreachable by the model (model_vol <= sigma <= 0.05 on the
+        // search grid). Before the unit fix this silently returned a
+        // boundary-pinned degenerate fit of (a, sigma) ~ (4e-4, 0.08).
+        let quotes = vec![(1.0, 5.0, 0.20), (3.0, 5.0, 0.19), (5.0, 10.0, 0.18)];
+        assert!(calibrate_hull_white_params(&quotes).is_none());
+
+        // A single wrong-unit quote poisons the set as well.
+        let mixed = vec![(1.0, 5.0, 0.009), (5.0, 5.0, 0.20)];
+        assert!(calibrate_hull_white_params(&mixed).is_none());
+
+        // Quotes at the boundary itself remain admissible.
+        let boundary = vec![(1.0, 5.0, MAX_QUOTED_NORMAL_VOL)];
+        assert!(calibrate_hull_white_params(&boundary).is_some());
     }
 }

--- a/src/pricing/tarf.rs
+++ b/src/pricing/tarf.rs
@@ -32,6 +32,16 @@ pub struct TarfPricingResult {
 
 /// Price a TARF via Monte Carlo simulation under GBM dynamics.
 ///
+/// # Conventions
+/// * KO direction is type-aware: a `Standard` TARF knocks out when spot fixes
+///   at or above `ko_barrier` (upside barrier); a `Decumulator` knocks out
+///   when spot fixes at or below it (downside barrier). `f64::INFINITY` means
+///   "no KO barrier" for both types.
+/// * The KO check runs before the fixing P&L: the breaching fixing pays
+///   nothing and all remaining fixings are cancelled.
+/// * Target termination uses the full-gain convention: the fixing that
+///   reaches `target_profit` pays its full uncapped gain before termination.
+///
 /// # Arguments
 /// * `tarf` - TARF instrument definition
 /// * `spot` - Current spot price
@@ -63,6 +73,11 @@ pub fn tarf_mc_price(
     let n_fix = tarf.fixing_times.len();
     let mut rng = StdRng::seed_from_u64(seed);
 
+    // `f64::INFINITY` is the universal "no KO barrier" sentinel for both TARF
+    // types. The explicit finiteness guard matters on the decumulator side:
+    // without it, `s <= INFINITY` would knock out every path at fixing 1.
+    let ko_active = tarf.ko_barrier.is_finite();
+
     let mut sum_pv = 0.0;
     let mut sum_pv2 = 0.0;
     let mut total_fixings = 0.0;
@@ -89,8 +104,15 @@ pub fn tarf_mc_price(
             let z: f64 = StandardNormal.sample(&mut rng);
             s *= ((rate - dividend_yield - 0.5 * vol * vol) * dt + vol * dt.sqrt() * z).exp();
 
-            // Check KO barrier
-            if s >= tarf.ko_barrier {
+            // Check KO barrier before the fixing P&L (the breaching fixing
+            // pays nothing). Direction is type-aware: Standard knocks out on
+            // the upside, Decumulator on the downside.
+            let knocked_out = ko_active
+                && match tarf.tarf_type {
+                    TarfType::Standard => s >= tarf.ko_barrier,
+                    TarfType::Decumulator => s <= tarf.ko_barrier,
+                };
+            if knocked_out {
                 ko_hits += 1;
                 terminated = true;
                 fixings_used = i + 1;
@@ -127,7 +149,8 @@ pub fn tarf_mc_price(
                 accumulated_profit += pnl;
             }
 
-            // Check target profit
+            // Check target profit (full-gain convention: the full uncapped
+            // pnl of this fixing was already added to path_pv above).
             if accumulated_profit >= tarf.target_profit {
                 target_hits += 1;
                 terminated = true;
@@ -281,17 +304,48 @@ mod tests {
         assert!(delta.is_finite());
     }
 
+    fn make_decumulator_tarf() -> Tarf {
+        // Weekly fixings for 1 year; downside KO barrier below the strike.
+        let fixing_times: Vec<f64> = (1..=52).map(|w| w as f64 / 52.0).collect();
+        Tarf::decumulator(
+            100.0,   // strike
+            1000.0,  // notional per fixing
+            80.0,    // downside KO barrier
+            50000.0, // target profit
+            2.0,     // 2x leverage on the losing side
+            fixing_times,
+        )
+    }
+
     #[test]
     fn tarf_decumulator_differs_from_standard() {
-        let mut tarf = make_standard_tarf();
-        let std_price = tarf_mc_price(&tarf, 100.0, 0.03, 0.0, 0.15, 5000, 42)
+        let std_price = tarf_mc_price(&make_standard_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42)
             .unwrap()
             .price;
-        tarf.tarf_type = TarfType::Decumulator;
-        let dec_price = tarf_mc_price(&tarf, 100.0, 0.03, 0.0, 0.15, 5000, 42)
+        let dec_price = tarf_mc_price(&make_decumulator_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42)
             .unwrap()
             .price;
         // Standard and decumulator should give different values
         assert!((std_price - dec_price).abs() > 0.01);
+    }
+
+    #[test]
+    fn tarf_decumulator_does_not_knock_out_immediately() {
+        // Regression for the inverted KO direction: the old code applied the
+        // upside check `s >= ko_barrier` to decumulators, so a downside
+        // barrier at 80 with spot 100 knocked out every path at fixing 1
+        // (prob_ko = 1, avg_fixings = 1, price = 0).
+        let result =
+            tarf_mc_price(&make_decumulator_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42).unwrap();
+        assert!(result.prob_ko_hit < 0.9);
+        assert!(result.avg_fixings > 2.0);
+        assert!(result.price.abs() > 1.0);
+    }
+
+    #[test]
+    fn tarf_rejects_barrier_on_wrong_side() {
+        let mut tarf = make_standard_tarf();
+        tarf.tarf_type = TarfType::Decumulator; // upside barrier 120 now invalid
+        assert!(tarf_mc_price(&tarf, 100.0, 0.03, 0.0, 0.15, 100, 42).is_err());
     }
 }

--- a/src/rates/bond.rs
+++ b/src/rates/bond.rs
@@ -22,12 +22,21 @@ pub struct FixedRateBond {
     pub frequency: u32,
     /// Maturity in years.
     pub maturity: f64,
-    /// Accrual day-count convention.
+    /// Informational day-count convention metadata.
+    ///
+    /// The bond model is dateless (all times are year fractions), so accrual
+    /// is computed as the elapsed fraction of the current coupon period
+    /// (equivalent to Act/Act-ICMA on the bond's abstract unit periods).
+    /// Date-based conventions such as Act/360 or 30E/360 cannot be applied
+    /// without calendar dates; this field records intent only and does not
+    /// affect pricing or accrual.
     pub day_count: DayCountConvention,
 }
 
 impl FixedRateBond {
-    /// Present value including accrued coupon.
+    /// Dirty price at time zero: the `t = 0` present value of all cashflows.
+    ///
+    /// Equivalent to [`Self::dirty_price_at`] with `settlement = 0`.
     pub fn dirty_price(&self, curve: &YieldCurve) -> f64 {
         self.cashflows()
             .iter()
@@ -35,12 +44,48 @@ impl FixedRateBond {
             .sum()
     }
 
-    /// Present value excluding accrued coupon at settlement.
+    /// Dirty price at `settlement`: the value at `settlement` of all
+    /// cashflows paid strictly after `settlement`.
+    ///
+    /// Cashflows are forward-valued with the curve's implied forward discount
+    /// factor `DF(s, t) = DF(0, t) / DF(0, s)`; coupons paid on or before
+    /// `settlement` (including a coupon paid exactly at `settlement`) are
+    /// excluded. For `settlement <= 0` this reduces exactly to
+    /// [`Self::dirty_price`].
+    pub fn dirty_price_at(&self, curve: &YieldCurve, settlement: f64) -> f64 {
+        if settlement <= 0.0 {
+            return self.dirty_price(curve);
+        }
+
+        // Cashflow times accumulate via repeated `+= period`, so use the same
+        // 1.0e-12 tolerance as `cashflows()` when excluding a coupon that
+        // falls exactly on the settlement date.
+        let pv_at_zero: f64 = self
+            .cashflows()
+            .iter()
+            .filter(|(t, _)| *t > settlement + 1.0e-12)
+            .map(|(t, cf)| cf * self.discount_at(curve, *t))
+            .sum();
+
+        if pv_at_zero == 0.0 {
+            return 0.0;
+        }
+
+        pv_at_zero / curve.discount_factor(settlement)
+    }
+
+    /// Clean price at `settlement`: [`Self::dirty_price_at`] minus
+    /// [`Self::accrued_interest`] at the same settlement time.
     pub fn clean_price(&self, curve: &YieldCurve, settlement: f64) -> f64 {
-        self.dirty_price(curve) - self.accrued_interest(settlement)
+        self.dirty_price_at(curve, settlement) - self.accrued_interest(settlement)
     }
 
     /// Coupon accrued from the last payment date up to settlement.
+    ///
+    /// Accrual is the elapsed fraction of the current coupon period
+    /// (Act/Act-ICMA on the bond's abstract unit periods); the `day_count`
+    /// field is informational metadata and does not alter this fraction
+    /// because the dateless model has no calendar dates to apply it to.
     pub fn accrued_interest(&self, settlement: f64) -> f64 {
         if self.frequency == 0 || settlement <= 0.0 || settlement >= self.maturity {
             return 0.0;
@@ -164,5 +209,67 @@ impl FixedRateBond {
         out.push((self.maturity, coupon + self.face_value));
 
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Flat continuously-compounded curve with half-year nodes so log-linear
+    /// interpolation reproduces `exp(-r t)` exactly at every time used below.
+    fn flat_cc_curve(rate: f64, max_tenor: f64) -> YieldCurve {
+        let n = (max_tenor * 2.0).ceil() as usize + 1;
+        let points: Vec<(f64, f64)> = (1..=n)
+            .map(|i| {
+                let t = i as f64 * 0.5;
+                (t, (-rate * t).exp())
+            })
+            .collect();
+        YieldCurve::new(points)
+    }
+
+    fn sample_bond() -> FixedRateBond {
+        FixedRateBond {
+            face_value: 100.0,
+            coupon_rate: 0.06,
+            frequency: 2,
+            maturity: 10.0,
+            day_count: DayCountConvention::Act365Fixed,
+        }
+    }
+
+    #[test]
+    fn dirty_price_at_zero_settlement_matches_dirty_price() {
+        let curve = flat_cc_curve(0.04, 12.0);
+        let bond = sample_bond();
+        let dirty = bond.dirty_price(&curve);
+        assert!((bond.dirty_price_at(&curve, 0.0) - dirty).abs() < 1.0e-12);
+        assert!((bond.clean_price(&curve, 0.0) - dirty).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn dirty_price_at_excludes_coupon_paid_exactly_at_settlement() {
+        let curve = flat_cc_curve(0.04, 12.0);
+        let bond = sample_bond();
+
+        // At s = 3.5 the coupon at t = 3.5 was just paid and must be
+        // excluded. Hand-computed forward value of the 13 remaining coupons
+        // of 3.0 at t = 4.0..10.0 plus 100 redemption, each discounted by
+        // exp(-0.04 * (t - 3.5)): 111.105142823 (same anchor as
+        // tests/audit_bond_clean_price.rs, hand computation documented there).
+        let dirty = bond.dirty_price_at(&curve, 3.5);
+        assert!((dirty - 111.105_142_823).abs() < 1.0e-9);
+        // Accrued at a coupon date is zero, so clean == dirty there.
+        assert!((bond.clean_price(&curve, 3.5) - dirty).abs() < 1.0e-12);
+    }
+
+    #[test]
+    fn dirty_price_at_maturity_or_later_is_zero() {
+        let curve = flat_cc_curve(0.04, 12.0);
+        let bond = sample_bond();
+        assert_eq!(bond.dirty_price_at(&curve, 10.0), 0.0);
+        assert_eq!(bond.dirty_price_at(&curve, 11.0), 0.0);
+        assert_eq!(bond.clean_price(&curve, 10.0), 0.0);
     }
 }

--- a/tests/audit_bond_clean_price.rs
+++ b/tests/audit_bond_clean_price.rs
@@ -1,0 +1,197 @@
+//! Regression tests for `FixedRateBond` settlement-aware clean/dirty pricing.
+//!
+//! Audit finding: `clean_price(curve, s)` used to subtract accrued-at-`s`
+//! from the t=0 present value of ALL cashflows -- including coupons already
+//! paid before `s` -- and never forward-valued to the settlement date. For a
+//! 10y bond at s = 3.7 that included 7 stale coupons and discounted to t=0.
+//!
+//! Correct semantics tested here:
+//!   dirty(s) = sum over cashflows with t > s of CF(t) * DF(0, t) / DF(0, s)
+//!   clean(s) = dirty(s) - accrued(s)
+//!
+//! All reference numbers below are hand-computed from first principles on
+//! flat continuously-compounded curves (DF(t) = exp(-r t)), where the
+//! forward discount factor is exp(-r (t - s)). The curves are built with
+//! node spacing such that every time used is inside the node range; ln DF is
+//! linear in t, so the default log-linear interpolation reproduces exp(-r t)
+//! exactly and 1e-9 epsilons are safe.
+
+use approx::assert_relative_eq;
+use openferric::rates::{DayCountConvention, FixedRateBond, YieldCurve};
+
+/// Flat continuously-compounded curve with `step`-spaced nodes out to
+/// `max_tenor`: DF(t) = exp(-r t) exactly at (and, via log-linear
+/// interpolation, between) every node.
+fn flat_cc_curve(rate: f64, step: f64, max_tenor: f64) -> YieldCurve {
+    let n = (max_tenor / step).ceil() as usize + 1;
+    let points: Vec<(f64, f64)> = (1..=n)
+        .map(|i| {
+            let t = i as f64 * step;
+            (t, (-rate * t).exp())
+        })
+        .collect();
+    YieldCurve::new(points)
+}
+
+fn ten_year_semiannual_bond() -> FixedRateBond {
+    FixedRateBond {
+        face_value: 100.0,
+        coupon_rate: 0.06,
+        frequency: 2,
+        maturity: 10.0,
+        day_count: DayCountConvention::Act365Fixed,
+    }
+}
+
+/// Anchor 1: 10y 6% semiannual bond, face 100, flat 4% cc curve, s = 3.7.
+///
+/// Hand computation (double-precision sum over the remaining cashflows):
+///   dirty(3.7)   = sum_{t in {4.0, 4.5, ..., 9.5}} 3 * exp(-0.04 (t - 3.7))
+///                  + 103 * exp(-0.04 (10 - 3.7))    = 111.997548830
+///   accrued(3.7) = 3 * (3.7 - 3.5) / 0.5            = 1.2
+///   clean(3.7)   = dirty - accrued                  = 110.797548830
+///
+/// The pre-fix implementation returned dirty = 115.991126156 (t=0 PV of all
+/// 20 coupons, including the 7 paid at t = 0.5..3.5) and clean =
+/// 114.791126156 -- an error of +3.99 per 100 face.
+#[test]
+fn ten_year_bond_settlement_anchor() {
+    let curve = flat_cc_curve(0.04, 0.5, 12.0);
+    let bond = ten_year_semiannual_bond();
+
+    let dirty = bond.dirty_price_at(&curve, 3.7);
+    let accrued = bond.accrued_interest(3.7);
+    let clean = bond.clean_price(&curve, 3.7);
+
+    assert_relative_eq!(dirty, 111.997548830, epsilon = 1.0e-9);
+    assert_relative_eq!(accrued, 1.2, epsilon = 1.0e-12);
+    assert_relative_eq!(clean, 110.797548830, epsilon = 1.0e-9);
+
+    // Guard against the old bug resurfacing: the buggy values were several
+    // points away from the correct ones.
+    assert!((dirty - 115.991126156).abs() > 1.0);
+    assert!((clean - 114.791126156).abs() > 1.0);
+}
+
+/// Anchor 2: 2y 5% annual bond, face 100, flat 4% cc curve, s = 0.5.
+///
+/// Hand computation:
+///   dirty(0.5)   = 5 * exp(-0.04 * 0.5) + 105 * exp(-0.04 * 1.5)
+///                = 4.900993347 + 98.885276046      = 103.786269393
+///   accrued(0.5) = 5 * 0.5                          = 2.5
+///   clean(0.5)   = dirty - accrued                  = 101.286269393
+///
+/// The pre-fix implementation returned clean = 99.231164 (t=0 discounting
+/// understates here: error sign varies with the coupon/discount mix).
+#[test]
+fn two_year_annual_bond_settlement_anchor() {
+    // Half-year node spacing so s = 0.5 and both coupon dates are nodes.
+    let curve = flat_cc_curve(0.04, 0.5, 3.0);
+    let bond = FixedRateBond {
+        face_value: 100.0,
+        coupon_rate: 0.05,
+        frequency: 1,
+        maturity: 2.0,
+        day_count: DayCountConvention::Act365Fixed,
+    };
+
+    let dirty = bond.dirty_price_at(&curve, 0.5);
+    let accrued = bond.accrued_interest(0.5);
+    let clean = bond.clean_price(&curve, 0.5);
+
+    assert_relative_eq!(dirty, 103.786269393, epsilon = 1.0e-9);
+    assert_relative_eq!(accrued, 2.5, epsilon = 1.0e-12);
+    assert_relative_eq!(clean, 101.286269393, epsilon = 1.0e-9);
+}
+
+/// Settlement 0 must be bitwise-identical to the historical behavior:
+/// clean(0) == dirty_price_at(0) == dirty_price() and accrued(0) == 0.
+#[test]
+fn settlement_zero_regression_guard() {
+    let curve = flat_cc_curve(0.04, 0.5, 12.0);
+    let bond = ten_year_semiannual_bond();
+
+    let dirty0 = bond.dirty_price(&curve);
+    assert_eq!(bond.dirty_price_at(&curve, 0.0), dirty0);
+    assert_eq!(bond.accrued_interest(0.0), 0.0);
+    assert_eq!(bond.clean_price(&curve, 0.0), dirty0);
+    // Negative settlement is clamped to the same degenerate case.
+    assert_eq!(bond.dirty_price_at(&curve, -1.0), dirty0);
+}
+
+/// A settlement exactly on a coupon date excludes the just-paid coupon.
+///
+/// Hand computation (s = 3.5): remaining cashflows are the 13 coupons of 3.0
+/// at t = 4.0..10.0 plus 100 redemption at 10.0, each forward-valued by
+/// exp(-0.04 (t - 3.5)):
+///   dirty(3.5) = 111.105142823, accrued(3.5) = 0, clean = dirty.
+/// Including the just-paid t = 3.5 coupon would add exactly 3.0.
+#[test]
+fn settlement_on_coupon_date_excludes_paid_coupon() {
+    let curve = flat_cc_curve(0.04, 0.5, 12.0);
+    let bond = ten_year_semiannual_bond();
+
+    let dirty = bond.dirty_price_at(&curve, 3.5);
+    assert_relative_eq!(dirty, 111.105142823, epsilon = 1.0e-9);
+    assert_relative_eq!(bond.accrued_interest(3.5), 0.0, epsilon = 1.0e-12);
+    assert_relative_eq!(bond.clean_price(&curve, 3.5), dirty, epsilon = 1.0e-12);
+}
+
+/// The settlement dirty price obeys the forward-value identity on any curve:
+/// dirty(s) * DF(0, s) == t=0 PV of the cashflows strictly after s.
+/// Checked on a non-flat (upward-sloping) curve to make sure the DF-ratio
+/// forward valuation is used rather than any flat-rate shortcut.
+#[test]
+fn forward_value_identity_on_sloped_curve() {
+    // Upward-sloping zero curve: r(t) = 0.02 + 0.004 t at half-year nodes.
+    let points: Vec<(f64, f64)> = (1..=24)
+        .map(|i| {
+            let t = i as f64 * 0.5;
+            let r = 0.02 + 0.004 * t;
+            (t, (-r * t).exp())
+        })
+        .collect();
+    let curve = YieldCurve::new(points);
+    let bond = ten_year_semiannual_bond();
+
+    for settlement in [1.3, 3.7, 6.25, 9.9] {
+        // t=0 PV of cashflows strictly after settlement, computed directly
+        // from node discount factors (all coupon times are nodes).
+        let mut pv0 = 0.0;
+        let mut t = 0.5;
+        while t < 10.0 - 1.0e-12 {
+            if t > settlement + 1.0e-12 {
+                pv0 += 3.0 * curve.discount_factor(t);
+            }
+            t += 0.5;
+        }
+        pv0 += 103.0 * curve.discount_factor(10.0);
+
+        let dirty = bond.dirty_price_at(&curve, settlement);
+        assert_relative_eq!(
+            dirty * curve.discount_factor(settlement),
+            pv0,
+            epsilon = 1.0e-9
+        );
+
+        // clean = dirty - accrued always holds against the settlement-aware
+        // dirty price (the identity the old code faked with a t=0 PV).
+        assert_relative_eq!(
+            bond.clean_price(&curve, settlement),
+            dirty - bond.accrued_interest(settlement),
+            epsilon = 1.0e-12
+        );
+    }
+}
+
+/// After the final cashflow there is nothing left to price.
+#[test]
+fn settlement_at_or_after_maturity_prices_to_zero() {
+    let curve = flat_cc_curve(0.04, 0.5, 12.0);
+    let bond = ten_year_semiannual_bond();
+
+    assert_eq!(bond.dirty_price_at(&curve, 10.0), 0.0);
+    assert_eq!(bond.dirty_price_at(&curve, 10.5), 0.0);
+    assert_eq!(bond.clean_price(&curve, 10.0), 0.0);
+    assert_eq!(bond.clean_price(&curve, 10.5), 0.0);
+}

--- a/tests/audit_cdo_hazard.rs
+++ b/tests/audit_cdo_hazard.rs
@@ -1,0 +1,206 @@
+//! Audit regression tests: `SyntheticCdo` must convert its pool par spread to a
+//! hazard rate via the credit triangle `h = s / (1 - R)` (O'Kane 2008, Ch. 5),
+//! and must discount with the given flat rate even when it is negative.
+//!
+//! Historical bug: `SyntheticCdo::hazard_rate()` returned the par spread
+//! directly (h = s), understating the 5y pool default probability for
+//! s = 100 bps, R = 40% as 4.88% instead of ~8.00%, biasing all tranche
+//! expected losses and fair spreads 36-60% low. Separately,
+//! `discount_factor()` floored the risk-free rate at zero, silently treating
+//! negative rates as 0%.
+
+use approx::assert_relative_eq;
+use openferric::credit::isda::hazard_from_par_spread;
+use openferric::credit::{CdoTranche, SyntheticCdo};
+
+fn base_cdo() -> SyntheticCdo {
+    SyntheticCdo {
+        num_names: 125,
+        pool_spread: 0.01,
+        recovery_rate: 0.4,
+        correlation: 0.30,
+        risk_free_rate: 0.05,
+        maturity: 5.0,
+        payment_freq: 4,
+    }
+}
+
+fn equity_tranche() -> CdoTranche {
+    CdoTranche {
+        attachment: 0.0,
+        detachment: 0.03,
+        notional: 0.03,
+        spread: 0.0,
+    }
+}
+
+fn mezz_tranche() -> CdoTranche {
+    CdoTranche {
+        attachment: 0.03,
+        detachment: 0.07,
+        notional: 0.04,
+        spread: 0.0,
+    }
+}
+
+fn senior_tranche() -> CdoTranche {
+    CdoTranche {
+        attachment: 0.07,
+        detachment: 1.0,
+        notional: 0.93,
+        spread: 0.0,
+    }
+}
+
+/// The CDO hazard rate must be pinned to the crate's canonical ISDA-style
+/// credit-triangle conversion for a grid of spreads and recoveries.
+#[test]
+fn cdo_hazard_rate_pins_to_isda_credit_triangle() {
+    let mut cdo = base_cdo();
+    for &s in &[0.0, 0.0025, 0.01, 0.05, 0.12] {
+        for &r in &[0.0, 0.25, 0.4, 0.75, 0.95] {
+            cdo.pool_spread = s;
+            cdo.recovery_rate = r;
+            assert_relative_eq!(
+                cdo.hazard_rate(),
+                hazard_from_par_spread(s, r),
+                epsilon = 0.0
+            );
+            // Closed form, independently: h = s / (1 - R).
+            assert_relative_eq!(cdo.hazard_rate(), s / (1.0 - r), epsilon = 1.0e-15);
+        }
+    }
+}
+
+/// External anchor: with a flat hazard, the pool default probability is
+/// 1 - exp(-h t) with h = s/(1-R). For s = 100 bps, R = 40%, T = 5y:
+/// h = 0.01/0.6 = 1/60, h*T = 1/12, PD = 1 - exp(-1/12) = 0.0799555853706767
+/// (hand computation; exp(-1/12) = 0.9200444146293233).
+/// The pre-fix code (h = s) gave PD = 1 - exp(-0.05) = 0.048771, which this
+/// test rejects.
+#[test]
+fn pool_default_probability_matches_hand_computed_anchor() {
+    let cdo = base_cdo();
+    let pd_5y = cdo.default_probability(5.0);
+    assert_relative_eq!(pd_5y, 0.079_955_585_370_676_7, epsilon = 1.0e-12);
+    // Explicitly reject the pre-fix value.
+    assert!((pd_5y - 0.048_771).abs() > 0.02);
+}
+
+/// External anchor: pool expected loss fraction must equal
+/// (1-R) * (1 - exp(-s T / (1-R))). For s = 0.01, R = 0.4, T = 5:
+/// 0.6 * (1 - exp(-1/12)) = 0.0479733512224060 (hand computation).
+#[test]
+fn portfolio_expected_loss_matches_credit_triangle_closed_form() {
+    let cdo = base_cdo();
+    let t = 5.0;
+    let closed_form = (1.0 - cdo.recovery_rate)
+        * (1.0 - (-cdo.pool_spread * t / (1.0 - cdo.recovery_rate)).exp());
+    assert_relative_eq!(closed_form, 0.047_973_351_222_406, epsilon = 1.0e-12);
+    assert_relative_eq!(
+        cdo.portfolio_expected_loss(t),
+        closed_form,
+        epsilon = 1.0e-12
+    );
+}
+
+/// Hand-computed tranche anchor at zero correlation, where the LHP pool loss
+/// is deterministic: L = (1-R) * PD = 0.6 * (1 - exp(-1/12)) = 0.0479733512.
+/// Equity 0-3%: tranche loss = min(L, 0.03) = 0.03, i.e. fraction 1.0 of the
+/// tranche. Mezz 3-7%: clamp(L - 0.03, 0, 0.04) = 0.0179733512, fraction
+/// 0.0179733512 / 0.04 = 0.4493337806. Senior 7-100%: 0. All derived by hand
+/// from the credit triangle and the tranche payoff definition.
+#[test]
+fn zero_correlation_tranche_losses_match_hand_computation() {
+    let mut cdo = base_cdo();
+    cdo.correlation = 0.0;
+    let t = 5.0;
+    let pool_loss = 0.047_973_351_222_406;
+
+    let equity = equity_tranche();
+    let mezz = mezz_tranche();
+    let senior = senior_tranche();
+
+    // Expected tranche loss in currency units = notional * loss fraction.
+    assert_relative_eq!(
+        cdo.expected_tranche_loss(&equity, t),
+        equity.notional * 1.0,
+        epsilon = 1.0e-10
+    );
+    assert_relative_eq!(
+        cdo.expected_tranche_loss(&mezz, t),
+        mezz.notional * ((pool_loss - 0.03) / 0.04),
+        epsilon = 1.0e-10
+    );
+    assert_relative_eq!(
+        cdo.expected_tranche_loss(&senior, t),
+        0.0,
+        epsilon = 1.0e-12
+    );
+}
+
+/// Consistency: with correlation on, tranche expected losses spanning
+/// 0-100% must still sum to the (corrected) pool expected loss.
+#[test]
+fn tranche_expected_losses_sum_to_corrected_pool_loss() {
+    let cdo = base_cdo();
+    let t = cdo.maturity;
+    let sum = cdo.expected_tranche_loss(&equity_tranche(), t)
+        + cdo.expected_tranche_loss(&mezz_tranche(), t)
+        + cdo.expected_tranche_loss(&senior_tranche(), t);
+    assert_relative_eq!(sum, cdo.portfolio_expected_loss(t), epsilon = 4.0e-3);
+    // The pool loss itself is the hand-computed anchor, so the sum is
+    // pinned to an external value, not a self-referential one.
+    assert_relative_eq!(sum, 0.047_973_351_222_406, epsilon = 4.0e-3);
+}
+
+/// Negative risk-free rates must change PVs. The pre-fix discount_factor
+/// floored the rate at 0, making r = -2% and r = 0% produce identical
+/// results (verified empirically on the old code: mezz fair spread
+/// 417.137926 bps and NPV 0.00398866 at both rates).
+#[test]
+fn negative_rates_are_not_floored_to_zero() {
+    let mezz = CdoTranche {
+        spread: 0.02,
+        ..mezz_tranche()
+    };
+
+    let mut cdo_neg = base_cdo();
+    cdo_neg.risk_free_rate = -0.02;
+    let mut cdo_zero = base_cdo();
+    cdo_zero.risk_free_rate = 0.0;
+
+    // With r = -2%, every discount factor exceeds 1, so both legs must be
+    // strictly larger than at r = 0%.
+    assert!(
+        cdo_neg.premium_leg_pv(&mezz, mezz.spread) > cdo_zero.premium_leg_pv(&mezz, mezz.spread)
+    );
+    assert!(cdo_neg.protection_leg_pv(&mezz) > cdo_zero.protection_leg_pv(&mezz));
+
+    // Fair spreads and NPVs must differ between r = -2% and r = 0%.
+    let fs_neg = cdo_neg.fair_spread(&mezz);
+    let fs_zero = cdo_zero.fair_spread(&mezz);
+    assert!(
+        (fs_neg - fs_zero).abs() > 1.0e-6,
+        "fair spreads identical: {fs_neg} vs {fs_zero}"
+    );
+    assert!(
+        (cdo_neg.npv(&mezz) - cdo_zero.npv(&mezz)).abs() > 1.0e-8,
+        "NPVs identical under negative vs zero rates"
+    );
+}
+
+/// NPV at the fair spread must be zero, including under negative rates.
+#[test]
+fn npv_is_zero_at_fair_spread_under_negative_rates() {
+    let mut cdo = base_cdo();
+    cdo.risk_free_rate = -0.015;
+    for tranche in [equity_tranche(), mezz_tranche(), senior_tranche()] {
+        let fair = cdo.fair_spread(&tranche);
+        let at_par = CdoTranche {
+            spread: fair,
+            ..tranche
+        };
+        assert_relative_eq!(cdo.npv(&at_par), 0.0, epsilon = 1.0e-12);
+    }
+}

--- a/tests/audit_convertible.rs
+++ b/tests/audit_convertible.rs
@@ -1,0 +1,135 @@
+//! Audit regression tests for `ConvertibleBinomialEngine`.
+//!
+//! Covers two verified findings:
+//!
+//! 1. The matured-bond (`maturity <= 0`) branch used to return
+//!    `min(face, call)`, so an expired bond with a call price below face
+//!    redeemed below par. A matured bond must redeem at face (best of face,
+//!    conversion, and the put floor); the issuer call right is meaningless at
+//!    expiry.
+//! 2. Model-convention pinning for the always-callable (no call-protection
+//!    schedule) convention: a straight bond callable anytime at `call < face`
+//!    rationally prices to PV(call), not PV(face), and the terminal nodes no
+//!    longer apply the call cap (an O(dt) change only).
+//!
+//! Reference values are closed-form discount factors, not tree output:
+//! `PV(x) = x * exp(-r * T)` for a zero-coupon claim under continuous
+//! compounding (the project-wide rate convention).
+
+use openferric::core::PricingEngine;
+use openferric::engines::tree::ConvertibleBinomialEngine;
+use openferric::instruments::ConvertibleBond;
+use openferric::market::Market;
+
+fn flat_market(spot: f64, rate: f64, vol: f64) -> Market {
+    Market::builder()
+        .spot(spot)
+        .rate(rate)
+        .flat_vol(vol)
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn expired_bond_with_call_below_face_redeems_at_face() {
+    // Face 100, issuer call 90, already matured. Redemption is contractual:
+    // the bond pays face = 100. The pre-fix engine returned
+    // min(face, call) = 90.
+    let market = flat_market(100.0, 0.05, 0.20);
+    let engine = ConvertibleBinomialEngine::new(0.0);
+
+    let bond = ConvertibleBond::new(100.0, 0.05, 0.0, 0.0, Some(90.0), None);
+    let price = engine.price(&bond, &market).unwrap().price;
+
+    assert_eq!(
+        price, 100.0,
+        "matured bond with call < face must redeem at face, got {price}"
+    );
+}
+
+#[test]
+fn expired_bond_pays_best_of_face_conversion_and_put() {
+    let market = flat_market(100.0, 0.05, 0.20);
+    let engine = ConvertibleBinomialEngine::new(0.0);
+
+    // Conversion value 1.2 * 100 = 120 dominates face 100 even with a low call.
+    let converting = ConvertibleBond::new(100.0, 0.0, 0.0, 1.2, Some(90.0), None);
+    assert_eq!(engine.price(&converting, &market).unwrap().price, 120.0);
+
+    // Put floor 130 dominates both face and conversion at expiry.
+    let puttable = ConvertibleBond::new(100.0, 0.0, 0.0, 1.2, Some(90.0), Some(130.0));
+    assert_eq!(engine.price(&puttable, &market).unwrap().price, 130.0);
+
+    // No embedded features: plain face redemption.
+    let plain = ConvertibleBond::new(100.0, 0.0, 0.0, 0.0, None, None);
+    assert_eq!(engine.price(&plain, &market).unwrap().price, 100.0);
+}
+
+#[test]
+fn always_callable_straight_bond_converges_to_pv_of_call() {
+    // Probe from the audit verification: zero-coupon straight bond
+    // (conversion ratio 0), face 100, callable anytime at 90, r = 5%, T = 5.
+    //
+    // Under the engine's always-callable model the rational issuer calls as
+    // soon as the hold value exceeds 90, so the bond is worth
+    // PV(call) = 90 * exp(-0.05 * 5) = 70.09207... (closed-form anchor),
+    // NOT PV(face) = 77.88. With the terminal call cap removed the finite-step
+    // price approaches PV(call) from above at O(dt); at 500 steps it must lie
+    // in [70.09, 70.14] (verified: 70.127125 with the cap applied only at
+    // interior steps, converging to 70.093823 by 10000 steps).
+    let market = flat_market(100.0, 0.05, 0.20);
+    let engine = ConvertibleBinomialEngine::new(0.0).with_steps(500);
+
+    let bond = ConvertibleBond::new(100.0, 0.0, 5.0, 0.0, Some(90.0), None);
+    let price = engine.price(&bond, &market).unwrap().price;
+
+    let pv_call = 90.0 * (-0.05_f64 * 5.0).exp();
+    assert!(
+        (pv_call - 1e-9..=70.14).contains(&price),
+        "always-callable straight bond: expected price in [{pv_call:.6}, 70.14], got {price:.6}"
+    );
+}
+
+#[test]
+fn straight_bond_with_call_at_or_above_face_prices_to_pv_of_face() {
+    // With call >= face the cap never binds (hold value never exceeds face
+    // for a zero-coupon bond), so the price is exactly
+    // PV(face) = 100 * exp(-0.05 * 5) = 77.880078... (closed-form anchor).
+    // This pins that removing the terminal call cap did not perturb the
+    // call >= face case at all.
+    let market = flat_market(100.0, 0.05, 0.20);
+    let engine = ConvertibleBinomialEngine::new(0.0).with_steps(500);
+
+    let pv_face = 100.0 * (-0.05_f64 * 5.0).exp();
+
+    let callable_at_par = ConvertibleBond::new(100.0, 0.0, 5.0, 0.0, Some(100.0), None);
+    let callable_above_par = ConvertibleBond::new(100.0, 0.0, 5.0, 0.0, Some(110.0), None);
+    let straight = ConvertibleBond::new(100.0, 0.0, 5.0, 0.0, None, None);
+
+    for bond in [&callable_at_par, &callable_above_par, &straight] {
+        let price = engine.price(bond, &market).unwrap().price;
+        assert!(
+            (price - pv_face).abs() < 1e-9,
+            "expected PV(face) = {pv_face:.9}, got {price:.9}"
+        );
+    }
+}
+
+#[test]
+fn callable_convertible_never_exceeds_non_callable() {
+    // Monotonicity guard for the terminal-cap change: an issuer call can only
+    // remove value from the holder.
+    let market = flat_market(100.0, 0.05, 0.20);
+    let engine = ConvertibleBinomialEngine::new(0.02).with_steps(400);
+
+    let no_call = ConvertibleBond::new(100.0, 0.04, 7.0, 1.0, None, None);
+    let with_call = ConvertibleBond::new(100.0, 0.04, 7.0, 1.0, Some(105.0), None);
+
+    let no_call_price = engine.price(&no_call, &market).unwrap().price;
+    let with_call_price = engine.price(&with_call, &market).unwrap().price;
+
+    assert!(
+        with_call_price <= no_call_price + 1e-12,
+        "callable {with_call_price} must not exceed non-callable {no_call_price}"
+    );
+}

--- a/tests/audit_discrete_dividends.rs
+++ b/tests/audit_discrete_dividends.rs
@@ -1,0 +1,531 @@
+//! Discrete cash/proportional dividend regression tests for early-exercise
+//! engines (audit finding: dividend smear via `effective_dividend_yield`).
+//!
+//! All early-exercise engines previously converted discrete dividends into a
+//! constant continuous yield over the whole lattice/grid/path set. That is
+//! forward-matching (exact for Europeans under the escrowed model) but wrong
+//! for Americans: the exercise incentive concentrated at each ex-date is
+//! smeared over the full horizon. On the probe scenario below the effective
+//! yield (~5.05%) exceeded the 3% rate and suppressed put exercise entirely,
+//! producing an early-exercise premium of ~0.001 where the escrowed-model
+//! premium is ~0.35.
+//!
+//! The library's discrete-dividend convention for vanilla options is the
+//! ESCROWED model (Haug-Haug-Lewis), already used by the analytic
+//! `BlackScholesEngine`: the tradable component `S* = S - PV(remaining cash
+//! dividends)` diffuses as a dividend-free GBM (with the true continuous
+//! yield), and exercise payoffs reconstruct the observed spot at each date.
+//! Barrier Monte Carlo engines instead apply true ex-date drops on the path
+//! (spot model), because knock events depend on the observed spot path.
+
+use openferric::core::{ExerciseStyle, OptionType, PricingEngine};
+use openferric::engines::analytic::BlackScholesEngine;
+use openferric::engines::lsm::LongstaffSchwartzEngine;
+use openferric::engines::numerical::american_binomial::AmericanBinomialEngine;
+use openferric::engines::pde::{
+    CrankNicolsonEngine, ExplicitFdEngine, HopscotchEngine, ImplicitFdEngine,
+};
+use openferric::engines::tree::binomial::BinomialTreeEngine;
+use openferric::engines::tree::trinomial::TrinomialTreeEngine;
+use openferric::instruments::{BarrierOption, BermudanOption, VanillaOption};
+use openferric::market::{DividendEvent, DividendSchedule, Market};
+
+/// Probe scenario: S = K = 100, r = 3%, q = 0, vol = 25%, T = 1y, one cash
+/// dividend of 5.0 at t = 0.5.
+fn probe_market() -> Market {
+    Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.0)
+        .dividend_schedule(
+            DividendSchedule::new(vec![DividendEvent::cash(0.5, 5.0).expect("valid event")])
+                .expect("valid schedule"),
+        )
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market")
+}
+
+/// Escrowed-model analytic European put for the probe scenario.
+///
+/// Hand-checkable: S* = 100 - 5 e^{-0.03*0.5} = 95.074441, then
+/// Black-Scholes(S*, K=100, r=3%, q=0, vol=25%, T=1) = 10.5727. This value
+/// was independently reproduced during audit verification (escrowed BS by
+/// hand: 10.572688; library analytic engine: 10.572685).
+const PROBE_ESCROWED_EUROPEAN_PUT: f64 = 10.5727;
+
+/// Escrowed-model American put for the probe scenario.
+///
+/// Reference: independent escrowed-spot CRR implementation from the audit
+/// verification (S* diffused GBM(r, vol), exercise payoff K - (S* + PV_t of
+/// remaining dividends)), 8000 steps: American put = 10.9246, early-exercise
+/// premium ~0.352 over the escrowed European 10.5727.
+const PROBE_ESCROWED_AMERICAN_PUT: f64 = 10.9246;
+
+#[test]
+fn european_engines_match_escrowed_analytic_with_cash_dividend() {
+    let market = probe_market();
+    let put = VanillaOption::european_put(100.0, 1.0);
+    let call = VanillaOption::european_call(100.0, 1.0);
+
+    let analytic_put = BlackScholesEngine.price(&put, &market).unwrap().price;
+    let analytic_call = BlackScholesEngine.price(&call, &market).unwrap().price;
+    assert!(
+        (analytic_put - PROBE_ESCROWED_EUROPEAN_PUT).abs() <= 1.0e-3,
+        "analytic escrowed European put drifted: {analytic_put}"
+    );
+
+    // Requirement (1): European prices through the early-exercise engines
+    // must stay forward-matching, i.e. converge to the escrowed analytic.
+    let checks: Vec<(&str, f64, f64, f64)> = vec![
+        (
+            "binomial put",
+            BinomialTreeEngine::new(2000)
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.01,
+        ),
+        (
+            "binomial call",
+            BinomialTreeEngine::new(2000)
+                .price(&call, &market)
+                .unwrap()
+                .price,
+            analytic_call,
+            0.01,
+        ),
+        (
+            "trinomial put",
+            TrinomialTreeEngine::new(1000)
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.01,
+        ),
+        (
+            "crank-nicolson put",
+            CrankNicolsonEngine::new(800, 800)
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.02,
+        ),
+        (
+            "implicit fd put",
+            ImplicitFdEngine::default()
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.02,
+        ),
+        (
+            "explicit fd put",
+            ExplicitFdEngine::default()
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.02,
+        ),
+        (
+            "hopscotch put",
+            HopscotchEngine::default()
+                .price(&put, &market)
+                .unwrap()
+                .price,
+            analytic_put,
+            0.02,
+        ),
+    ];
+    for (label, price, reference, tol) in checks {
+        assert!(
+            (price - reference).abs() <= tol,
+            "{label}: engine={price}, escrowed analytic={reference}"
+        );
+    }
+
+    // LSM European (exercise only at expiry) is unbiased for the escrowed
+    // European; allow Monte Carlo noise.
+    let lsm = LongstaffSchwartzEngine::new(60_000, 50, 42)
+        .price(&put, &market)
+        .unwrap();
+    let tol = 4.0 * lsm.stderr.unwrap_or(0.0) + 1.0e-6;
+    assert!(
+        (lsm.price - analytic_put).abs() <= tol,
+        "lsm european put: {} vs analytic {} (tol {tol})",
+        lsm.price,
+        analytic_put
+    );
+}
+
+#[test]
+fn hull_dividend_european_call_reference() {
+    // External anchor: Hull, "Options, Futures, and Other Derivatives"
+    // (5th ed.), Exercise 12.8 — also cached as 3.67 in QuantLib's
+    // test-suite/dividendoption.cpp (testEuropeanKnownValue, Actual/360):
+    // S=40, K=40, r=9%, vol=30%, T=180/360, cash dividends 0.50 at 60/360
+    // and 0.50 at 150/360. Escrowed European call = 3.67.
+    let market = Market::builder()
+        .spot(40.0)
+        .rate(0.09)
+        .dividend_yield(0.0)
+        .dividend_schedule(
+            DividendSchedule::new(vec![
+                DividendEvent::cash(60.0 / 360.0, 0.50).expect("valid event"),
+                DividendEvent::cash(150.0 / 360.0, 0.50).expect("valid event"),
+            ])
+            .expect("valid schedule"),
+        )
+        .flat_vol(0.30)
+        .build()
+        .expect("valid market");
+    let call = VanillaOption::european_call(40.0, 0.5);
+
+    let analytic = BlackScholesEngine.price(&call, &market).unwrap().price;
+    let tree = BinomialTreeEngine::new(2000)
+        .price(&call, &market)
+        .unwrap()
+        .price;
+    let pde = CrankNicolsonEngine::new(800, 800)
+        .price(&call, &market)
+        .unwrap()
+        .price;
+
+    for (label, price) in [("analytic", analytic), ("binomial", tree), ("cn", pde)] {
+        assert!(
+            (price - 3.67).abs() <= 0.02,
+            "{label}: {price} vs Hull reference 3.67"
+        );
+    }
+}
+
+#[test]
+fn american_put_cash_dividend_has_material_early_exercise_premium() {
+    let market = probe_market();
+    let am_put = VanillaOption::american_put(100.0, 1.0);
+    let eu_put = VanillaOption::european_put(100.0, 1.0);
+
+    let analytic_eu = BlackScholesEngine.price(&eu_put, &market).unwrap().price;
+
+    // Requirement (2): a materially positive early-exercise premium. The
+    // pre-fix engines produced ~0.001 here (q_eff > r suppressed exercise).
+    let binomial = BinomialTreeEngine::new(2000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (binomial - PROBE_ESCROWED_AMERICAN_PUT).abs() <= 0.02,
+        "binomial American put {binomial} vs escrowed CRR reference {PROBE_ESCROWED_AMERICAN_PUT}"
+    );
+    let premium = binomial - analytic_eu;
+    assert!(
+        premium >= 0.30,
+        "early-exercise premium {premium} should be ~0.35, got binomial={binomial}, european={analytic_eu}"
+    );
+
+    // American call premium must also come from the discrete-dividend
+    // mechanism: calls on cash-dividend stocks exercise just before ex-dates.
+    let am_call = VanillaOption::american_call(100.0, 1.0);
+    let eu_call = VanillaOption::european_call(100.0, 1.0);
+    let am_call_px = BinomialTreeEngine::new(2000)
+        .price(&am_call, &market)
+        .unwrap()
+        .price;
+    let eu_call_px = BlackScholesEngine.price(&eu_call, &market).unwrap().price;
+    assert!(
+        am_call_px > eu_call_px + 0.05,
+        "American call {am_call_px} should carry a dividend-driven premium over European {eu_call_px}"
+    );
+}
+
+#[test]
+fn cross_engine_agreement_american_put_with_cash_dividend() {
+    // Requirement (3): all engines implementing the escrowed model agree.
+    let market = probe_market();
+    let am_put = VanillaOption::american_put(100.0, 1.0);
+
+    let reference = BinomialTreeEngine::new(4000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+
+    let american_binomial = AmericanBinomialEngine::new(4000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (american_binomial - reference).abs() <= 1.0e-9,
+        "american_binomial {american_binomial} vs binomial {reference}"
+    );
+
+    let checks: Vec<(&str, f64, f64)> = vec![
+        (
+            "trinomial",
+            TrinomialTreeEngine::new(1500)
+                .price(&am_put, &market)
+                .unwrap()
+                .price,
+            0.02,
+        ),
+        (
+            "crank-nicolson",
+            CrankNicolsonEngine::new(800, 800)
+                .price(&am_put, &market)
+                .unwrap()
+                .price,
+            0.05,
+        ),
+        (
+            "implicit fd",
+            ImplicitFdEngine::default()
+                .price(&am_put, &market)
+                .unwrap()
+                .price,
+            0.05,
+        ),
+        (
+            "explicit fd",
+            ExplicitFdEngine::default()
+                .price(&am_put, &market)
+                .unwrap()
+                .price,
+            0.05,
+        ),
+        (
+            "hopscotch",
+            HopscotchEngine::default()
+                .price(&am_put, &market)
+                .unwrap()
+                .price,
+            0.05,
+        ),
+    ];
+    for (label, price, tol) in checks {
+        assert!(
+            (price - reference).abs() <= tol,
+            "{label}: {price} vs binomial reference {reference}"
+        );
+    }
+
+    // LSM is a lower-bound estimator with regression bias; allow a wider
+    // band but require it to sit near the escrowed American value, far above
+    // the pre-fix smeared value (~10.57).
+    let lsm = LongstaffSchwartzEngine::new(60_000, 100, 42)
+        .price(&am_put, &market)
+        .unwrap();
+    let tol = 0.10 + 4.0 * lsm.stderr.unwrap_or(0.0);
+    assert!(
+        (lsm.price - reference).abs() <= tol,
+        "lsm american put {} vs binomial reference {} (tol {tol})",
+        lsm.price,
+        reference
+    );
+}
+
+#[test]
+fn proportional_dividend_escrowed_consistency() {
+    // 5% proportional dividend at t = 0.5 (requirement (3) uses a 5%
+    // dividend; the proportional case must be escrowed-consistent too).
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.0)
+        .dividend_schedule(
+            DividendSchedule::new(vec![
+                DividendEvent::proportional(0.5, 0.05).expect("valid event"),
+            ])
+            .expect("valid schedule"),
+        )
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+
+    let eu_put = VanillaOption::european_put(100.0, 1.0);
+    let am_put = VanillaOption::american_put(100.0, 1.0);
+
+    // Europeans stay forward-matching against the escrowed analytic engine.
+    let analytic_eu = BlackScholesEngine.price(&eu_put, &market).unwrap().price;
+    let tree_eu = BinomialTreeEngine::new(2000)
+        .price(&eu_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (tree_eu - analytic_eu).abs() <= 0.01,
+        "european binomial {tree_eu} vs analytic {analytic_eu}"
+    );
+
+    // American engines agree with each other and carry a real premium.
+    let tree_am = BinomialTreeEngine::new(2000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    let tri_am = TrinomialTreeEngine::new(1000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    let cn_am = CrankNicolsonEngine::new(800, 800)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (tree_am - tri_am).abs() <= 0.02,
+        "binomial {tree_am} vs trinomial {tri_am}"
+    );
+    assert!(
+        (tree_am - cn_am).abs() <= 0.05,
+        "binomial {tree_am} vs crank-nicolson {cn_am}"
+    );
+    let premium = tree_am - analytic_eu;
+    assert!(
+        premium >= 0.10,
+        "proportional-dividend American put premium too small: {premium}"
+    );
+}
+
+#[test]
+fn bermudan_engines_respect_escrowed_dividends() {
+    let market = probe_market();
+    let dates = vec![0.25, 0.5, 0.75];
+
+    let mut bermudan_vanilla = VanillaOption::american_put(100.0, 1.0);
+    bermudan_vanilla.exercise = ExerciseStyle::Bermudan {
+        dates: dates.clone(),
+    };
+    let european = VanillaOption::european_put(100.0, 1.0);
+    let american = VanillaOption::american_put(100.0, 1.0);
+
+    let tree_engine = BinomialTreeEngine::new(2000);
+    let eu = BlackScholesEngine.price(&european, &market).unwrap().price;
+    let berm_tree = tree_engine.price(&bermudan_vanilla, &market).unwrap().price;
+    let am = tree_engine.price(&american, &market).unwrap().price;
+
+    assert!(
+        eu - 1.0e-9 <= berm_tree && berm_tree <= am + 1.0e-9,
+        "bermudan {berm_tree} must sit between european {eu} and american {am}"
+    );
+    // The 0.5 exercise date sits right at the ex-date, so the Bermudan must
+    // capture most of the American early-exercise premium.
+    assert!(
+        berm_tree - eu >= 0.15,
+        "bermudan premium too small: {} (eu={eu})",
+        berm_tree - eu
+    );
+
+    // Dedicated Bermudan instruments through CN and LSM agree with the tree.
+    let bermudan = BermudanOption::new(
+        OptionType::Put,
+        1.0,
+        dates.clone(),
+        vec![100.0, 100.0, 100.0],
+    );
+    let cn = CrankNicolsonEngine::new(800, 800)
+        .price(&bermudan, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (cn - berm_tree).abs() <= 0.05,
+        "cn bermudan {cn} vs tree bermudan {berm_tree}"
+    );
+
+    let lsm = LongstaffSchwartzEngine::new(60_000, 100, 42)
+        .price(&bermudan, &market)
+        .unwrap();
+    let tol = 0.10 + 4.0 * lsm.stderr.unwrap_or(0.0);
+    assert!(
+        (lsm.price - berm_tree).abs() <= tol,
+        "lsm bermudan {} vs tree bermudan {berm_tree} (tol {tol})",
+        lsm.price
+    );
+}
+
+#[test]
+fn lsm_barrier_applies_true_ex_dividend_drops_on_path() {
+    // Mirrors tests/dividend_modelling_issue58.rs barrier_mc test: with
+    // r = q = 0 and ~zero vol, the path is deterministic at 100 until the
+    // 10.0 cash dividend at t = 0.5 drops it to 90, knocking in the
+    // down-and-in 95 put, which then pays K - S_T = 10 at expiry. The old
+    // effective-yield smear drifted the path smoothly and never produced
+    // the discrete drop.
+    let barrier = BarrierOption::builder()
+        .put()
+        .strike(100.0)
+        .expiry(1.0)
+        .down_and_in(95.0)
+        .rebate(0.0)
+        .build()
+        .expect("valid barrier");
+
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.0)
+        .dividend_yield(0.0)
+        .dividend_schedule(
+            DividendSchedule::new(vec![DividendEvent::cash(0.5, 10.0).expect("valid event")])
+                .expect("valid schedule"),
+        )
+        .flat_vol(1.0e-8)
+        .build()
+        .expect("valid market");
+
+    let engine = LongstaffSchwartzEngine::new(4_000, 252, 42);
+    let price = engine.price(&barrier, &market).unwrap().price;
+    assert!(
+        (price - 10.0).abs() <= 1.0e-3,
+        "expected ~10 from the knocked-in put after the ex-div drop, got {price}"
+    );
+}
+
+#[test]
+fn continuous_yield_only_behavior_is_preserved() {
+    // With an empty discrete schedule the escrowed transform is the exact
+    // identity: engines must agree with the analytic European and each other
+    // exactly as before the escrowed-model change.
+    let market = Market::builder()
+        .spot(100.0)
+        .rate(0.03)
+        .dividend_yield(0.02)
+        .flat_vol(0.25)
+        .build()
+        .expect("valid market");
+
+    assert_eq!(market.escrowed_spot(1.0), 100.0);
+    assert_eq!(market.escrowed_reconstruction(0.5, 1.0), (1.0, 0.0));
+
+    let eu_put = VanillaOption::european_put(100.0, 1.0);
+    let analytic = BlackScholesEngine.price(&eu_put, &market).unwrap().price;
+    let tree = BinomialTreeEngine::new(2000)
+        .price(&eu_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (tree - analytic).abs() <= 0.01,
+        "continuous-yield European drifted: tree={tree}, analytic={analytic}"
+    );
+
+    let am_put = VanillaOption::american_put(100.0, 1.0);
+    let bin = BinomialTreeEngine::new(2000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    let ambin = AmericanBinomialEngine::new(2000)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    let cn = CrankNicolsonEngine::new(400, 400)
+        .price(&am_put, &market)
+        .unwrap()
+        .price;
+    assert!(
+        (bin - ambin).abs() <= 1.0e-12,
+        "binomial engines diverged without dividends: {bin} vs {ambin}"
+    );
+    assert!(
+        (bin - cn).abs() <= 0.05,
+        "binomial vs CN diverged without dividends: {bin} vs {cn}"
+    );
+}

--- a/tests/audit_fft_admissibility.rs
+++ b/tests/audit_fft_admissibility.rs
@@ -1,0 +1,312 @@
+//! Regression tests for Carr-Madan damping admissibility and non-finite propagation.
+//!
+//! Audit finding: the FFT transform layer masked NaN integrands to 0.0
+//! (`f64::max(0.0)` returns the non-NaN operand) and never verified the
+//! Carr-Madan admissibility condition `E[S_T^(alpha+1)] < inf` (Carr & Madan
+//! 1999, Section 2; default alpha = 1.5 requires a finite 2.5-th spot moment).
+//! Moment-exploding Heston parameterizations silently returned all-zero calls
+//! (parity puts near -50), and VG/CGMY/NIG sets that pass their risk-neutral
+//! constructors but violate the damping moment bound crossed principal branch
+//! cuts and returned finite calls far below the no-arbitrage lower bound
+//! `S*exp(-q*T) - K*exp(-r*T)` (e.g. a K=50 call of 8.79 against a bound of
+//! ~51).
+//!
+//! After the fix every FFT pricing entry point must either return arbitrage-
+//! free prices (possibly after automatically reducing alpha to an admissible
+//! value) or a clean error - never a silent zero or below-intrinsic price.
+//!
+//! Reference numbers used below:
+//! - No-arbitrage bounds are the standard European call bounds
+//!   `max(0, S*exp(-q*T) - K*exp(-r*T)) <= C <= S*exp(-q*T)` (model-free).
+//! - The Black-Scholes anchor 8.916037 for S=K=100, r=0.02, q=0, sigma=0.2,
+//!   T=1 is the closed-form value: d1=0.2, d2=0.0,
+//!   C = 100*N(0.2) - 100*exp(-0.02)*N(0.0).
+//! - The Heston anchor 16.070154917028834 (K=100) is QuantLib's cached Lewis
+//!   dataset value from vendor/QuantLib/test-suite/hestonmodel.cpp (same
+//!   source as tests/fixtures/heston_expected_put_call.csv).
+
+use openferric::engines::fft::{
+    CarrMadanContext, CarrMadanParams, CgmyCharFn, DEFAULT_ALPHA, NigCharFn, VarianceGammaCharFn,
+    carr_madan_price_at_strikes, heston_price_fft, try_heston_price_fft,
+};
+
+const SPOT: f64 = 100.0;
+const RATE: f64 = 0.02;
+const DIV: f64 = 0.0;
+const STRIKES: [f64; 3] = [50.0, 100.0, 150.0];
+
+/// Absolute tolerance on the model-free call bounds. The audited failures
+/// violated the lower bound by 17-51 currency units; genuine quadrature noise
+/// (including reduced-alpha fallbacks) stays well inside half a unit.
+const BOUND_TOL: f64 = 0.5;
+
+fn assert_arbitrage_free(prices: &[(f64, f64)], maturity: f64, label: &str) {
+    assert_eq!(prices.len(), STRIKES.len(), "{label}: wrong output length");
+    let forward_spot = SPOT * (-DIV * maturity).exp();
+    for (strike, call) in prices {
+        let lower = (forward_spot - strike * (-RATE * maturity).exp()).max(0.0);
+        assert!(
+            call.is_finite(),
+            "{label}: non-finite call at K={strike}: {call}"
+        );
+        assert!(
+            *call >= lower - BOUND_TOL,
+            "{label}: call {call} at K={strike} is below the no-arbitrage lower bound {lower}"
+        );
+        assert!(
+            *call <= forward_spot + BOUND_TOL,
+            "{label}: call {call} at K={strike} exceeds the upper bound {forward_spot}"
+        );
+    }
+}
+
+/// Audit case 1 (NaN-masked-to-zero regime): Heston v0=0.04, kappa=0.5,
+/// theta=0.04, xi=1.5, rho=+0.7, T=5. The 2.5-th moment explodes and the
+/// characteristic function is non-finite on the damping contour; before the
+/// fix every strike returned exactly 0.0 (parity put ~ -54.8).
+#[test]
+fn heston_nan_regime_is_not_masked_to_zero() {
+    let result = try_heston_price_fft(SPOT, &STRIKES, RATE, DIV, 0.04, 0.5, 0.04, 1.5, 0.7, 5.0);
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, 5.0, "heston kappa=0.5 xi=1.5 rho=0.7 T=5"),
+    }
+
+    // The infallible convenience API documents an empty vector on failure;
+    // it must never return confident garbage.
+    let prices = heston_price_fft(SPOT, &STRIKES, RATE, DIV, 0.04, 0.5, 0.04, 1.5, 0.7, 5.0);
+    if !prices.is_empty() {
+        assert_arbitrage_free(
+            &prices,
+            5.0,
+            "heston_price_fft kappa=0.5 xi=1.5 rho=0.7 T=5",
+        );
+    }
+}
+
+/// Audit case 2 (finite-but-wrong-branch regime): same as case 1 but with
+/// kappa=2.0 the characteristic function stays finite while the moment still
+/// explodes. Before the fix the K=50 call was 37.72 against a lower bound of
+/// 54.76 - no NaN ever appeared, so NaN propagation alone cannot catch this.
+#[test]
+fn heston_finite_branch_garbage_is_not_below_intrinsic() {
+    let result = try_heston_price_fft(SPOT, &STRIKES, RATE, DIV, 0.04, 2.0, 0.04, 1.5, 0.7, 5.0);
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, 5.0, "heston kappa=2.0 xi=1.5 rho=0.7 T=5"),
+    }
+}
+
+/// Audit case 3: Heston rho=0, xi=3, T=3 returned a K=50 call of ~50.1
+/// against a lower bound of 52.91 before the fix.
+#[test]
+fn heston_high_volvol_zero_corr_is_not_below_intrinsic() {
+    let result = try_heston_price_fft(SPOT, &STRIKES, RATE, DIV, 0.04, 1.0, 0.04, 3.0, 0.0, 3.0);
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, 3.0, "heston kappa=1.0 xi=3.0 rho=0 T=3"),
+    }
+}
+
+/// Audit case 4: VG sigma=0.3, theta=+0.3, nu=1.5 passes the risk-neutral
+/// constructor (martingale term 1 - 0.45 - 0.0675 = 0.4825 > 0) but the
+/// Carr-Madan denominator at the default damping point u = -2.5i is
+/// 1 - 0.45*2.5 - 0.0675*6.25 = -0.546875, so powf continued on the principal
+/// branch and the K=50 call came back ~9.0 against a lower bound of 50.99.
+#[test]
+fn vg_positive_theta_high_nu_is_not_below_intrinsic() {
+    let maturity = 1.0;
+    let cf = VarianceGammaCharFn::risk_neutral(SPOT, RATE, DIV, maturity, 0.3, 0.3, 1.5)
+        .expect("VG constructor accepts this set");
+    let result = carr_madan_price_at_strikes(
+        &cf,
+        RATE,
+        maturity,
+        SPOT,
+        &STRIKES,
+        CarrMadanParams::default(),
+    );
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, maturity, "vg sigma=0.3 theta=0.3 nu=1.5"),
+    }
+}
+
+/// Audit case 5: CGMY with M=1.2 passes the constructor (which only requires
+/// M > 1) but E[S^2.5] needs M > 2.5; the base of (M - i*u)^Y turns negative
+/// real on the contour and powc crosses the branch cut. Before the fix the
+/// K=50 call was 3.67 against a lower bound of 50.99.
+#[test]
+fn cgmy_m_slightly_above_one_is_not_below_intrinsic() {
+    let maturity = 1.0;
+    let cf = CgmyCharFn::risk_neutral(SPOT, RATE, DIV, maturity, 0.5, 5.0, 1.2, 0.5)
+        .expect("CGMY constructor accepts M=1.2");
+    let result = carr_madan_price_at_strikes(
+        &cf,
+        RATE,
+        maturity,
+        SPOT,
+        &STRIKES,
+        CarrMadanParams::default(),
+    );
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, maturity, "cgmy M=1.2"),
+    }
+}
+
+/// CGMY with M=1.05 admits no damping alpha at or above the fallback floor
+/// (0.1 requires a finite 1.1-th moment, but moments explode at 1.05), so the
+/// pricing call must fail cleanly instead of returning garbage.
+#[test]
+fn cgmy_without_admissible_alpha_errors_cleanly() {
+    let maturity = 1.0;
+    let cf = CgmyCharFn::risk_neutral(SPOT, RATE, DIV, maturity, 0.5, 5.0, 1.05, 0.5)
+        .expect("CGMY constructor accepts M=1.05");
+    let result = carr_madan_price_at_strikes(
+        &cf,
+        RATE,
+        maturity,
+        SPOT,
+        &STRIKES,
+        CarrMadanParams::default(),
+    );
+    let err = result.expect_err("no admissible damping alpha exists for M=1.05");
+    assert!(
+        err.contains("inadmissible"),
+        "error should explain the admissibility failure, got: {err}"
+    );
+}
+
+/// NIG with alpha_nig=2, beta=0.5 passes the constructor (|beta+1| < alpha)
+/// but the default damping moment 2.5 violates |beta + 2.5| < alpha_nig, so
+/// the CF square root turns imaginary on the contour.
+#[test]
+fn nig_damping_beyond_martingale_bound_is_not_below_intrinsic() {
+    let maturity = 1.0;
+    let cf = NigCharFn::risk_neutral(SPOT, RATE, DIV, maturity, 2.0, 0.5, 0.5)
+        .expect("NIG constructor accepts alpha=2, beta=0.5");
+    let result = carr_madan_price_at_strikes(
+        &cf,
+        RATE,
+        maturity,
+        SPOT,
+        &STRIKES,
+        CarrMadanParams::default(),
+    );
+    match result {
+        Err(msg) => assert!(!msg.is_empty(), "error message must be descriptive"),
+        Ok(prices) => assert_arbitrage_free(&prices, maturity, "nig alpha=2 beta=0.5"),
+    }
+}
+
+/// The automatic fallback must be observable: a VG model whose admissible
+/// moment bound (m < 1.7584) rejects the default alpha=1.5 gets a reduced
+/// alpha in the reusable context, and the context still prices sanely.
+#[test]
+fn context_reports_reduced_alpha_when_fallback_engages() {
+    let maturity = 1.0;
+    let cf = VarianceGammaCharFn::risk_neutral(SPOT, RATE, DIV, maturity, 0.3, 0.3, 1.5)
+        .expect("VG constructor accepts this set");
+    let ctx = CarrMadanContext::new(&cf, RATE, maturity, SPOT, CarrMadanParams::default())
+        .expect("an admissible fallback alpha exists (any alpha < 0.7584)");
+    assert!(
+        ctx.params().alpha < DEFAULT_ALPHA,
+        "context must expose the reduced admissible alpha, got {}",
+        ctx.params().alpha
+    );
+    let prices = ctx
+        .price_strikes(&STRIKES)
+        .expect("context pricing succeeds");
+    assert_arbitrage_free(&prices, maturity, "vg fallback context");
+}
+
+/// The automatic fallback must refine the frequency grid alongside the
+/// reduced alpha. A small alpha sharpens the damped integrand's peak near
+/// v = 0 (peak width scales with alpha), and the default eta = 0.25 that was
+/// tuned for alpha = 1.5 under-resolves it: before the grid refinement the
+/// Heston kappa=2, xi=1.5, rho=+0.7, T=5 fallback (alpha 1.5 -> 0.1875)
+/// returned calls with a ~0.9 currency-unit strike-independent error - within
+/// the model-free bounds, so only visible on the parity put (K=50 put of 1.03
+/// instead of ~0.102).
+///
+/// Anchors:
+/// - Parity put at K=50 cross-checked against an independent full-truncation
+///   Euler Monte Carlo (400k antithetic paths, 2000 steps, splitmix64 seed
+///   4242): put = 0.1015 +/- 0.0019 (1 s.e.). The converged FFT value is
+///   0.10198, stable to 1e-9 under further eta refinement (eta = 0.0625 and
+///   0.015625 at fixed range n*eta = 1024).
+/// - Self-consistency: an explicitly finer admissible grid must agree with
+///   the auto-refined fallback grid to quadrature accuracy.
+#[test]
+fn fallback_refines_quadrature_grid() {
+    use openferric::engines::fft::{CarrMadanContext, HestonCharFn};
+
+    let (v0, kappa, theta, xi, rho, t) = (0.04, 2.0, 0.04, 1.5, 0.7, 5.0);
+    let prices = try_heston_price_fft(SPOT, &STRIKES, RATE, DIV, v0, kappa, theta, xi, rho, t)
+        .expect("fallback alpha exists for this set");
+    let put50 = prices[0].1 - SPOT + STRIKES[0] * (-RATE * t).exp();
+    assert!(
+        (put50 - 0.102).abs() < 0.02,
+        "K=50 parity put {put50} deviates from the MC-anchored value 0.102: \
+         the fallback frequency grid under-resolves the small-alpha integrand peak"
+    );
+
+    // Self-consistency against an explicitly refined grid (the context also
+    // resolves admissibility, exercising the n-cap branch of the refinement).
+    let cf = HestonCharFn::new(SPOT, RATE, DIV, t, v0, kappa, theta, xi, rho);
+    let fine = CarrMadanParams {
+        n: 65536,
+        eta: 0.015625,
+        alpha: DEFAULT_ALPHA,
+    };
+    let refined = CarrMadanContext::new(&cf, RATE, t, SPOT, fine)
+        .expect("refined context builds")
+        .price_strikes(&STRIKES)
+        .expect("refined context prices");
+    for ((k_a, c_a), (k_b, c_b)) in prices.iter().zip(refined.iter()) {
+        assert_eq!(k_a, k_b);
+        assert!(
+            (c_a - c_b).abs() < 1e-4,
+            "fallback grid call {c_a} at K={k_a} disagrees with refined-grid call {c_b}"
+        );
+    }
+}
+
+/// Healthy-regime anchor: the QuantLib Lewis dataset (cached values from
+/// vendor/QuantLib/test-suite/hestonmodel.cpp, same source as
+/// tests/fixtures/heston_expected_put_call.csv) must still price through the
+/// default path with alpha untouched - the admissibility layer must not
+/// perturb valid parameterizations.
+#[test]
+fn healthy_heston_reference_price_is_unchanged() {
+    // spot=100, r=0.01, q=0.02, T=1, v0=0.04, kappa=4.0, theta=0.25,
+    // sigma_v=1.0, rho=-0.5; expected K=100 call = 16.070154917028834.
+    let prices = try_heston_price_fft(100.0, &[100.0], 0.01, 0.02, 0.04, 4.0, 0.25, 1.0, -0.5, 1.0)
+        .expect("healthy Heston set must price without error");
+    let expected = 16.070154917028834;
+    assert!(
+        (prices[0].1 - expected).abs() < 1e-2,
+        "QuantLib Lewis anchor drifted: got {} expected {expected}",
+        prices[0].1
+    );
+}
+
+/// Healthy-regime anchor: Carr-Madan under Black-Scholes matches the closed
+/// form C = S*N(d1) - K*exp(-r*T)*N(d2) = 8.916037 for S=K=100, r=0.02, q=0,
+/// sigma=0.2, T=1 (d1=0.2, d2=0).
+#[test]
+fn healthy_black_scholes_anchor_is_unchanged() {
+    use openferric::engines::fft::BlackScholesCharFn;
+
+    let cf = BlackScholesCharFn::new(100.0, 0.02, 0.0, 0.2, 1.0);
+    let prices =
+        carr_madan_price_at_strikes(&cf, 0.02, 1.0, 100.0, &[100.0], CarrMadanParams::default())
+            .expect("BS pricing succeeds");
+    let expected = 8.916037;
+    assert!(
+        (prices[0].1 - expected).abs() < 5e-3,
+        "BS closed-form anchor drifted: got {} expected {expected}",
+        prices[0].1
+    );
+}

--- a/tests/audit_hw_calibration.rs
+++ b/tests/audit_hw_calibration.rs
@@ -1,0 +1,223 @@
+//! Audit tests for `models::hw_calibration` volatility-unit consistency.
+//!
+//! Background: `hw_atm_swaption_vol_approx` returns an ATM *normal
+//! (Bachelier)* volatility (absolute rate units, Hull-White `sigma` scale,
+//! ~0.01), not a lognormal Black volatility (~0.20 at 4% rates). A past
+//! defect labeled it a Black vol and pushed it through a lognormal ATM price
+//! transform next to market Black quotes; feeding realistic Black vols then
+//! silently returned a boundary-pinned degenerate fit (a, sigma) ~ (4e-4,
+//! 0.08) instead of ~0.01. The in-module round-trip test could not catch this
+//! because it generates quotes from the same formula.
+//!
+//! These tests anchor the approximation and the calibrator against an
+//! *independent* pricing path: the exact Hull-White ATM payer swaption price
+//! via Jamshidian's (1989) decomposition into zero-coupon-bond puts, using
+//! the closed forms of Brigo and Mercurio, "Interest Rate Models - Theory and
+//! Practice", 2nd ed. (2006), Section 3.3 (Eqs. (3.39)-(3.41) and the
+//! decomposition around Eq. (3.45)). Prices are converted to normal vols with
+//! the Bachelier ATM formula `price = annuity * sigma_n * sqrt(T / (2*pi))`.
+
+use openferric::math::normal_cdf;
+use openferric::models::{calibrate_hull_white_params, hw_atm_swaption_vol_approx};
+
+/// Flat continuously-compounded zero curve.
+const R0: f64 = 0.04;
+
+fn discount(t: f64) -> f64 {
+    (-R0 * t).exp()
+}
+
+/// `B(t, T) = (1 - exp(-a (T - t))) / a`, Brigo-Mercurio Eq. (3.39).
+fn hw_b(a: f64, t: f64, maturity: f64) -> f64 {
+    (1.0 - (-a * (maturity - t)).exp()) / a
+}
+
+/// `A(t, T)` for Hull-White fitted to the initial curve, Brigo-Mercurio
+/// Eq. (3.39). On a flat curve the instantaneous forward is `f(0, t) = R0`.
+fn hw_a(a: f64, sigma: f64, t: f64, maturity: f64) -> f64 {
+    let b = hw_b(a, t, maturity);
+    (discount(maturity) / discount(t))
+        * (b * R0 - sigma * sigma / (4.0 * a) * (1.0 - (-2.0 * a * t).exp()) * b * b).exp()
+}
+
+/// Fitted-curve Hull-White zero-coupon bond price `P(t, T; r)`.
+fn hw_bond_price(a: f64, sigma: f64, t: f64, maturity: f64, short_rate: f64) -> f64 {
+    hw_a(a, sigma, t, maturity) * (-hw_b(a, t, maturity) * short_rate).exp()
+}
+
+/// European put on a zero-coupon bond, `ZBP(0, expiry, bond_maturity, strike)`,
+/// Brigo-Mercurio Eqs. (3.40)-(3.41).
+fn hw_zero_bond_put(a: f64, sigma: f64, expiry: f64, bond_maturity: f64, strike: f64) -> f64 {
+    let sigma_p = sigma
+        * ((1.0 - (-2.0 * a * expiry).exp()) / (2.0 * a)).sqrt()
+        * hw_b(a, expiry, bond_maturity);
+    let h = (discount(bond_maturity) / (discount(expiry) * strike)).ln() / sigma_p + 0.5 * sigma_p;
+    strike * discount(expiry) * normal_cdf(-h + sigma_p) - discount(bond_maturity) * normal_cdf(-h)
+}
+
+/// Annuity (PVBP) of an annual fixed leg paying at `expiry + 1, .., expiry + tenor`.
+fn annuity(expiry: f64, tenor_years: usize) -> f64 {
+    (1..=tenor_years).map(|i| discount(expiry + i as f64)).sum()
+}
+
+/// ATM forward swap rate on the flat curve.
+fn forward_swap_rate(expiry: f64, tenor_years: usize) -> f64 {
+    (discount(expiry) - discount(expiry + tenor_years as f64)) / annuity(expiry, tenor_years)
+}
+
+/// Exact Hull-White ATM payer swaption price via Jamshidian's decomposition
+/// (Brigo-Mercurio Section 3.3): find `r*` with
+/// `sum_i c_i P(expiry, t_i; r*) = 1`, then the payer swaption is
+/// `sum_i c_i ZBP(expiry, t_i, K_i)` with `K_i = P(expiry, t_i; r*)`.
+fn jamshidian_atm_payer_price(a: f64, sigma: f64, expiry: f64, tenor_years: usize) -> f64 {
+    let strike_rate = forward_swap_rate(expiry, tenor_years);
+    let pay_times: Vec<f64> = (1..=tenor_years).map(|i| expiry + i as f64).collect();
+    let coupons: Vec<f64> = (1..=tenor_years)
+        .map(|i| {
+            if i == tenor_years {
+                1.0 + strike_rate
+            } else {
+                strike_rate
+            }
+        })
+        .collect();
+
+    // Coupon-bond price at expiry is strictly decreasing in the short rate,
+    // so bisect for r*.
+    let bond_at = |r: f64| -> f64 {
+        pay_times
+            .iter()
+            .zip(coupons.iter())
+            .map(|(t, c)| c * hw_bond_price(a, sigma, expiry, *t, r))
+            .sum()
+    };
+    let (mut lo, mut hi) = (-1.0_f64, 2.0_f64);
+    assert!(bond_at(lo) > 1.0 && bond_at(hi) < 1.0, "r* bracket invalid");
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if bond_at(mid) > 1.0 {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    let r_star = 0.5 * (lo + hi);
+
+    pay_times
+        .iter()
+        .zip(coupons.iter())
+        .map(|(t, c)| {
+            let strike_i = hw_bond_price(a, sigma, expiry, *t, r_star);
+            c * hw_zero_bond_put(a, sigma, expiry, *t, strike_i)
+        })
+        .sum()
+}
+
+/// Invert the Bachelier ATM formula `price = annuity * sigma_n * sqrt(T/(2 pi))`
+/// (exact at the money, where the Bachelier price is linear in the vol).
+fn implied_atm_normal_vol(price: f64, expiry: f64, tenor_years: usize) -> f64 {
+    price / (annuity(expiry, tenor_years) * (expiry / (2.0 * std::f64::consts::PI)).sqrt())
+}
+
+/// The approximation must sit at the *normal-vol* scale: within a modest
+/// approximation tolerance of the Jamshidian-implied Bachelier vol, and an
+/// order of magnitude away from the Black (lognormal) vol of the same price.
+///
+/// For (a, sigma) = (0.05, 0.01), expiry 5y, tenor 5y on a flat 4% curve the
+/// implied Black ATM vol is `~ sigma_n / F ~ 0.19`, roughly 25x the normal
+/// vol, so a 10% tolerance decisively pins the unit (observed relative error
+/// of the frozen-weight approximation is 4.0%-5.5% across this matrix).
+#[test]
+fn approximation_matches_jamshidian_implied_normal_vol_scale() {
+    let a = 0.05;
+    let sigma = 0.01;
+
+    for expiry in [1.0, 2.0, 5.0] {
+        for tenor_years in [2usize, 5, 10] {
+            let price = jamshidian_atm_payer_price(a, sigma, expiry, tenor_years);
+            let implied_normal = implied_atm_normal_vol(price, expiry, tenor_years);
+            let approx = hw_atm_swaption_vol_approx(a, sigma, expiry, tenor_years as f64);
+            let rel = (approx - implied_normal).abs() / implied_normal;
+            eprintln!(
+                "expiry={expiry} tenor={tenor_years}: jamshidian_normal={implied_normal:.6} \
+                 approx={approx:.6} rel_err={rel:.4} black_equiv={:.4}",
+                implied_normal / forward_swap_rate(expiry, tenor_years)
+            );
+            assert!(
+                rel < 0.10,
+                "approx {approx} vs Jamshidian-implied normal vol {implied_normal} \
+                 (rel err {rel}) for expiry {expiry}, tenor {tenor_years}"
+            );
+
+            // Unit pin: the same price expressed as a Black vol is
+            // sigma_n / F at the money, ~20x larger. The approximation must
+            // be nowhere near it.
+            let black_equiv = implied_normal / forward_swap_rate(expiry, tenor_years);
+            assert!(
+                approx < 0.25 * black_equiv,
+                "approx {approx} is at the lognormal scale ({black_equiv})"
+            );
+        }
+    }
+}
+
+/// End-to-end external anchor: generate ATM swaption prices from the exact
+/// Jamshidian pricer at known (a, sigma) = (0.05, 0.01), convert to normal
+/// vols via the Bachelier ATM formula, calibrate, and recover sigma. The
+/// pre-fix code fed comparable market data into a lognormal transform and
+/// returned sigma pinned at 0.08; recovered sigma must sit near 0.01 and
+/// inside the plausible normal-vol band [0.003, 0.03].
+#[test]
+fn calibration_recovers_sigma_from_jamshidian_prices() {
+    let true_a = 0.05;
+    let true_sigma = 0.01;
+
+    let mut quotes = Vec::new();
+    for expiry in [1.0, 2.0, 3.0, 4.0, 5.0] {
+        for tenor_years in [2usize, 5, 10] {
+            let price = jamshidian_atm_payer_price(true_a, true_sigma, expiry, tenor_years);
+            let vol = implied_atm_normal_vol(price, expiry, tenor_years);
+            quotes.push((expiry, tenor_years as f64, vol));
+        }
+    }
+
+    let (cal_a, cal_sigma) =
+        calibrate_hull_white_params(&quotes).expect("normal-vol quotes must calibrate");
+    eprintln!("calibrated a={cal_a:.6} sigma={cal_sigma:.6}");
+
+    assert!(
+        (0.003..=0.03).contains(&cal_sigma),
+        "calibrated sigma {cal_sigma} outside plausible normal-vol band"
+    );
+    // Observed recovery: (a, sigma) = (0.0472, 0.01034); the residual bias is
+    // the frozen-weight approximation error, well under the 10% band.
+    let rel_sigma = (cal_sigma - true_sigma).abs() / true_sigma;
+    assert!(
+        rel_sigma <= 0.10,
+        "sigma {cal_sigma} not within 10% of true {true_sigma} (rel {rel_sigma})"
+    );
+    assert!(
+        cal_a > 0.0 && cal_a < 0.5,
+        "calibrated a {cal_a} implausible"
+    );
+}
+
+/// Feeding lognormal Black ATM vols (~0.20 at 4% rates, the verified failure
+/// mode) must fail loudly instead of silently returning the boundary-pinned
+/// (a, sigma) ~ (4e-4, 0.08) the pre-fix code produced.
+#[test]
+fn black_lognormal_vol_inputs_are_rejected() {
+    // Realistic ATM Black vol surface at ~4% rates: 15-25% lognormal.
+    let mut quotes = Vec::new();
+    for expiry in [1.0, 2.0, 3.0, 4.0, 5.0] {
+        for tenor in [2.0, 5.0, 10.0] {
+            let black_vol = 0.20 - 0.005 * (expiry - 1.0) + 0.002 * (tenor - 2.0) / 8.0;
+            quotes.push((expiry, tenor, black_vol));
+        }
+    }
+
+    assert!(
+        calibrate_hull_white_params(&quotes).is_none(),
+        "Black-scale vols must be rejected, not fitted to a boundary-pinned sigma"
+    );
+}

--- a/tests/audit_tarf.rs
+++ b/tests/audit_tarf.rs
@@ -1,0 +1,301 @@
+//! Audit regression tests for TARF knock-out semantics.
+//!
+//! Guards against a bug where the decumulator TARF applied the *upside* KO
+//! check `s >= ko_barrier` (the standard-TARF direction), so a downside
+//! barrier knocked out every path at the first fixing and an upside barrier
+//! cancelled the product exactly in the states where the holder was losing,
+//! overstating decumulator value.
+//!
+//! Reference values are external anchors: analytic Black-Scholes prices from
+//! `openferric::engines::analytic::black_scholes::bs_price` combined into
+//! closed-form strips of leveraged forwards (each TARF fixing without KO and
+//! target is a leveraged synthetic forward, Wystup "FX Options and Structured
+//! Products" 2nd ed.). No MC self-references.
+
+use openferric::core::OptionType;
+use openferric::engines::analytic::black_scholes::bs_price;
+use openferric::instruments::tarf::Tarf;
+use openferric::pricing::tarf::tarf_mc_price;
+
+/// Effectively unreachable target profit (must stay finite for `validate()`).
+const NO_TARGET: f64 = 1e15;
+/// Universal "no KO barrier" sentinel for both TARF types.
+const NO_BARRIER: f64 = f64::INFINITY;
+
+fn weekly_fixings() -> Vec<f64> {
+    (1..=52).map(|w| w as f64 / 52.0).collect()
+}
+
+/// Closed-form value of a TARF with no KO barrier and unreachable target: a
+/// strip of leveraged forwards. `gain`/`lose` are the option payoffs
+/// replicating the winning and (leveraged) losing legs of each fixing:
+/// Standard = Call/Put, Decumulator = Put/Call. `bs_price` handles
+/// discounting, matching the `exp(-rate * t_i)` factor in the MC.
+#[allow(clippy::too_many_arguments)]
+fn strip_closed_form(
+    gain: OptionType,
+    lose: OptionType,
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    q: f64,
+    vol: f64,
+    notional: f64,
+    leverage: f64,
+    fixings: &[f64],
+) -> f64 {
+    fixings
+        .iter()
+        .map(|&t| {
+            notional
+                * (bs_price(gain, spot, strike, rate, q, vol, t)
+                    - leverage * bs_price(lose, spot, strike, rate, q, vol, t))
+        })
+        .sum()
+}
+
+/// The decumulator KO barrier is a downside barrier: it must trigger when
+/// spot falls through it and must NOT trigger when spot rallies away from it.
+///
+/// Under the inverted implementation (`s >= 80` with spot 100) every path
+/// knocked out at fixing 1 regardless of direction: prob_ko = 1.0,
+/// avg_fixings = 1.0, price = 0.0 in both scenarios below.
+#[test]
+fn decumulator_downside_ko_triggers_on_falling_spot_not_on_rally() {
+    let tarf = Tarf::decumulator(100.0, 1000.0, 80.0, NO_TARGET, 2.0, weekly_fixings());
+
+    // Strong downward risk-neutral drift (r = 0, q = 30%): log-drift is
+    // -0.311/yr, so P(S_1y <= 80) = Phi(0.59) ~ 0.72 before even counting
+    // intermediate fixings. The downside KO must fire on most paths.
+    let falling = tarf_mc_price(&tarf, 100.0, 0.0, 0.30, 0.15, 20_000, 42).unwrap();
+
+    // Strong upward drift (r = 30%, q = 0): the static lower-barrier hit
+    // probability (b/S0)^(2 nu / sigma^2) = 0.8^25.7 ~ 0.3% bounds the
+    // continuously-monitored case from above; discrete weekly monitoring is
+    // rarer still.
+    let rallying = tarf_mc_price(&tarf, 100.0, 0.30, 0.0, 0.15, 20_000, 42).unwrap();
+
+    assert!(
+        falling.prob_ko_hit > 0.5,
+        "downside KO must fire on falling paths, got prob_ko = {}",
+        falling.prob_ko_hit
+    );
+    assert!(
+        rallying.prob_ko_hit < 0.05,
+        "downside KO must not fire on rallying paths, got prob_ko = {}",
+        rallying.prob_ko_hit
+    );
+    // Not an instant fixing-1 knock-out in either scenario.
+    assert!(
+        falling.avg_fixings > 1.5,
+        "avg_fixings = {} suggests instant KO at fixing 1",
+        falling.avg_fixings
+    );
+    assert!(
+        rallying.avg_fixings > 10.0,
+        "avg_fixings = {} suggests spurious early KO",
+        rallying.avg_fixings
+    );
+}
+
+/// Degenerate limit: KO barrier unreachable (INFINITY sentinel) + target
+/// unreachable reduces both TARF types to closed-form strips of leveraged
+/// forwards. Anchors are analytic Black-Scholes strips (see module docs); the
+/// GBM stepping is exact-in-distribution, so the MC estimate is unbiased and
+/// a 4-standard-error band at a fixed seed is a sound acceptance region.
+#[test]
+fn tarf_without_ko_and_target_prices_as_forward_strip() {
+    let (spot, rate, q, vol) = (100.0, 0.03, 0.0, 0.15);
+    let (strike, notional, leverage) = (100.0, 1000.0, 2.0);
+    let fixings = weekly_fixings();
+
+    // Standard: each fixing pays N * [(S-K)+ - L*(K-S)+]  => N * [C - L*P].
+    let std_closed = strip_closed_form(
+        OptionType::Call,
+        OptionType::Put,
+        spot,
+        strike,
+        rate,
+        q,
+        vol,
+        notional,
+        leverage,
+        &fixings,
+    );
+    // Decumulator: each fixing pays N * [(K-S)+ - L*(S-K)+] => N * [P - L*C].
+    let dec_closed = strip_closed_form(
+        OptionType::Put,
+        OptionType::Call,
+        spot,
+        strike,
+        rate,
+        q,
+        vol,
+        notional,
+        leverage,
+        &fixings,
+    );
+
+    let std_tarf = Tarf::standard(
+        strike,
+        notional,
+        NO_BARRIER,
+        NO_TARGET,
+        leverage,
+        fixings.clone(),
+    );
+    let dec_tarf = Tarf::decumulator(strike, notional, NO_BARRIER, NO_TARGET, leverage, fixings);
+
+    let std_mc = tarf_mc_price(&std_tarf, spot, rate, q, vol, 100_000, 42).unwrap();
+    let dec_mc = tarf_mc_price(&dec_tarf, spot, rate, q, vol, 100_000, 42).unwrap();
+
+    assert!(
+        (std_mc.price - std_closed).abs() < 4.0 * std_mc.std_error,
+        "standard strip: mc = {} +/- {}, closed form = {}",
+        std_mc.price,
+        std_mc.std_error,
+        std_closed
+    );
+    assert!(
+        (dec_mc.price - dec_closed).abs() < 4.0 * dec_mc.std_error,
+        "decumulator strip: mc = {} +/- {}, closed form = {}",
+        dec_mc.price,
+        dec_mc.std_error,
+        dec_closed
+    );
+    // The INFINITY sentinel must never register a KO for either type (for the
+    // decumulator this exercises the is_finite() guard on `s <= barrier`).
+    assert_eq!(std_mc.prob_ko_hit, 0.0);
+    assert_eq!(dec_mc.prob_ko_hit, 0.0);
+    assert_eq!(std_mc.avg_fixings, 52.0);
+    assert_eq!(dec_mc.avg_fixings, 52.0);
+}
+
+/// A KO barrier cancels the remaining fixings precisely in the states where
+/// the holder is accumulating gains, so enabling a finite barrier must
+/// REDUCE holder value for BOTH types. Under the inverted implementation an
+/// upside barrier RAISED decumulator value (by truncating losing rally
+/// states) instead of reducing it.
+#[test]
+fn finite_ko_barrier_reduces_holder_value_for_both_types() {
+    let (spot, rate, q, vol) = (100.0, 0.03, 0.0, 0.15);
+    let fixings = weekly_fixings();
+    let price = |t: &Tarf| tarf_mc_price(t, spot, rate, q, vol, 50_000, 42).unwrap();
+
+    let std_no_ko = price(&Tarf::standard(
+        100.0,
+        1000.0,
+        NO_BARRIER,
+        NO_TARGET,
+        2.0,
+        fixings.clone(),
+    ));
+    let std_ko = price(&Tarf::standard(
+        100.0,
+        1000.0,
+        120.0,
+        NO_TARGET,
+        2.0,
+        fixings.clone(),
+    ));
+    let dec_no_ko = price(&Tarf::decumulator(
+        100.0,
+        1000.0,
+        NO_BARRIER,
+        NO_TARGET,
+        2.0,
+        fixings.clone(),
+    ));
+    let dec_ko = price(&Tarf::decumulator(
+        100.0, 1000.0, 80.0, NO_TARGET, 2.0, fixings,
+    ));
+
+    // 3 * (sum of standard errors) exceeds the standard error of the
+    // difference of independent estimates, so this is a conservative bound.
+    assert!(
+        std_ko.price < std_no_ko.price - 3.0 * (std_ko.std_error + std_no_ko.std_error),
+        "upside KO must reduce standard TARF value: with KO {} vs without {}",
+        std_ko.price,
+        std_no_ko.price
+    );
+    assert!(
+        dec_ko.price < dec_no_ko.price - 3.0 * (dec_ko.std_error + dec_no_ko.std_error),
+        "downside KO must reduce decumulator value: with KO {} vs without {}",
+        dec_ko.price,
+        dec_no_ko.price
+    );
+    // The KO genuinely fires and removes remaining fixings.
+    assert!(std_ko.prob_ko_hit > 0.0);
+    assert!(dec_ko.prob_ko_hit > 0.0);
+    assert!(std_ko.avg_fixings < 52.0);
+    assert!(dec_ko.avg_fixings < 52.0);
+}
+
+/// The KO check precedes the fixing P&L: the breaching fixing pays nothing.
+/// With a single fixing and the barrier epsilon-close to the strike, the
+/// surviving payoff is only the losing leg, giving analytic anchors:
+///   Standard   (barrier = K + eps): pays (S-K)*L*N only when S < K  => -L*N*Put
+///   Decumulator (barrier = K - eps): pays (K-S)*L*N only when S > K => -L*N*Call
+/// If the breaching fixing were paid (wrong ordering), the winning leg would
+/// be included and both prices would be strongly positive instead.
+#[test]
+fn ko_breaching_fixing_pays_nothing_single_fixing_closed_form() {
+    let (spot, rate, q, vol, t) = (100.0, 0.03, 0.0, 0.15, 1.0);
+    let (strike, notional, leverage) = (100.0, 1000.0, 1.0);
+    // Epsilon band (K, K+eps) pays at most eps * notional = 0.1 with tiny
+    // probability; the +0.2 slack in the assertions dominates it.
+    let eps = 1e-4;
+
+    let std_tarf = Tarf::standard(strike, notional, strike + eps, NO_TARGET, leverage, vec![t]);
+    let std_mc = tarf_mc_price(&std_tarf, spot, rate, q, vol, 200_000, 42).unwrap();
+    let std_expected =
+        -leverage * notional * bs_price(OptionType::Put, spot, strike, rate, q, vol, t);
+    assert!(
+        (std_mc.price - std_expected).abs() < 4.0 * std_mc.std_error + 0.2,
+        "standard KO ordering: mc = {} +/- {}, expected -L*N*Put = {}",
+        std_mc.price,
+        std_mc.std_error,
+        std_expected
+    );
+
+    let dec_tarf = Tarf::decumulator(strike, notional, strike - eps, NO_TARGET, leverage, vec![t]);
+    let dec_mc = tarf_mc_price(&dec_tarf, spot, rate, q, vol, 200_000, 42).unwrap();
+    let dec_expected =
+        -leverage * notional * bs_price(OptionType::Call, spot, strike, rate, q, vol, t);
+    assert!(
+        (dec_mc.price - dec_expected).abs() < 4.0 * dec_mc.std_error + 0.2,
+        "decumulator KO ordering: mc = {} +/- {}, expected -L*N*Call = {}",
+        dec_mc.price,
+        dec_mc.std_error,
+        dec_expected
+    );
+}
+
+/// A finite KO barrier must sit strictly on the KO side of the strike for the
+/// product type; INFINITY (no barrier) is accepted for both types.
+#[test]
+fn validation_enforces_type_aware_barrier_side() {
+    let fixings = weekly_fixings();
+    assert!(
+        Tarf::standard(100.0, 1000.0, 80.0, 50_000.0, 2.0, fixings.clone())
+            .validate()
+            .is_err(),
+        "standard TARF with downside barrier must be rejected"
+    );
+    assert!(
+        Tarf::decumulator(100.0, 1000.0, 120.0, 50_000.0, 2.0, fixings.clone())
+            .validate()
+            .is_err(),
+        "decumulator TARF with upside barrier must be rejected"
+    );
+    assert!(
+        Tarf::standard(100.0, 1000.0, NO_BARRIER, 50_000.0, 2.0, fixings.clone())
+            .validate()
+            .is_ok()
+    );
+    assert!(
+        Tarf::decumulator(100.0, 1000.0, NO_BARRIER, 50_000.0, 2.0, fixings)
+            .validate()
+            .is_ok()
+    );
+}

--- a/tests/rates_bond_quantlib.rs
+++ b/tests/rates_bond_quantlib.rs
@@ -312,11 +312,33 @@ fn accrued_interest_basic_cases() {
     assert_relative_eq!(bond.accrued_interest(0.25), half_coupon, epsilon = 1.0e-12);
 }
 
-/// Clean price = dirty price - accrued interest.
+/// Clean price = dirty price at settlement - accrued interest, with the
+/// settlement dirty price anchored to a hand computation.
+///
+/// The dirty price at settlement `s` is the value AT `s` of the cashflows
+/// paid strictly after `s`: sum_{t > s} CF(t) * DF(0, t) / DF(0, s).
+///
+/// Anchor (hand-computed): 5y 6% semiannual bond, face 100, flat 5%
+/// continuously-compounded curve, s = 0.25:
+///   dirty(0.25)   = sum_{t in {0.5, 1.0, .., 4.5}} 3 * exp(-0.05 (t - 0.25))
+///                   + 103 * exp(-0.05 (5 - 0.25))  = 105.402903895
+///   accrued(0.25) = 3 * 0.25 / 0.5                 = 1.5
+///   clean(0.25)   = 105.402903895 - 1.5            = 103.902903895
+/// (The pre-fix implementation discounted every cashflow to t=0 instead of
+/// to settlement: 104.093568 dirty / 102.593568 clean.)
 #[test]
-fn clean_price_equals_dirty_minus_accrued() {
+fn clean_price_equals_settlement_dirty_minus_accrued() {
     let rate = 0.05;
-    let curve = flat_curve(rate, 12.0);
+    // Quarter-year node spacing so both the 0.25 settlement and the
+    // half-year coupon grid lie inside the node range and log-linear
+    // interpolation reproduces exp(-r t) exactly (no extrapolation).
+    let points: Vec<(f64, f64)> = (1..=21)
+        .map(|i| {
+            let t = i as f64 * 0.25;
+            (t, (-rate * t).exp())
+        })
+        .collect();
+    let curve = YieldCurve::new(points);
 
     let bond = FixedRateBond {
         face_value: 100.0,
@@ -327,9 +349,19 @@ fn clean_price_equals_dirty_minus_accrued() {
     };
 
     let settlement = 0.25;
-    let dirty = bond.dirty_price(&curve);
+    let dirty = bond.dirty_price_at(&curve, settlement);
     let accrued = bond.accrued_interest(settlement);
     let clean = bond.clean_price(&curve, settlement);
 
+    assert_relative_eq!(dirty, 105.402903895, epsilon = 1.0e-9);
+    assert_relative_eq!(accrued, 1.5, epsilon = 1.0e-12);
     assert_relative_eq!(clean, dirty - accrued, epsilon = 1.0e-12);
+    assert_relative_eq!(clean, 103.902903895, epsilon = 1.0e-9);
+
+    // Settlement 0 degenerates to today's dirty price (accrued(0) = 0).
+    assert_relative_eq!(
+        bond.clean_price(&curve, 0.0),
+        bond.dirty_price(&curve),
+        epsilon = 1.0e-12
+    );
 }

--- a/tests/strata_bond_reference.rs
+++ b/tests/strata_bond_reference.rs
@@ -409,9 +409,24 @@ fn strata_accrued_interest_semiannual_quarter() {
 // 8. Clean vs dirty price
 // ===========================================================================
 
-/// Clean = dirty - accrued at any settlement date.
+/// Settlement-aware clean/dirty prices against hand-computed anchors.
+///
+/// Dirty price at settlement `s` is the value AT `s` of the cashflows paid
+/// strictly after `s`, forward-valued with DF(s, t) = DF(0, t) / DF(0, s);
+/// clean = dirty - accrued. The flat continuous curve has ln DF linear in t,
+/// so log-linear interpolation reproduces exp(-r t) exactly at every time
+/// used here and tight epsilons are safe.
+///
+/// Anchors hand-computed from first principles (10y 6% semiannual bond,
+/// face 100, flat 4% continuously-compounded curve, s = 3.7):
+///   dirty(3.7)   = sum_{t in {4.0, 4.5, .., 9.5}} 3 * exp(-0.04 (t - 3.7))
+///                  + 103 * exp(-0.04 (10 - 3.7))   = 111.997548830
+///   accrued(3.7) = 3 * (3.7 - 3.5) / 0.5           = 1.2
+///   clean(3.7)   = 111.997548830 - 1.2             = 110.797548830
+/// (The pre-fix implementation returned the t=0 PV of ALL 20 coupons,
+/// 115.991126 dirty / 114.791126 clean, which is not a market clean price.)
 #[test]
-fn strata_clean_equals_dirty_minus_accrued() {
+fn strata_clean_and_dirty_at_settlement_anchor() {
     let rate = 0.04;
     let curve = flat_continuous_curve(rate, 12.0);
 
@@ -423,12 +438,61 @@ fn strata_clean_equals_dirty_minus_accrued() {
         day_count: DayCountConvention::Act365Fixed,
     };
 
-    // Test at several settlement dates within the bond's life
-    for settlement in [0.1, 0.25, 0.4, 0.75, 1.3, 3.7, 9.9] {
-        let dirty = bond.dirty_price(&curve);
+    let settlement = 3.7;
+    let dirty = bond.dirty_price_at(&curve, settlement);
+    let accrued = bond.accrued_interest(settlement);
+    let clean = bond.clean_price(&curve, settlement);
+
+    assert_relative_eq!(dirty, 111.997548830, epsilon = 1.0e-9);
+    assert_relative_eq!(accrued, 1.2, epsilon = 1.0e-12);
+    assert_relative_eq!(clean, 110.797548830, epsilon = 1.0e-9);
+}
+
+/// Clean = dirty-at-settlement - accrued at any settlement date, and the
+/// settlement-zero case degenerates to the t=0 dirty price.
+#[test]
+fn strata_clean_equals_settlement_dirty_minus_accrued() {
+    let rate = 0.04;
+    let curve = flat_continuous_curve(rate, 12.0);
+
+    let bond = FixedRateBond {
+        face_value: 100.0,
+        coupon_rate: 0.06,
+        frequency: 2,
+        maturity: 10.0,
+        day_count: DayCountConvention::Act365Fixed,
+    };
+
+    // Settlement 0 must reproduce today's dirty price exactly (regression
+    // guard for the pre-settlement-aware behavior).
+    assert_relative_eq!(
+        bond.clean_price(&curve, 0.0),
+        bond.dirty_price(&curve),
+        epsilon = 1.0e-12
+    );
+
+    // Test at several settlement dates within the bond's life. All times
+    // here are >= 1.0, inside the curve's node range, so no extrapolation.
+    for settlement in [1.3, 3.7, 9.9] {
+        let dirty = bond.dirty_price_at(&curve, settlement);
         let accrued = bond.accrued_interest(settlement);
         let clean = bond.clean_price(&curve, settlement);
 
         assert_relative_eq!(clean, dirty - accrued, epsilon = 1.0e-12);
+
+        // The settlement dirty price must equal the directly-computed
+        // forward value of the remaining cashflows on the flat curve.
+        let mut expected = 0.0;
+        let mut t = 0.5;
+        while t < bond.maturity - 1.0e-12 {
+            if t > settlement + 1.0e-12 {
+                expected += 3.0 * (-rate * (t - settlement)).exp();
+            }
+            t += 0.5;
+        }
+        if bond.maturity > settlement {
+            expected += 103.0 * (-rate * (bond.maturity - settlement)).exp();
+        }
+        assert_relative_eq!(dirty, expected, epsilon = 1.0e-9);
     }
 }


### PR DESCRIPTION
## Summary

A deep-dive audit of pricing correctness across every asset class in the repo (equity/FX vanilla, path-dependent exotics, multi-asset, rates, credit/commodity/risk, and stochastic models) found seven confirmed defects. Each finding below was independently re-verified by an adversarial reviewer with its own compiled reproduction before any fix was written, and each fix was independently re-reviewed against the same reproduction after the change. One additional candidate finding (a convertible-bond maturity call-cap) was refuted during re-verification and is not included — see commit `e41049e` for the narrower defect that verification did surface instead.

- **`4f37276`** — Synthetic CDO used the pool spread directly as the hazard rate instead of the credit triangle `h = s/(1-R)`, understating tranche expected losses/fair spreads ~36-60%. Also removed a floor that silently zeroed negative discount rates.
- **`310d1ee`** — TARF decumulator knock-out used the upside barrier condition for both `Standard` and `Decumulator` types, inverting the KO feature's value for decumulators (which conventionally knock out on a downside barrier).
- **`4577a59`** — `FixedRateBond::clean_price` at nonzero settlement subtracted accrued interest from a t=0 PV that still included already-paid coupons. Added `dirty_price_at(curve, settlement)` with correct forward valuation.
- **`37168ba`** — Hull-White swaption calibration fed an absolute (normal) rate vol into a lognormal Black pricing formula alongside market Black vols, producing a calibrated sigma off by roughly 25x. Objective now compares Bachelier ATM prices on both sides.
- **`e41049e`** — Matured convertible bonds could redeem below face value when the issuer call price was below face, because the maturity branch applied `min(face, call)`. A call right is meaningless at maturity.
- **`901cf31`** — The Carr-Madan FFT layer had no moment-admissibility check and silently clamped NaN to 0.0 via `f64::max(0.0)`, producing confidently wrong prices (including below intrinsic value) for Heston/VG/CGMY parameter regimes with exploding or branch-crossing characteristic functions, with no error surfaced anywhere.
- **`5054d55`** — Every early-exercise engine (binomial, trinomial, PDE, LSM) smeared discrete cash dividends into a continuous yield, which is exact for European options but suppresses the early-exercise premium for American options with material cash dividends. Switched to the escrowed-spot model already used by the analytic engine.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --locked --workspace --all-targets --all-features`
- [x] `cargo test --locked --workspace --features accelerated-native` — 1495 passed, 0 failed, 1 ignored (pre-existing performance benchmark), across 62 suites, including 6 new `tests/audit_*.rs` regression suites with externally-derived reference values
- [x] Each fix independently re-verified against the original failure reproduction by a separate adversarial review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)