### PR TITLE
Harden pricing reference coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ Project-level instructions for coding agents working in this repository. Keep th
 - Core crate: `openferric` in the repository root.
 - Workspace crates: `wasm/`, `python/`, `lsp/`, `mcp/`.
 - TypeScript workspaces: `excel-addin/`, `vscode-ext/` managed from the root `package.json`.
-- Reference data: `vendor/QuantLib/` is a git submodule used by validation tests.
+- Reference source: `vendor/QuantLib/` is a citation-only git submodule. Tests
+  use committed reference literals and never build, import, or read the
+  submodule at runtime.
 
 ## Toolchain
 
@@ -37,6 +39,10 @@ cargo test --test quantlib_reference
 cargo bench
 cargo bench --bench pricing_bench
 ```
+
+`quantlib_reference` is one of roughly 15 QuantLib-derived integration suites,
+not a complete QuantLib validation run; use the workspace test command for the
+full set.
 
 ### Coverage
 
@@ -151,7 +157,9 @@ PricingEngine::price(&self, instrument: &I, market: &Market) -> Result<PricingRe
 ## Testing Notes
 
 - Many integration tests are validated against external references rather than self-generated values.
-- QuantLib-based tests depend on `vendor/QuantLib/` being present.
+- QuantLib-derived values are generated offline and committed as literals with
+  provenance. Tests do not require `vendor/QuantLib/`, QuantLib libraries, or
+  Python packages to be present.
 - Keep tests close to the code when adding unit coverage; integration coverage lives in `tests/`.
 - Do not hardcode repository-wide test counts in docs unless you are updating them deliberately.
 

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -23,11 +23,12 @@ Here, "exact" means the target price is exact for the stated contract and model.
 Stochastic and discretized methods necessarily compare to that target with an
 explicit statistical or numerical error budget rather than bitwise equality.
 
-Reference values in this audit were regenerated with
+Reference values in this audit were regenerated with Python 3.11.15,
 [QuantLib-Python 1.43](https://pypi.org/project/QuantLib/) and
 [SciPy 1.17.1](https://docs.scipy.org/doc/scipy/reference/), with
 [NumPy 2.4.3 Gauss-Hermite nodes](https://numpy.org/doc/stable/reference/generated/numpy.polynomial.hermite.hermgauss.html)
-for Gaussian-factor integration. Each cached value is accompanied by its
+for Gaussian-factor integration and mpmath 1.4.1 for selected high-precision
+closed-form cross-checks. Each cached value is accompanied by its
 contract/model parameters;
 SciPy Sobol references additionally record replicate counts and reference
 standard errors. Correlated first-to-default is also checked against
@@ -37,6 +38,8 @@ in the test. Lévy-process FFT values use the open-source
 [fypy Carr-Madan implementation](https://github.com/jkirkby3/fypy), and product
 grids are cross-checked against the upstream
 [QuantLib test suite](https://github.com/lballabio/QuantLib/tree/master/test-suite).
+`vendor/QuantLib` is citation-only: CI and local tests consume the committed
+literals and never build, import, or read that submodule at runtime.
 Four-decimal Haug book values are retained only as provenance checks within half
 of their last printed digit; every such product also has a full-precision formula,
 package value, or stated finite-grid regression target.
@@ -47,15 +50,21 @@ package value, or stated finite-grid regression target.
 |---|---|---|
 | Vanilla equity, Greeks, FX, Black-76, Bachelier | `strata_black_scholes`, `european_quantlib`, `quantlib_reference`, Python/WASM pricing tests | Strata/QuantLib grids and closed forms |
 | Barriers, digitals, lookbacks, compound, chooser, quanto, rainbow, spreads | `barrier_quantlib`, `strata_barrier`, `digital_reference`, `exotic_reference`, `equity_exotics_exact_reference`, `haug_rainbow_spread` | QuantLib/Haug grids and independent SciPy formulas |
-| Asian, basket, autocall, range accrual, TARF, swing, convertible, real options, structured notes | `asian_quantlib`, `equity_exotics_exact_reference`, `audit_convertible`, DSL tests and focused structured-note/swing/real-option tests | QuantLib/SciPy Sobol values, including full stochastic path Greeks; Black-Scholes reductions, exact discounted cashflows, independent Decimal CRR and separately implemented full-slice Hull-White recurrences |
+| Asian, basket, autocall, range accrual, TARF and convertible products | `asian_quantlib`, `equity_exotics_exact_reference`, `audit_convertible`, DSL tests and focused product tests | QuantLib/formula values, exact discounted cashflows and independently scrambled SciPy Sobol prices/Greeks/termination statistics with combined sampling error |
+| Employee stock options and real options | `instruments::employee_stock_option`, `hjm_adjustments_test` and focused `pricing::real_option` tests | Independent 80-digit Decimal CRR recurrences on the stated finite grids, plus analytic reductions and deterministic exercise cases |
+| Swing options | `engines::tree::swing` tests | Black-Scholes strip reduction and QuantLib-Python 1.43 `FdSimpleBSSwingEngine` values with tree convergence; `min_exercises=2` has supplemental state-path coverage but is non-binding for the nonnegative payoff |
+| Structured notes | focused `instruments::structured_notes` tests | Exact deterministic discounted cashflows and a separately written in-repo full-slice Hull-White recurrence; no independent external callable-note price is claimed |
 | American/Bermudan, binomial/trinomial, PDE, LSM | `american_approx_reference`, `bermudan_quantlib`, `hull_white_tree_reference`, `pde_solvers_issue35`, `lsm_reference`, `cross_engine_consistency`, tree module tests | QuantLib, Black-Scholes/CRR, published approximations, Jamshidian's closed form, an independent continuous-state Hull-White Gaussian program, and a local-vol log-price trinomial chain |
-| FFT/FRFT, Heston, VG, CGMY, NIG | `fang_oosterlee_heston`, `fft_levy_reference`, `heston_quantlib`, `variance_gamma_model_quantlib`, Python/WASM FFT tests | QuantLib, fypy, Lewis and Fang-Oosterlee values |
+| FFT/FRFT, Heston, VG, CGMY, NIG | `fang_oosterlee_heston`, `fft_levy_reference`, `heston_quantlib`, `variance_gamma_model_quantlib`, `models::cgmy`, Python/WASM FFT tests | QuantLib, fypy and Fang-Oosterlee values; independent NumPy high-resolution Carr-Madan grids cross-checked by SciPy Lewis integrals |
 | SABR, SVI, Heston, Hull-White and mixture calibration | focused calibration/model tests and Python/WASM vol tests | Exact synthetic quote repricing, identifiable parameter recovery, and solver-conditioned error budgets |
-| MC, QMC, SIMD/parallel MC, AAD, rough volatility and SLV | `cross_engine_consistency` and focused engine/model tests | Closed-form BSM/Margrabe/moment targets, non-flat SLV surface repricing, two-step conditional-Gaussian and eight-step SciPy/NumPy Sobol rough-Bergomi grids, all with reported sampling/calibration error |
-| Bonds, curves, FRA, swaps, OIS/basis, caps/floors, swaptions, XCCY, inflation, CMS | `rates_*`, `strata_bond_reference` and focused rates module tests | QuantLib/Strata values, exact discounted cashflows, Black-76 reductions, SciPy conditional-lognormal quadrature and QuantLib spread-basket QMC |
+| MC, QMC, SIMD/parallel MC, AAD, rough volatility, SLV and LMM | `cross_engine_consistency`, `models::lmm` and focused engine/model tests | Closed-form BSM/Margrabe/Black-76/moment targets, non-flat SLV repricing and independent SciPy/NumPy Sobol rough-Bergomi and correlated multi-forward LMM grids with reported sampling/calibration error |
+| GPU Monte Carlo | `engines::gpu::gpu_mc` tests | CPU-side reduction/layout/shader invariants always run; Black-Scholes and deterministic-payoff price locks run only when a WebGPU adapter is available and otherwise report an explicit skip |
+| Bonds, curves, FRA, swaps, OIS/basis, caps/floors, swaptions, XCCY, inflation, CMS | `rates_*`, `rates_capfloor_quantlib`, `strata_bond_reference` and focused rates module tests | QuantLib/Strata values, exact discounted cashflows, QuantLib Black cap/floor and optionlet NPVs, Black-76 reductions, SciPy conditional-lognormal quadrature and QuantLib spread-basket QMC |
 | CDS, CDS options/index, ISDA, copulas, first/nth default, CDO | `credit_isda_quantlib`, `credit_quantlib_cds_test`, `cdo_heterogeneous_reference` and focused credit module tests | QuantLib and FinancePy values, exact survival cashflows, SciPy quadrature, direct finite-pool Bernoulli enumeration and distribution formulas |
-| Commodity, weather, catastrophe bonds, MBS/PSA and funding swaps | `commodity_reference`, `commodity_weather_test` and focused instrument tests | Black-76/Kirk, exact Poisson/cashflow calculations, SIFMA PSA formulas, and OTS refinancing-incentive coefficients/seasonality with full cashflow paths independently evaluated using Decimal arithmetic under the library's gross-WAC convention |
-| VaR/ES, XVA, KVA/FVA/MVA, margin/liquidation and portfolio sensitivities | `var_es_reference` and focused risk module tests | Exact empirical order statistics, Gaussian formulas, discounted exposure/capital cashflows, closed-form margin rules, and an independent SciPy Sobol discrete-Vasicek first-passage reference with reported sampling error |
+| Commodity, weather and catastrophe bonds | `commodity_reference`, `commodity_weather_test` and focused instrument tests | Black-76/Kirk, exact Poisson and discounted-cashflow calculations |
+| MBS/PSA | focused `instruments::mbs` and `pricing::mbs` tests | Independently evaluated Decimal PSA and documented OTS refinancing-incentive/seasonality cashflow paths under the gross-WAC convention; no low-precision published example is presented as an exact external NPV |
+| Funding-rate/perpetual swaps | `funding_swap_reference` and focused funding-rate tests | Independent 80-digit Decimal realised P&L, piecewise-linear funding integral, non-flat discounted MTM and same-bump funding/discount DV01 arithmetic |
+| VaR/ES, XVA, KVA/FVA/MVA, margin/liquidation, portfolio sensitivities and statistical primitives | `var_es_reference`, `math::timeseries`, `math::correlation` and focused risk tests | Exact empirical order statistics, Gaussian formulas, discounted cashflows, closed-form margin rules, independent SciPy Sobol first-passage references, Bartlett ACF/PACF bands and chi-square central-moment sampling errors |
 | Rust, Python and WebAssembly surfaces | workspace tests, `python/tests`, and `wasm-pack test --node` | The same full-precision references exercised through each binding |
 
 ## Known Model Scope
@@ -92,7 +101,9 @@ external engine exists:
   scenario duration rebuilds prepayment cashflows under each parallel rate bump.
   The benchmark intentionally omits proprietary borrower calibration, default,
   burnout, and a stochastic OAS rate engine; it is not labeled as the full
-  Richard--Roll model.
+  Richard--Roll model. Published SIFMA/Fabozzi examples are too coarsely rounded
+  to improve on the existing Decimal cashflow locks, so no external MBS NPV
+  anchor is claimed.
 - Cross-currency swaps accept explicit fixed- and floating-leg frequencies;
   legacy methods remain annual compatibility wrappers. Quarterly dual-curve
   cashflows and par rates are pinned to independent high-precision Decimal
@@ -118,7 +129,15 @@ external engine exists:
 - The funding-rate swap payoff is linear in realised rates, so under
   deterministic discounting its value depends only on conditional forward
   means and its volatility sensitivity is mathematically zero. Nonlinear
-  funding options require a separate stochastic model.
+  funding options require a separate stochastic model. Realised P&L, non-flat
+  discounted MTM and both one-basis-point curve sensitivities are recomputed by
+  an independent 80-digit Decimal cashflow program.
+- `InterestRateFutureQuote::convexity_adjustment` implements the standalone
+  Hull approximation `sigma^2 * T1 * T2 / 2`. QuantLib's
+  `HullWhite::convexityBias` additionally depends on the futures quote, accrual
+  period and mean reversion; even its zero-mean-reversion expression does not
+  reduce to this API for the same `(T1, T2)` arguments. The validation map
+  therefore does not claim a like-for-like QuantLib Hull-White oracle.
 - Liquidation probability and conditional first-passage time are checked
   against independently scrambled SciPy Sobol paths using the exact Gaussian
   Vasicek transition on the contract's monitoring grid. Seeded engine values
@@ -154,15 +173,26 @@ external engine exists:
   and LSM reported error tested separately.
 - Swing tests reduce unconstrained rights to a strip of Black-Scholes calls and
   converge to a QuantLib-Python 1.43 finite-difference price for the constrained
-  monthly contract. Real-option defer, expansion, and abandonment trees are
-  checked against Black-Scholes reductions, independent high-precision
-  multi-stage CRR recurrences and deterministic immediate exercise. Structured
+  monthly contract. A `min_exercises=2, max_exercises=6` case executes the
+  constrained state path, but minimum exercise is not economically binding
+  because unused rights can be spent for zero payoff; that case is supplemental.
+  Real-option defer, expansion, and abandonment trees are checked against
+  Black-Scholes reductions, independent high-precision multi-stage CRR
+  recurrences and deterministic immediate exercise. Structured
   notes and convertibles pin exact discounted cashflows plus finite-grid
   recurrences for non-zero-volatility callable and fully featured exercise
   cases. The callable-note recurrence is independently written at the lattice
   and event-order layer but deliberately reuses the model's calibrated-theta
   and bond-price primitives, which the separate Jamshidian/QuantLib tests cover;
-  exercise/order/no-arbitrage properties remain supplemental.
+  exercise/order/no-arbitrage properties remain supplemental. A dated
+  QuantLib-Python bridge matched deterministic bond cashflows within 1.5e-14
+  and reconciled clean/dirty call semantics, but the 1,200-step non-zero-vol
+  OpenFerric tree remained 3.36e-5 from the analytic Hull-White bond-option
+  value. The external callable-note lock is therefore deferred rather than
+  presented with a false closed-form tolerance.
+- GPU Monte Carlo integration tests request a real WebGPU adapter. If none is
+  available they print an explicit skip and return; CPU reduction, request
+  validation, WGSL parsing and shader validation still run in every build.
 - Native and WebAssembly SIMD batch pricers evaluate the tail-accurate Cody
   normal CDF independently per lane while retaining vectorized log, discount
   and payoff arithmetic. Cached SciPy price/Greek grids are checked with an

--- a/src/engines/analytic/digital.rs
+++ b/src/engines/analytic/digital.rs
@@ -717,37 +717,4 @@ mod tests {
         let g = engine.price(&gap, &market).unwrap().greeks.unwrap();
         assert_eq!(g.delta, 0.0);
     }
-
-    // --- Sanity checks ---
-
-    #[test]
-    fn cash_or_nothing_greeks_present() {
-        let engine = DigitalAnalyticEngine::new();
-        let market = test_market();
-        let inst = CashOrNothingOption::new(OptionType::Call, 100.0, 10.0, 1.0);
-        let result = engine.price(&inst, &market).unwrap();
-        assert!(result.greeks.is_some());
-        let g = result.greeks.unwrap();
-        assert!(g.delta > 0.0, "call delta should be positive");
-    }
-
-    #[test]
-    fn asset_or_nothing_greeks_present() {
-        let engine = DigitalAnalyticEngine::new();
-        let market = test_market();
-        let inst = AssetOrNothingOption::new(OptionType::Call, 100.0, 1.0);
-        let result = engine.price(&inst, &market).unwrap();
-        assert!(result.greeks.is_some());
-        let g = result.greeks.unwrap();
-        assert!(g.delta > 0.0, "call delta should be positive");
-    }
-
-    #[test]
-    fn gap_greeks_present() {
-        let engine = DigitalAnalyticEngine::new();
-        let market = test_market();
-        let inst = GapOption::new(OptionType::Call, 100.0, 100.0, 1.0);
-        let result = engine.price(&inst, &market).unwrap();
-        assert!(result.greeks.is_some());
-    }
 }

--- a/src/engines/tree/swing.rs
+++ b/src/engines/tree/swing.rs
@@ -341,4 +341,51 @@ mod tests {
             euro_price
         );
     }
+
+    #[test]
+    fn minimum_rights_swing_matches_quantlib_fd_reference_and_converges() {
+        // Offline QuantLib-Python 1.43 reference: evaluation date 2025-01-01,
+        // monthly SwingExercise dates through 2026-01-01, 30/360 Bond Basis
+        // (so the times are exactly m/12), flat continuous r=5%, q=0%,
+        // BlackConstantVol=20%, PlainVanillaPayoff(Call, K=100), and
+        // VanillaSwingOption(minExerciseRights=2, maxExerciseRights=6).
+        // FdSimpleBSSwingEngine(tGrid=960, xGrid=1200) gives the literal below.
+        // Because every exercise payoff is floored at zero, the two minimum
+        // rights can be spent for zero and do not alter this particular NPV.
+        // This is supplemental state-path execution coverage, not evidence
+        // that a positive minimum has an economically binding effect.
+        const QUANTLIB_REFERENCE: f64 = 54.200_380_350_565_76;
+        const FINE_GRID_DISCRETIZATION_BUDGET: f64 = 7.5e-3;
+        let market = Market::builder()
+            .spot(100.0)
+            .rate(0.05)
+            .dividend_yield(0.0)
+            .flat_vol(0.20)
+            .build()
+            .unwrap();
+        let exercise_dates: Vec<f64> = (1..=12).map(|m| m as f64 / 12.0).collect();
+        let swing = SwingOption::new(2, 6, exercise_dates, 100.0, 1.0);
+
+        let coarse_price = SwingTreeEngine::new(960)
+            .price(&swing, &market)
+            .unwrap()
+            .price;
+        let fine_price = SwingTreeEngine::new(1_920)
+            .price(&swing, &market)
+            .unwrap()
+            .price;
+        let coarse_error = (coarse_price - QUANTLIB_REFERENCE).abs();
+        let fine_error = (fine_price - QUANTLIB_REFERENCE).abs();
+
+        assert!(
+            fine_error <= FINE_GRID_DISCRETIZATION_BUDGET,
+            "fine minimum-rights swing price {fine_price:.12} differs from QuantLib reference \
+             {QUANTLIB_REFERENCE:.12} by {fine_error:.12}"
+        );
+        assert!(
+            fine_error <= 0.51 * coarse_error,
+            "expected first-order convergence for minimum-rights swing: \
+             coarse error={coarse_error:.12}, fine error={fine_error:.12}"
+        );
+    }
 }

--- a/src/instruments/employee_stock_option.rs
+++ b/src/instruments/employee_stock_option.rs
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn dilution_and_attrition_reduce_value() {
+    fn diluted_attrition_eso_matches_independent_tree_recomputation() {
         let base = EmployeeStockOption::new(
             OptionType::Call,
             100.0,
@@ -277,6 +277,24 @@ mod tests {
         let v_base = base.price_binomial(100.0, 0.03, 0.0, 0.3, 600).unwrap();
         let v_diluted = diluted.price_binomial(100.0, 0.03, 0.0, 0.3, 600).unwrap();
 
+        // Independently generated with Python 3.11.15 `decimal` at 80-digit
+        // precision.  The generator built the complete 600-step CRR terminal
+        // slice for effective maturity min(5, 4) = 4, then rolled it back with
+        // vesting step ceil(600 / 4) = 150 and the strict forced-exercise rule
+        // S > 1.8 K.  Only after the recurrence did it apply dilution 1000/1200
+        // and survival exp(-0.08 * 4).  No OpenFerric output entered the
+        // calculation.
+        const DECIMAL_600_STEP_REFERENCE: f64 = 16.009_902_331_905_17;
+        const RELATIVE_ROUNDOFF_BUDGET: f64 = 2.0e-10;
+        let roundoff_budget = RELATIVE_ROUNDOFF_BUDGET * DECIMAL_600_STEP_REFERENCE.abs().max(1.0);
+        assert!(
+            (v_diluted - DECIMAL_600_STEP_REFERENCE).abs() <= roundoff_budget,
+            "diluted/attrition ESO finite-grid price: actual={v_diluted:.17e}, \
+             independent Decimal reference={DECIMAL_600_STEP_REFERENCE:.17e}, \
+             roundoff budget={roundoff_budget:.3e}"
+        );
+
+        // Supplemental economic invariant.
         assert!(v_diluted < v_base);
     }
 }

--- a/src/math/correlation.rs
+++ b/src/math/correlation.rs
@@ -758,9 +758,11 @@ mod tests {
             let mean = sum / n as f64;
             let var = sum_sq / n as f64 - mean * mean;
 
-            // Mean nu, variance 2*nu. Std errors: sqrt(2nu/n) and ~sqrt(8nu^2... )
+            // Mean nu, variance 2*nu.  The variance-estimator SE follows from
+            // the chi-square central moments:
+            // sqrt((mu_4 - variance^2) / n) = sqrt((8 nu^2 + 48 nu) / n).
             let mean_tol = 5.0 * (2.0 * nu / n as f64).sqrt();
-            let var_tol = 0.05 * 2.0 * nu + 0.5;
+            let var_tol = 5.0 * ((8.0 * nu * nu + 48.0 * nu) / n as f64).sqrt();
             assert!(
                 (mean - nu).abs() < mean_tol,
                 "nu={nu} mean={mean} tol={mean_tol}"

--- a/src/math/timeseries.rs
+++ b/src/math/timeseries.rs
@@ -1501,16 +1501,25 @@ mod tests {
     }
 
     #[test]
-    fn acf_and_pacf_match_ar1_behavior() {
+    fn acf_and_pacf_match_ar1_within_bartlett_error_bands() {
         let phi = 0.7;
-        let s = ar1_series(phi, 8000, 321);
+        let n = 8000;
+        let s = ar1_series(phi, n, 321);
         let acf = autocorrelation(&s, 5);
         let pacf = partial_autocorrelation(&s, 5);
 
-        assert!((acf[1] - phi).abs() < 0.05);
-        assert!((pacf[1] - phi).abs() < 0.05);
-        assert!(pacf[2].abs() < 0.10);
-        assert!(pacf[3].abs() < 0.10);
+        // For a stationary Gaussian AR(1), the lag-one estimator has
+        // asymptotic SE sqrt((1-phi^2)/n).  ACF/PACF estimators also carry an
+        // O(1/n) finite-sample bias, negligible beside this four-SE band.
+        let lag_one_band = 4.0 * ((1.0 - phi * phi) / n as f64).sqrt();
+        assert!((acf[1] - phi).abs() < lag_one_band);
+        assert!((pacf[1] - phi).abs() < lag_one_band);
+
+        // The population PACF is zero beyond lag one; Bartlett's white-noise
+        // approximation gives SE 1/sqrt(n) for those coefficients.
+        let zero_pacf_band = 4.0 / (n as f64).sqrt();
+        assert!(pacf[2].abs() < zero_pacf_band);
+        assert!(pacf[3].abs() < zero_pacf_band);
     }
 
     #[test]

--- a/src/models/cgmy.rs
+++ b/src/models/cgmy.rs
@@ -520,20 +520,55 @@ mod tests {
     }
 
     #[test]
-    fn cgmy_fft_prices_are_positive_and_bounded() {
+    fn cgmy_model_fft_calls_match_high_resolution_carr_madan_grid() {
         let cgmy = Cgmy {
             c: 1.0,
             g: 5.0,
             m: 10.0,
             y: 0.5,
         };
-        let strikes = vec![90.0, 95.0, 100.0, 105.0, 110.0];
+        let strikes = [90.0, 95.0, 100.0, 105.0, 110.0];
+
+        // Independent NumPy 2.4.3 Carr-Madan inversion using N=2^20,
+        // eta=2^-12, alpha=1.5, the analytic CGMY characteristic function,
+        // and the risk-neutral martingale correction.  A separate SciPy
+        // 1.17.1 Lewis-contour `quad` calculation returned respectively
+        // [15.293225902699064, 11.983428900938335, 9.128818730345728,
+        //  6.768454786543018, 4.905240411525213], agreeing within 6.6e-14.
+        let references: [f64; 5] = [
+            15.293_225_902_699_088,
+            11.983_428_900_938_383,
+            9.128_818_730_345_747,
+            6.768_454_786_543_084,
+            4.905_240_411_525_213,
+        ];
+
+        // Repeating the independent inversion on the production grid
+        // (N=4096, eta=0.25) measured these absolute discretization gaps.
+        // The Rust-vs-oracle gap measured on Linux was at most 9.77e-14 (from
+        // gamma, complex-power and exp evaluation order).  The remaining
+        // 512-epsilon allowance retains the suite's cross-libm headroom; it is
+        // not an economic or percentage price band.
+        let measured_default_grid_gaps = [3.6e-15_f64, 3.6e-15, 1.8e-15, 0.0, 3.6e-15];
         let prices = cgmy
             .european_calls_fft(100.0, &strikes, 0.03, 0.0, 0.5, CarrMadanParams::default())
             .unwrap();
-        for (k, p) in &prices {
-            assert!(*p > 0.0, "price at strike {k} should be > 0, got {p}");
-            assert!(*p < 100.0, "price at strike {k} should be < spot, got {p}");
+
+        for (((actual_strike, actual_price), expected_strike), (reference, grid_gap)) in prices
+            .iter()
+            .zip(strikes)
+            .zip(references.into_iter().zip(measured_default_grid_gaps))
+        {
+            assert_eq!(*actual_strike, expected_strike);
+            let binary64_roundoff = 512.0 * f64::EPSILON * reference.abs().max(1.0);
+            let tolerance = grid_gap + binary64_roundoff;
+            let error = (actual_price - reference).abs();
+            assert!(
+                error <= tolerance,
+                "CGMY call at K={expected_strike}: actual={actual_price:.17}, \
+                 high-resolution reference={reference:.17}, error={error:.3e}, \
+                 measured grid gap={grid_gap:.3e}, roundoff={binary64_roundoff:.3e}"
+            );
         }
     }
 

--- a/src/pricing/tarf.rs
+++ b/src/pricing/tarf.rs
@@ -313,12 +313,39 @@ mod tests {
     }
 
     #[test]
-    fn tarf_higher_vol_changes_price() {
+    fn standard_tarf_price_matches_scipy_sobol_reference_across_vols() {
         let tarf = make_standard_tarf();
-        let low_vol = tarf_mc_price(&tarf, 100.0, 0.03, 0.0, 0.10, 5000, 42).unwrap();
-        let high_vol = tarf_mc_price(&tarf, 100.0, 0.03, 0.0, 0.30, 5000, 42).unwrap();
-        // Higher vol should lead to more KO events and different pricing
-        assert!((low_vol.price - high_vol.price).abs() > 0.01);
+        let mut prices = [0.0_f64; 2];
+
+        // Independent Python 3.11.15 / SciPy 1.17.1 / NumPy 2.4.3
+        // inverse-normal integration with `qmc.Sobol(...).random_base2(17)`
+        // and `norm.ppf`: 24 Owen scrambles x 2^17 paths, dimension 52, with
+        // scramble seeds 73_001 + 104_729 * replicate.
+        // Each path uses the weekly GBM increments and contract conventions
+        // documented on `tarf_mc_price`: KO before fixing P&L, full-gain
+        // target termination, and discounting at each fixing.  The literals
+        // are (mean across scrambles, replicate standard error).
+        for (index, (vol, reference, reference_se)) in [
+            (0.10, -156_141.929_416_458_53, 22.302_196_410_223_71),
+            (0.30, -585_948.393_144_894, 142.626_894_341_611_06),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let actual = tarf_mc_price(&tarf, 100.0, 0.03, 0.0, vol, 250_000, 42).unwrap();
+            let combined_se = actual.std_error.hypot(reference_se);
+            assert!(
+                (actual.price - reference).abs() <= 4.0 * combined_se,
+                "standard TARF vol={vol}: actual={} reference={reference} implementation_se={} reference_se={reference_se}",
+                actual.price,
+                actual.std_error,
+            );
+            prices[index] = actual.price;
+        }
+
+        // Supplemental economic regression: volatility makes this leveraged
+        // downside structure less valuable at the two locked grid points.
+        assert!(prices[1] < prices[0]);
     }
 
     #[test]
@@ -476,28 +503,96 @@ mod tests {
     }
 
     #[test]
-    fn tarf_decumulator_differs_from_standard() {
-        let std_price = tarf_mc_price(&make_standard_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42)
-            .unwrap()
-            .price;
-        let dec_price = tarf_mc_price(&make_decumulator_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42)
-            .unwrap()
-            .price;
-        // Standard and decumulator should give different values
-        assert!((std_price - dec_price).abs() > 0.01);
-    }
-
-    #[test]
-    fn tarf_decumulator_does_not_knock_out_immediately() {
+    fn decumulator_tarf_price_and_termination_stats_match_scipy_sobol_reference() {
         // Regression for the inverted KO direction: the old code applied the
         // upside check `s >= ko_barrier` to decumulators, so a downside
         // barrier at 80 with spot 100 knocked out every path at fixing 1
         // (prob_ko = 1, avg_fixings = 1, price = 0).
-        let result =
-            tarf_mc_price(&make_decumulator_tarf(), 100.0, 0.03, 0.0, 0.15, 5000, 42).unwrap();
-        assert!(result.prob_ko_hit < 0.9);
-        assert!(result.avg_fixings > 2.0);
-        assert!(result.price.abs() > 1.0);
+        const N_REPLICATES: usize = 12;
+        const PATHS_PER_REPLICATE: usize = 20_000;
+        let tarf = make_decumulator_tarf();
+        let mut prices = [0.0_f64; N_REPLICATES];
+        let mut target_probabilities = [0.0_f64; N_REPLICATES];
+        let mut ko_probabilities = [0.0_f64; N_REPLICATES];
+        let mut average_fixings = [0.0_f64; N_REPLICATES];
+
+        for replicate in 0..N_REPLICATES {
+            let result = tarf_mc_price(
+                &tarf,
+                100.0,
+                0.03,
+                0.0,
+                0.15,
+                PATHS_PER_REPLICATE,
+                91_003 + 65_537 * replicate as u64,
+            )
+            .unwrap();
+            prices[replicate] = result.price;
+            target_probabilities[replicate] = result.prob_target_hit;
+            ko_probabilities[replicate] = result.prob_ko_hit;
+            average_fixings[replicate] = result.avg_fixings;
+        }
+
+        fn mean_and_replicate_se<const N: usize>(samples: &[f64; N]) -> (f64, f64) {
+            let mean = samples.iter().sum::<f64>() / N as f64;
+            let variance = samples
+                .iter()
+                .map(|sample| (sample - mean).powi(2))
+                .sum::<f64>()
+                / (N - 1) as f64;
+            (mean, (variance / N as f64).sqrt())
+        }
+
+        // Independent Python 3.11.15 / SciPy 1.17.1 / NumPy 2.4.3
+        // inverse-normal integration with `qmc.Sobol(...).random_base2(17)`
+        // and `norm.ppf`: 24 Owen scrambles x 2^17 paths, dimension 52, with
+        // scramble seeds 73_001 + 104_729 * replicate.
+        // Weekly GBM paths implement the documented decumulator conventions
+        // directly: downside KO before P&L, full-gain target termination, and
+        // per-fixing discounting.  Each tuple is (mean, scramble-replicate SE).
+        let price_reference = (-424_355.735_306_639, 55.419_705_784_844_77);
+        let target_reference = (0.564_653_714_497_884_2, 1.576_225_240_594_642_6e-4);
+        let ko_reference = (8.583_068_847_656_25e-6, 1.544_595_726_015_269_6e-6);
+        let avg_fixings_reference = (34.607_343_673_706_055, 3.726_654_134_463_966e-3);
+
+        let (price, price_implementation_se) = mean_and_replicate_se(&prices);
+        let price_combined_se = price_implementation_se.hypot(price_reference.1);
+        assert!(
+            (price - price_reference.0).abs() <= 4.0 * price_combined_se,
+            "decumulator TARF price={price} reference={} implementation_se={price_implementation_se} reference_se={}",
+            price_reference.0,
+            price_reference.1,
+        );
+
+        let total_paths = (N_REPLICATES * PATHS_PER_REPLICATE) as f64;
+        for (label, samples, reference) in [
+            ("target", &target_probabilities, target_reference),
+            ("KO", &ko_probabilities, ko_reference),
+        ] {
+            let probability = samples.iter().sum::<f64>() / N_REPLICATES as f64;
+            // Evaluate the binomial sampling SE under the independently
+            // estimated reference probability.  A plug-in SE based on the
+            // implementation count collapses to zero when a legitimate
+            // rare-event run observes no KO hits (the expected count here is
+            // only about two), which would create a false rejection.
+            let implementation_se = (reference.0 * (1.0 - reference.0) / total_paths).sqrt();
+            let combined_se = implementation_se.hypot(reference.1);
+            assert!(
+                (probability - reference.0).abs() <= 4.0 * combined_se,
+                "decumulator TARF {label} probability={probability} reference={} implementation_se={implementation_se} reference_se={}",
+                reference.0,
+                reference.1,
+            );
+        }
+
+        let (avg_fixings, avg_fixings_implementation_se) = mean_and_replicate_se(&average_fixings);
+        let avg_fixings_combined_se = avg_fixings_implementation_se.hypot(avg_fixings_reference.1);
+        assert!(
+            (avg_fixings - avg_fixings_reference.0).abs() <= 4.0 * avg_fixings_combined_se,
+            "decumulator TARF avg_fixings={avg_fixings} reference={} implementation_se={avg_fixings_implementation_se} reference_se={}",
+            avg_fixings_reference.0,
+            avg_fixings_reference.1,
+        );
     }
 
     #[test]

--- a/tests/exotic_reference.rs
+++ b/tests/exotic_reference.rs
@@ -86,7 +86,7 @@ fn floating_lookback_put_haug() {
 // These should be purely time value
 // =======================================================================
 #[test]
-fn floating_lookback_call_at_inception() {
+fn floating_lookback_call_at_inception_matches_goldman_sosin_gatto() {
     let market = make_market(100.0, 0.05, 0.0, 0.20);
     let option = ExoticOption::LookbackFloating(LookbackFloatingOption {
         option_type: OptionType::Call,
@@ -94,7 +94,20 @@ fn floating_lookback_call_at_inception() {
         observed_extreme: None, // defaults to spot
     });
     let price = price_exotic(option, &market);
-    // Time value should be > vanilla ATM call (lookbacks are more expensive)
+
+    // Goldman-Sosin-Gatto floating-strike closed form, evaluated offline with
+    // SciPy 1.17.1 `ndtr` / NumPy 2.4.3 and cross-checked at 80 digits with
+    // mpmath 1.4.1 (17.2168022373608675867...).  The binary64 oracle differs
+    // from the high-precision value by 1.72e-15.
+    assert_close(
+        "floating lookback call at inception",
+        price,
+        17.216_802_237_360_866,
+        3.0e-12,
+    );
+
+    // Supplemental economic dominance: lookbacks are more valuable than the
+    // otherwise identical vanilla option.
     let bs_atm = openferric::pricing::european::black_scholes_price(
         openferric::pricing::OptionType::Call,
         100.0,
@@ -110,7 +123,7 @@ fn floating_lookback_call_at_inception() {
 }
 
 #[test]
-fn floating_lookback_put_at_inception() {
+fn floating_lookback_put_at_inception_matches_goldman_sosin_gatto() {
     let market = make_market(100.0, 0.05, 0.0, 0.20);
     let option = ExoticOption::LookbackFloating(LookbackFloatingOption {
         option_type: OptionType::Put,
@@ -118,6 +131,18 @@ fn floating_lookback_put_at_inception() {
         observed_extreme: None,
     });
     let price = price_exotic(option, &market);
+
+    // Same offline Goldman-Sosin-Gatto evaluation as the call above.  SciPy's
+    // binary64 result is 14.290567707403714; mpmath at 80 digits gives
+    // 14.2905677074037083528..., a 5.65e-15 oracle roundoff gap.
+    assert_close(
+        "floating lookback put at inception",
+        price,
+        14.290_567_707_403_714,
+        3.0e-12,
+    );
+
+    // Supplemental economic dominance.
     let bs_atm = openferric::pricing::european::black_scholes_price(
         openferric::pricing::OptionType::Put,
         100.0,

--- a/tests/funding_swap_reference.rs
+++ b/tests/funding_swap_reference.rs
@@ -1,0 +1,196 @@
+//! Independent exact-arithmetic references for perpetual funding-rate swaps.
+//!
+//! The cached values in this file were generated offline with Python 3.11.15
+//! `decimal` at precision 80.  The generator enumerated UTC settlement times,
+//! represented every stated input as an exact decimal, evaluated each cashflow
+//! as `(floating_apr - fixed_apr) * notional * hours / 8760`, and applied the
+//! stated discount factor at each settlement.  Funding- and discount-DV01
+//! references independently repriced the Decimal cashflow sum at the same 1 bp
+//! bump as the public API.  No OpenFerric code or output entered the generator.
+//! The Linux Rust-vs-Decimal session measured a maximum 6.67e-14 absolute gap
+//! for non-cancelling quantities and 1.55e-15 for discount DV01.
+
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+
+use openferric::instruments::FundingRateSwap;
+use openferric::pricing::funding_rate_swap::{
+    funding_rate_swap_discount_dv01, funding_rate_swap_dv01,
+};
+use openferric::rates::{FundingRateCurve, FundingRateSnapshot, YieldCurve};
+
+const INTERVAL_HOURS: i64 = 8;
+const INTERVAL_YEARS: f64 = 8.0 / 8_760.0;
+const RELATIVE_ROUNDOFF_BUDGET: f64 = 2.0e-12;
+
+fn dt(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
+    DateTime::from_naive_utc_and_offset(
+        NaiveDate::from_ymd_opt(year, month, day)
+            .expect("valid date")
+            .and_hms_opt(hour, 0, 0)
+            .expect("valid hour"),
+        Utc,
+    )
+}
+
+fn assert_decimal_reference(label: &str, actual: f64, reference: f64) {
+    let roundoff_budget = RELATIVE_ROUNDOFF_BUDGET * reference.abs();
+    assert!(
+        (actual - reference).abs() <= roundoff_budget,
+        "{label}: actual={actual:.17e}, independent Decimal reference={reference:.17e}, \
+         roundoff budget={roundoff_budget:.3e}"
+    );
+}
+
+fn reference_fixture() -> (FundingRateSwap, FundingRateCurve, YieldCurve) {
+    let entry_time = dt(2026, 1, 1, 0);
+    let swap = FundingRateSwap {
+        notional: 3_750_000.0,
+        fixed_rate: 0.0375,
+        entry_time,
+        maturity: dt(2026, 1, 2, 8),
+        settlement_interval_hours: INTERVAL_HOURS as u32,
+        venue: "reference".to_string(),
+        asset: "BTCUSD".to_string(),
+    };
+
+    // Exact Decimal APR inputs {0.0612, -0.0045, 0.0827, 0.0291}, divided by
+    // the documented 1095 funding periods per year before conversion to f64.
+    let per_period_rates = [
+        5.589_041_095_890_411e-5,
+        -4.109_589_041_095_89e-6,
+        7.552_511_415_525_114e-5,
+        2.657_534_246_575_342_4e-5,
+    ];
+    let snapshots = per_period_rates
+        .into_iter()
+        .enumerate()
+        .map(|(i, rate)| FundingRateSnapshot {
+            venue: "reference".to_string(),
+            asset: "BTCUSD".to_string(),
+            rate,
+            timestamp: entry_time + Duration::hours(i as i64 * INTERVAL_HOURS),
+        })
+        .collect();
+    let funding_curve = FundingRateCurve::new(snapshots);
+
+    // Pillars coincide exactly with the four settlement year fractions.  This
+    // locks the supplied non-flat DFs without introducing an interpolation
+    // convention into the NPV reference.
+    let discount_curve = YieldCurve::new(vec![
+        (INTERVAL_YEARS, 0.99993),
+        (2.0 * INTERVAL_YEARS, 0.99971),
+        (3.0 * INTERVAL_YEARS, 0.99932),
+        (4.0 * INTERVAL_YEARS, 0.99876),
+    ]);
+
+    (swap, funding_curve, discount_curve)
+}
+
+#[test]
+fn funding_rate_curve_matches_independent_decimal_linear_integral() {
+    let (_, funding_curve, _) = reference_fixture();
+
+    // At 1.5 intervals the piecewise-linear forward is the midpoint of the
+    // second and third APR nodes, converted to a per-8-hour rate.  At four
+    // intervals the cumulative index is three trapezoids plus one final flat
+    // interval, matching FundingRateCurve's documented extrapolation.
+    const DECIMAL_MIDPOINT_FORWARD: f64 = 3.570_776_255_707_762_5e-5;
+    const DECIMAL_FOUR_INTERVAL_INDEX: f64 = 1.392_237_442_922_374_4e-4;
+    let midpoint_forward = funding_curve.forward_rate(1.5 * INTERVAL_YEARS);
+    let cumulative_index = funding_curve.cumulative_index(4.0 * INTERVAL_YEARS);
+
+    assert_decimal_reference(
+        "piecewise-linear funding forward",
+        midpoint_forward,
+        DECIMAL_MIDPOINT_FORWARD,
+    );
+    assert_decimal_reference(
+        "piecewise-linear cumulative funding index",
+        cumulative_index,
+        DECIMAL_FOUR_INTERVAL_INDEX,
+    );
+}
+
+#[test]
+fn funding_rate_swap_realized_pnl_matches_independent_decimal_sum() {
+    let (swap, _, _) = reference_fixture();
+    let fixings = [
+        (dt(2026, 1, 1, 4), 0.90), // not a scheduled settlement
+        (dt(2026, 1, 1, 8), 0.0550),
+        (dt(2026, 1, 1, 16), 0.0210),
+        (dt(2026, 1, 2, 0), -0.0070),
+        (dt(2026, 1, 2, 8), 0.0640),
+    ];
+
+    // Decimal sum over the four scheduled fixings only.
+    const DECIMAL_REALIZED_PNL: f64 = -58.219_178_082_191_78;
+    assert_decimal_reference(
+        "realized funding PnL",
+        swap.realized_pnl(&fixings),
+        DECIMAL_REALIZED_PNL,
+    );
+}
+
+#[test]
+fn funding_rate_swap_mtm_matches_independent_decimal_discounted_cashflows() {
+    let (swap, funding_curve, discount_curve) = reference_fixture();
+
+    // Decimal explicitly sampled APRs {0.0612, -0.0045, 0.0827, 0.0291}
+    // at the four interval starts and applied settlement DFs
+    // {0.99993, 0.99971, 0.99932, 0.99876} cashflow by cashflow.
+    const DECIMAL_DISCOUNTED_MTM: f64 = 63.322_606_164_383_565;
+    let mtm = swap.mark_to_market(&funding_curve, Some(&discount_curve), swap.entry_time);
+    assert_decimal_reference("discounted funding-swap MTM", mtm, DECIMAL_DISCOUNTED_MTM);
+}
+
+#[test]
+fn funding_rate_swap_dv01_matches_independent_decimal_central_difference() {
+    let (swap, funding_curve, discount_curve) = reference_fixture();
+
+    // The Decimal generator evaluated (PV(f + 1bp) - PV(f - 1bp)) / 2.
+    // Because every funding cashflow is affine in its forward APR, this central
+    // cash change is exactly the API's one-sided PV(f + 1bp) - PV(f).
+    const DECIMAL_FUNDING_DV01: f64 = 1.369_082_191_780_822;
+    let dv01 = funding_rate_swap_dv01(
+        &swap,
+        &funding_curve,
+        Some(&discount_curve),
+        swap.entry_time,
+    );
+    assert_decimal_reference("funding-curve DV01", dv01, DECIMAL_FUNDING_DV01);
+}
+
+#[test]
+fn funding_rate_swap_discount_dv01_matches_independent_decimal_central_decomposition() {
+    let (swap, funding_curve, discount_curve) = reference_fixture();
+
+    // The API defines the discrete one-sided change PV(z + 1bp) - PV(z).
+    // The independent Decimal calculation decomposed that exact change into
+    // its central odd and even-curvature parts at the same bump:
+    //
+    //   [PV(+h) - PV(-h)] / 2 = -1.30331384875212719422e-5
+    //   [PV(+h) + PV(-h) - 2 PV(0)] / 2 = 1.82849896876829718e-12.
+    //
+    // Their sum is the one-sided API quantity below; directly equating a
+    // central derivative with a discrete one-sided PV change would omit the
+    // stated curvature term.
+    const DECIMAL_DISCOUNT_DV01: f64 = -1.303_313_665_902_230_3e-5;
+    const DECIMAL_BASE_PV: f64 = 63.322_606_164_383_565;
+    let dv01 = funding_rate_swap_discount_dv01(
+        &swap,
+        &funding_curve,
+        Some(&discount_curve),
+        swap.entry_time,
+    );
+    // The API subtracts two O(63) PVs to obtain an O(1e-5) change.  Budget
+    // accumulated cancellation at 128 binary64 epsilons of the two-operand
+    // scale, rather than applying a misleading relative tolerance to DV01.
+    let cancellation_scale = 2.0 * DECIMAL_BASE_PV.abs();
+    let roundoff_budget = 128.0 * f64::EPSILON * cancellation_scale;
+    assert!(
+        (dv01 - DECIMAL_DISCOUNT_DV01).abs() <= roundoff_budget,
+        "discount-curve DV01: actual={dv01:.17e}, independent Decimal \
+         reference={DECIMAL_DISCOUNT_DV01:.17e}, cancellation \
+         roundoff budget={roundoff_budget:.3e}"
+    );
+}

--- a/tests/hjm_adjustments_test.rs
+++ b/tests/hjm_adjustments_test.rs
@@ -100,7 +100,7 @@ fn timing_adjustment_matches_zero_and_nonzero_closed_forms() {
 }
 
 #[test]
-fn real_option_to_defer_is_at_least_intrinsic_value() {
+fn real_option_to_defer_matches_independent_decimal_crr_grid() {
     let option = DeferInvestmentOption {
         model: RealOptionBinomialSpec {
             project_value: 120.0,
@@ -113,12 +113,29 @@ fn real_option_to_defer_is_at_least_intrinsic_value() {
         investment_cost: 100.0,
     };
 
+    // Python 3.11.15 `decimal`, precision=80, independently materialized the
+    // 200-step CRR terminal slice and rolled back
+    // max(V - 100, exp(-r dt) E[next]).  Before generating the reference, the
+    // CRR parameters were independently checked from dt=0.01:
+    // u=exp(0.03), d=1/u, p=0.5008347292820301768798637453, and
+    // discount=0.9995001249791692705729383665.  No OpenFerric output was used.
+    const DECIMAL_200_STEP_REFERENCE: f64 = 36.114_318_311_734_4;
+    const RELATIVE_ROUNDOFF_BUDGET: f64 = 1.0e-12;
     let value = price_option_to_defer(&option).unwrap().price;
+    let roundoff_budget = RELATIVE_ROUNDOFF_BUDGET * DECIMAL_200_STEP_REFERENCE.abs().max(1.0);
+    assert!(
+        (value - DECIMAL_200_STEP_REFERENCE).abs() <= roundoff_budget,
+        "defer-option finite-grid price: actual={value:.17e}, \
+         independent Decimal reference={DECIMAL_200_STEP_REFERENCE:.17e}, \
+         roundoff budget={roundoff_budget:.3e}"
+    );
+
+    // Supplemental no-arbitrage bound.
     assert!(value >= (option.model.project_value - option.investment_cost).max(0.0));
 }
 
 #[test]
-fn option_to_abandon_is_above_european_put_equivalent() {
+fn real_option_to_abandon_matches_independent_decimal_crr_grid() {
     let option = AbandonmentOption {
         model: RealOptionBinomialSpec {
             project_value: 90.0,
@@ -131,8 +148,25 @@ fn option_to_abandon_is_above_european_put_equivalent() {
         salvage_value: 100.0,
     };
 
+    // Python 3.11.15 `decimal`, precision=80, independently materialized the
+    // 200-step CRR terminal slice and rolled back
+    // max(100 - V, exp(-r dt) E[next]).  The independently checked dt=0.01
+    // parameters were u=exp(0.035), d=1/u,
+    // p=0.4969651551103012289869698153, and
+    // discount=0.9996000799893343999146723552.
+    const DECIMAL_200_STEP_REFERENCE: f64 = 20.320_892_847_045_855;
+    const RELATIVE_ROUNDOFF_BUDGET: f64 = 1.0e-12;
     let american = price_option_to_abandon(&option).unwrap().price;
+    let roundoff_budget = RELATIVE_ROUNDOFF_BUDGET * DECIMAL_200_STEP_REFERENCE.abs().max(1.0);
+    assert!(
+        (american - DECIMAL_200_STEP_REFERENCE).abs() <= roundoff_budget,
+        "abandon-option finite-grid price: actual={american:.17e}, \
+         independent Decimal reference={DECIMAL_200_STEP_REFERENCE:.17e}, \
+         roundoff budget={roundoff_budget:.3e}"
+    );
+
     let european = european_abandonment_put(&option).unwrap();
 
+    // Supplemental American-exercise dominance bound.
     assert!(american >= european - 1.0e-10);
 }

--- a/tests/rates_capfloor_quantlib.rs
+++ b/tests/rates_capfloor_quantlib.rs
@@ -1,0 +1,390 @@
+//! Black cap/floor references generated offline with QuantLib-Python 1.43.
+//!
+//! Provenance: Python 3.11.15, QuantLib 1.43, SciPy 1.17.1, NumPy 2.4.3, and
+//! mpmath 1.4.1 (installed in the reference environment, but not needed here).
+//! `Settings.evaluationDate` is 2024-01-01.  Each QuantLib contract uses a
+//! `WeekendsOnly` calendar, Modified Following adjustment, Actual/365 (Fixed),
+//! zero fixing days, and a custom Ibor index forecast from the same continuously
+//! compounded `FlatForward` curve used for discounting.  NPVs and optionlet
+//! prices come from `BlackCapFloorEngine`; all values below are frozen literals,
+//! so neither QuantLib nor the citation-only vendor submodule is used at runtime.
+//!
+//! The same adjusted dates were also evaluated by a separate Python strip that
+//! formed `F=(DF(t1)/DF(t2)-1)/accrual` and called SciPy's `special.ndtr` in the
+//! Black-76 formula.  Across the 16 aggregate fixtures the largest measured
+//! `|QuantLib - SciPy strip|` was 3.7834979593753815e-10 currency units.  Each
+//! case records its own measured gap.  The Linux Rust-vs-QuantLib session also
+//! measured a maximum 3.7834979593753815e-10 gap; assertions allow four times
+//! the per-case oracle gap for implementation-order/cross-platform libm
+//! variation, plus 64 binary64 ULP.
+
+use chrono::NaiveDate;
+
+use openferric::rates::{
+    CapFloor, DayCountConvention, Frequency, YieldCurve, generate_schedule, year_fraction,
+};
+
+const NOTIONAL: f64 = 1_000_000.0;
+const START_YEAR: i32 = 2024;
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).unwrap()
+}
+
+fn start_date() -> NaiveDate {
+    date(START_YEAR, 1, 1)
+}
+
+fn curve_on_schedule(rate: f64, end_date: NaiveDate, frequency: Frequency) -> YieldCurve {
+    let start = start_date();
+    let nodes = generate_schedule(start, end_date, frequency)
+        .into_iter()
+        .skip(1)
+        .map(|payment_date| {
+            let t = year_fraction(start, payment_date, DayCountConvention::Act365Fixed);
+            (t, (-rate * t).exp())
+        })
+        .collect();
+    YieldCurve::new(nodes)
+}
+
+fn ulp(value: f64) -> f64 {
+    let magnitude = value.abs();
+    magnitude.next_up() - magnitude
+}
+
+fn assert_quantlib_black_reference(
+    actual: f64,
+    expected: f64,
+    measured_scipy_gap: f64,
+    case: &str,
+) {
+    let cross_platform_oracle_budget = 4.0 * measured_scipy_gap;
+    let rust_roundoff_budget = 64.0 * ulp(expected.abs().max(1.0));
+    let tolerance = cross_platform_oracle_budget + rust_roundoff_budget;
+    let error = (actual - expected).abs();
+    assert!(
+        error <= tolerance,
+        "{case}: actual={actual:.17}, QuantLib={expected:.17}, error={error:e}, tolerance={tolerance:e}"
+    );
+}
+
+#[test]
+fn capfloor_schedules_match_quantlib_weekends_only_modified_following() {
+    let start = start_date();
+
+    // An offline scan over a complete 400-year Gregorian cycle found a
+    // weekday-only start for this 2Y quarterly schedule.  No start makes all
+    // eleven boundaries of an inclusive 5Y semiannual schedule weekdays, so
+    // the two 2028 adjustments for the common 2024 start are locked below.
+    let quarterly = generate_schedule(start, date(2026, 1, 1), Frequency::Quarterly);
+    let quantlib_quarterly = [
+        date(2024, 1, 1),
+        date(2024, 4, 1),
+        date(2024, 7, 1),
+        date(2024, 10, 1),
+        date(2025, 1, 1),
+        date(2025, 4, 1),
+        date(2025, 7, 1),
+        date(2025, 10, 1),
+        date(2026, 1, 1),
+    ];
+    assert_eq!(quarterly, quantlib_quarterly);
+
+    let semiannual = generate_schedule(start, date(2029, 1, 1), Frequency::SemiAnnual);
+    let quantlib_semiannual = [
+        date(2024, 1, 1),
+        date(2024, 7, 1),
+        date(2025, 1, 1),
+        date(2025, 7, 1),
+        date(2026, 1, 1),
+        date(2026, 7, 1),
+        date(2027, 1, 1),
+        date(2027, 7, 1),
+        date(2028, 1, 3),
+        date(2028, 7, 3),
+        date(2029, 1, 1),
+    ];
+    assert_eq!(semiannual, quantlib_semiannual);
+}
+
+#[derive(Clone, Copy)]
+struct BlackGridCase {
+    label: &'static str,
+    end_date: NaiveDate,
+    frequency: Frequency,
+    rate: f64,
+    strike: f64,
+    vol: f64,
+    quantlib_cap: f64,
+    quantlib_floor: f64,
+    scipy_gap_cap: f64,
+    scipy_gap_floor: f64,
+}
+
+fn black_grid() -> [BlackGridCase; 8] {
+    [
+        BlackGridCase {
+            label: "2Y quarterly, r=3%, K=2%, vol=15%",
+            end_date: date(2026, 1, 1),
+            frequency: Frequency::Quarterly,
+            rate: 0.03,
+            strike: 0.02,
+            vol: 0.15,
+            quantlib_cap: 19_599.918_621_214_58,
+            quantlib_floor: 16.493_431_247_276_41,
+            scipy_gap_cap: 0.0,
+            scipy_gap_floor: 4.547_473_508_864_641e-13,
+        },
+        BlackGridCase {
+            label: "2Y quarterly, r=3%, K=3%, vol=25%",
+            end_date: date(2026, 1, 1),
+            frequency: Frequency::Quarterly,
+            rate: 0.03,
+            strike: 0.03,
+            vol: 0.25,
+            quantlib_cap: 4_964.860_184_421_881,
+            quantlib_floor: 4_746.156_668_935_327,
+            scipy_gap_cap: 9.094_947_017_729_282e-13,
+            scipy_gap_floor: 9.094_947_017_729_282e-13,
+        },
+        BlackGridCase {
+            label: "2Y quarterly, r=5%, K=4%, vol=15%",
+            end_date: date(2026, 1, 1),
+            frequency: Frequency::Quarterly,
+            rate: 0.05,
+            strike: 0.04,
+            vol: 0.15,
+            quantlib_cap: 19_892.936_623_858_866,
+            quantlib_floor: 359.542_769_009_595_1,
+            scipy_gap_cap: 7.275_957_614_183_426e-12,
+            scipy_gap_floor: 8.299_139_153_677_97e-12,
+        },
+        BlackGridCase {
+            label: "2Y quarterly, r=5%, K=2%, vol=25%",
+            end_date: date(2026, 1, 1),
+            frequency: Frequency::Quarterly,
+            rate: 0.05,
+            strike: 0.02,
+            vol: 0.25,
+            quantlib_cap: 57_412.942_565_792_73,
+            quantlib_floor: 2.983_735_409_493_438,
+            scipy_gap_cap: 1.455_191_522_836_685_2e-11,
+            scipy_gap_floor: 7.092_104_681_305_5e-13,
+        },
+        BlackGridCase {
+            label: "5Y semiannual, r=3%, K=4%, vol=15%",
+            end_date: date(2029, 1, 1),
+            frequency: Frequency::SemiAnnual,
+            rate: 0.03,
+            strike: 0.04,
+            vol: 0.15,
+            quantlib_cap: 2_055.381_010_162_325,
+            quantlib_floor: 47_140.766_487_939_75,
+            scipy_gap_cap: 4.547_473_508_864_641e-13,
+            scipy_gap_floor: 7.275_957_614_183_426e-12,
+        },
+        BlackGridCase {
+            label: "5Y semiannual, r=3%, K=2%, vol=25%",
+            end_date: date(2029, 1, 1),
+            frequency: Frequency::SemiAnnual,
+            rate: 0.03,
+            strike: 0.02,
+            vol: 0.25,
+            quantlib_cap: 50_206.911_635_270_17,
+            quantlib_floor: 3_032.855_279_522_312_2,
+            scipy_gap_cap: 7.275_957_614_183_426e-12,
+            scipy_gap_floor: 2.273_736_754_432_320_6e-12,
+        },
+        BlackGridCase {
+            label: "5Y semiannual, r=5%, K=3%, vol=15%",
+            end_date: date(2029, 1, 1),
+            frequency: Frequency::SemiAnnual,
+            rate: 0.05,
+            strike: 0.03,
+            vol: 0.15,
+            quantlib_cap: 90_515.035_114_107_68,
+            quantlib_floor: 294.465_733_810_374_84,
+            scipy_gap_cap: 3.783_497_959_375_381_5e-10,
+            scipy_gap_floor: 9.094_947_017_729_282e-13,
+        },
+        BlackGridCase {
+            label: "5Y semiannual, r=5%, K=4%, vol=25%",
+            end_date: date(2029, 1, 1),
+            frequency: Frequency::SemiAnnual,
+            rate: 0.05,
+            strike: 0.04,
+            vol: 0.25,
+            quantlib_cap: 57_232.576_195_010_54,
+            quantlib_floor: 10_742.669_614_627_632,
+            scipy_gap_cap: 3.346_940_502_524_376e-10,
+            scipy_gap_floor: 6.184_563_972_055_912e-11,
+        },
+    ]
+}
+
+#[test]
+fn caps_and_floors_match_quantlib_black_cap_floor_engine_grid() {
+    for case in black_grid() {
+        let curve = curve_on_schedule(case.rate, case.end_date, case.frequency);
+        let cap = CapFloor {
+            notional: NOTIONAL,
+            strike: case.strike,
+            start_date: start_date(),
+            end_date: case.end_date,
+            frequency: case.frequency,
+            day_count: DayCountConvention::Act365Fixed,
+            is_cap: true,
+        };
+        let floor = CapFloor {
+            is_cap: false,
+            ..cap.clone()
+        };
+
+        let cap_price = cap.price(&curve, case.vol);
+        let floor_price = floor.price(&curve, case.vol);
+        assert_quantlib_black_reference(
+            cap_price,
+            case.quantlib_cap,
+            case.scipy_gap_cap,
+            &format!("{} cap", case.label),
+        );
+        assert_quantlib_black_reference(
+            floor_price,
+            case.quantlib_floor,
+            case.scipy_gap_floor,
+            &format!("{} floor", case.label),
+        );
+
+        // Supplemental identity: C - F is the underlying strike swap.  The
+        // operation-count allowance covers each optionlet and both strip sums.
+        let parity_lhs = cap_price - floor_price;
+        let parity_rhs = cap.swap_npv(&curve);
+        let periods = generate_schedule(start_date(), case.end_date, case.frequency).len() - 1;
+        let operation_scale = cap_price
+            .abs()
+            .max(floor_price.abs())
+            .max(parity_rhs.abs())
+            .max(1.0);
+        let parity_roundoff = 32.0 * periods as f64 * f64::EPSILON * operation_scale;
+        assert!(
+            (parity_lhs - parity_rhs).abs() <= parity_roundoff,
+            "{} parity: lhs={parity_lhs:.17}, rhs={parity_rhs:.17}, budget={parity_roundoff:e}",
+            case.label
+        );
+    }
+}
+
+#[test]
+fn caplets_match_quantlib_black_cap_floor_engine_optionlets_price() {
+    let end_date = date(2026, 1, 1);
+    let frequency = Frequency::Quarterly;
+    let curve = curve_on_schedule(0.03, end_date, frequency);
+    let cap = CapFloor {
+        notional: NOTIONAL,
+        strike: 0.03,
+        start_date: start_date(),
+        end_date,
+        frequency,
+        day_count: DayCountConvention::Act365Fixed,
+        is_cap: true,
+    };
+    let schedule = generate_schedule(start_date(), end_date, frequency);
+
+    // QuantLib `optionletsPrice()` for the same 2Y quarterly cap.  The first
+    // caplet fixes on the evaluation date, so its zero-expiry value is intrinsic
+    // in both engines; no historical fixing is required with zero fixing days.
+    let quantlib_optionlets = [
+        27.832_019_590_435_67,
+        381.368_571_871_275_1,
+        535.126_017_130_184_6,
+        648.024_696_460_711_8,
+        724.351_746_373_320_1,
+        809.510_947_563_870_8,
+        887.910_770_527_743_5,
+        950.735_414_904_34,
+    ];
+    let scipy_gaps = [
+        0.0,
+        5.684_341_886_080_802e-14,
+        0.0,
+        1.182_343_112_304_806_7e-10,
+        1.182_343_112_304_806_7e-10,
+        0.0,
+        1.136_868_377_216_160_3e-13,
+        0.0,
+    ];
+
+    for (i, period) in schedule.windows(2).enumerate() {
+        let actual = cap.optionlet_price(&curve, 0.25, period[0], period[1]);
+        assert_quantlib_black_reference(
+            actual,
+            quantlib_optionlets[i],
+            scipy_gaps[i],
+            &format!("quarterly caplet {i}"),
+        );
+    }
+}
+
+#[test]
+fn capfloor_implied_vol_round_trip_uses_quantlib_market_prices() {
+    // These are package prices, rather than prices generated by the solver's
+    // own objective function.  The bisection stopping rule is price-based, so
+    // 2e-10 volatility is a conservative solver tolerance, not a price band.
+    let cases = [
+        (
+            date(2026, 1, 1),
+            Frequency::Quarterly,
+            0.03,
+            0.03,
+            0.25,
+            true,
+            4_964.860_184_421_881,
+        ),
+        (
+            date(2026, 1, 1),
+            Frequency::Quarterly,
+            0.05,
+            0.04,
+            0.15,
+            false,
+            359.542_769_009_595_1,
+        ),
+        (
+            date(2029, 1, 1),
+            Frequency::SemiAnnual,
+            0.03,
+            0.04,
+            0.15,
+            true,
+            2_055.381_010_162_325,
+        ),
+        (
+            date(2029, 1, 1),
+            Frequency::SemiAnnual,
+            0.05,
+            0.04,
+            0.25,
+            false,
+            10_742.669_614_627_632,
+        ),
+    ];
+
+    for (end_date, frequency, rate, strike, vol, is_cap, quantlib_price) in cases {
+        let curve = curve_on_schedule(rate, end_date, frequency);
+        let instrument = CapFloor {
+            notional: NOTIONAL,
+            strike,
+            start_date: start_date(),
+            end_date,
+            frequency,
+            day_count: DayCountConvention::Act365Fixed,
+            is_cap,
+        };
+        let recovered = instrument.implied_vol(quantlib_price, &curve);
+        assert!(
+            (recovered - vol).abs() <= 2.0e-10,
+            "is_cap={is_cap}, r={rate}, K={strike}: recovered={recovered:.17}, expected={vol:.17}"
+        );
+    }
+}

--- a/tests/rates_capfloor_quantlib.rs
+++ b/tests/rates_capfloor_quantlib.rs
@@ -13,10 +13,14 @@
 //! formed `F=(DF(t1)/DF(t2)-1)/accrual` and called SciPy's `special.ndtr` in the
 //! Black-76 formula.  Across the 16 aggregate fixtures the largest measured
 //! `|QuantLib - SciPy strip|` was 3.7834979593753815e-10 currency units.  Each
-//! case records its own measured gap.  The Linux Rust-vs-QuantLib session also
-//! measured a maximum 3.7834979593753815e-10 gap; assertions allow four times
-//! the per-case oracle gap for implementation-order/cross-platform libm
-//! variation, plus 64 binary64 ULP.
+//! case records its own measured gap.  The Linux Rust-vs-QuantLib session
+//! measured a maximum 3.7834979593753815e-10 gap.  A subsequent macOS CI run
+//! measured a 1.2096279533579946e-10 maximum on cases whose Linux gap was near
+//! zero: the discount-factor ratio subtracts two notional-scale quantities, so
+//! the expected option price is not the correct roundoff scale.  Assertions
+//! therefore allow four times the per-case oracle gap, 64 scaled epsilons at
+//! the fixed notional input scale for cross-libm operation order, and 64 ULP
+//! for the final strip sum.  This is an arithmetic budget, not a price band.
 
 use chrono::NaiveDate;
 
@@ -59,13 +63,17 @@ fn assert_quantlib_black_reference(
     measured_scipy_gap: f64,
     case: &str,
 ) {
-    let cross_platform_oracle_budget = 4.0 * measured_scipy_gap;
-    let rust_roundoff_budget = 64.0 * ulp(expected.abs().max(1.0));
-    let tolerance = cross_platform_oracle_budget + rust_roundoff_budget;
+    let measured_oracle_budget = 4.0 * measured_scipy_gap;
+    let cross_platform_libm_budget = 64.0 * f64::EPSILON * NOTIONAL;
+    let strip_sum_roundoff_budget = 64.0 * ulp(expected.abs().max(1.0));
+    let tolerance = measured_oracle_budget + cross_platform_libm_budget + strip_sum_roundoff_budget;
     let error = (actual - expected).abs();
     assert!(
         error <= tolerance,
-        "{case}: actual={actual:.17}, QuantLib={expected:.17}, error={error:e}, tolerance={tolerance:e}"
+        "{case}: actual={actual:.17}, QuantLib={expected:.17}, error={error:e}, \
+         measured-oracle budget={measured_oracle_budget:e}, cross-libm \
+         budget={cross_platform_libm_budget:e}, strip-sum \
+         roundoff={strip_sum_roundoff_budget:e}, tolerance={tolerance:e}"
     );
 }
 


### PR DESCRIPTION
## Summary

- add a flagship QuantLib-Python Black cap/floor suite with locked ModifiedFollowing schedules, 16 cap/floor NPVs, optionlet prices, cap-floor parity, and implied-volatility round trips
- replace the remaining range-, ordering-, and fudge-band pricing checks with exact or explicitly budgeted references for CGMY FFT, TARF prices and termination statistics, floating lookbacks, diluted employee options, defer/abandon real options, funding swaps, ACF/PACF, and chi-square variance
- add independent 80-digit Decimal references for perpetual funding cashflows and sensitivities
- remove the obsolete digital “Greeks present” checks already subsumed by exact price-and-Greeks fixtures
- add a QuantLib swing convergence fixture with positive minimum rights, documented honestly as supplemental because the nonnegative payoff makes those rights economically non-binding
- correct the validation map and contributor guidance so the QuantLib submodule is clearly citation-only and never a runtime or CI dependency

## Reference provenance

Closed-form and package references were generated offline with Python 3.11.15, QuantLib-Python 1.43, SciPy 1.17.1, NumPy 2.4.3, and mpmath 1.4.1 where noted. Independent tree and funding references use Python Decimal at precision 80. Monte Carlo references use independently scrambled SciPy Sobol replicates and combine implementation/reference standard errors rather than percentage bands.

Each committed fixture records its contract conventions, oracle, measured implementation/oracle gap, and either a binary64 roundoff budget, a finite-grid discretization budget, or an explicit sampling-error model.

The first macOS accelerated run measured a `1.2096279533579946e-10` cap/floor variation on fixtures whose Linux oracle gap was near zero. Commit `778689b` records that observation and adds a `64 * epsilon * notional` operation-roundoff budget (`1.42e-8` currency units, or `1.42e-14` of notional); the complete cross-platform rerun is green.

## Stretch gates and deferrals

- The callable fixed-rate note gate was not promoted to a reference test. Exact dated non-callable cashflows matched QuantLib within 1.421e-14 and clean/dirty call semantics were reconciled, but the 1,200-step non-zero-volatility tree remained 3.360e-5 from the analytic Hull-White bond-option value. The coverage map records this rather than presenting a false closed-form tolerance.
- QuantLib `HullWhite::convexityBias` is not a like-for-like oracle for this repository’s standalone `sigma^2 * T1 * T2 / 2` futures adjustment: it also depends on the futures quote, accrual period, and mean reversion. Documentation now states that scope precisely.
- MBS remains anchored to its existing independent Decimal cashflow suite because published examples are too coarsely rounded. GPU price locks remain adapter-gated with explicit skips. Existing LMM Sobol and swing QuantLib oracles are cited accurately.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets --all-features`
- `cargo test --locked --workspace --features accelerated-native` (full workspace; core 844 passed, 1 ignored, plus all integration/workspace/doc tests)
- focused cap/floor, funding swap, TARF, CGMY, exotic, ESO, real-option, swing, digital, time-series, and correlation suites
- commit/push hooks: workspace `cargo check`, Clippy, native build, and wasm32 library build
- `git diff --check`
- GitHub Actions on `778689b`: complete Linux default/parallel/SIMD/all-features, Windows/macOS accelerated, ARM64, WASM, MSRV, Rust/Python/TypeScript, benchmark, and coverage matrix green
