### PR TITLE
Harden remaining test coverage

### DIFF
--- a/src/dsl/analysis.rs
+++ b/src/dsl/analysis.rs
@@ -317,8 +317,10 @@ pub fn build_symbol_table(ast: &ProductDef, source: &str) -> SymbolTable {
         });
     }
 
-    // Walk AST items.
-    let mut schedule_index = 0usize;
+    // Collect product-scope declarations before walking any schedule. The
+    // compiler performs the same two-pass traversal, so a declaration remains
+    // visible regardless of whether its block appears before or after a
+    // schedule in the source.
     for item in &ast.body {
         match item {
             ProductItem::Underlyings(decls, _) => {
@@ -356,20 +358,35 @@ pub fn build_symbol_table(ast: &ProductDef, source: &str) -> SymbolTable {
                     });
                 }
             }
-            ProductItem::Schedule(sched) => {
-                let mut scope_decls = declarations.clone();
-                walk_statements(
-                    &sched.body,
-                    &mut scope_decls,
-                    &mut references,
-                    &mut declarations,
-                    SymbolScope::Schedule(schedule_index),
-                    source,
-                );
-                schedule_index += 1;
-            }
             _ => {}
         }
+    }
+
+    // Each schedule gets a fresh copy of the product scope. Locals are still
+    // retained in `declarations` for editor features, but must not leak into a
+    // later schedule.
+    for (schedule_index, sched) in ast
+        .body
+        .iter()
+        .filter_map(|item| match item {
+            ProductItem::Schedule(sched) => Some(sched),
+            _ => None,
+        })
+        .enumerate()
+    {
+        let mut scope_decls = declarations
+            .iter()
+            .filter(|declaration| declaration.kind != SymbolKind::Local)
+            .cloned()
+            .collect();
+        walk_statements(
+            &sched.body,
+            &mut scope_decls,
+            &mut references,
+            &mut declarations,
+            SymbolScope::Schedule(schedule_index),
+            source,
+        );
     }
 
     SymbolTable {
@@ -530,7 +547,9 @@ fn determine_context(source: &str, offset: usize) -> Context {
     let before = &source[..floor_char_boundary(source, offset)];
 
     let line_start = before.rfind('\n').map_or(0, |nl| nl + 1);
-    let line = before[line_start..].trim();
+    // Preserve trailing whitespace: `set ` and `schedule ` are distinct
+    // completion contexts while the user is typing.
+    let line = before[line_start..].trim_start();
 
     if line.starts_with("set ") && !line.contains('=') {
         return Context::AfterSet;
@@ -1010,6 +1029,554 @@ mod tests {
 
     const UTF8_SOURCE: &str =
         "product \"Caf\u{e9} \u{2014} N\u{f8}te\"\n    notional: 100\n    maturity: 1.0\n";
+
+    const ANALYSIS_SOURCE: &str = "\
+product \"Analysis\"
+    notional: 100
+    maturity: 2.0
+    underlyings
+        SPX = equity(0)
+        EURUSD = fx(1)
+        WTI = commodity(2)
+        USD3M = rate(3)
+    state
+        active: bool = true
+        accrued: float = 0.0
+    schedule semi_annual from 0.5 to 2.0
+        let perf = SPX / 100
+        if not active or perf >= 1.0 then
+            pay max(perf, accrued) + price(1)
+            set active = false
+        else
+            redeem WTI * notional
+        skip
+";
+
+    fn analysis_symbols() -> SymbolTable {
+        let tokens = lexer::tokenize(ANALYSIS_SOURCE).expect("fixture should lex");
+        let ast = parser::parse(tokens).expect("fixture should parse");
+        build_symbol_table(&ast, ANALYSIS_SOURCE)
+    }
+
+    fn labels(items: &[CompletionCandidate]) -> Vec<&str> {
+        items.iter().map(|item| item.label.as_str()).collect()
+    }
+
+    fn nth_offset(source: &str, needle: &str, occurrence: usize) -> usize {
+        source
+            .match_indices(needle)
+            .nth(occurrence)
+            .unwrap_or_else(|| panic!("missing occurrence {occurrence} of {needle:?}"))
+            .0
+    }
+
+    fn decoded_semantic_tokens(source: &str, symbols: &SymbolTable) -> Vec<(String, u32, u32)> {
+        let mut line = 0u32;
+        let mut col = 0u32;
+        semantic_token_data(source, symbols)
+            .into_iter()
+            .map(|token| {
+                line += token.delta_line;
+                if token.delta_line == 0 {
+                    col += token.delta_start;
+                } else {
+                    col = token.delta_start;
+                }
+                let start = line_col_to_offset(source, line, col);
+                let end = start + token.length as usize;
+                assert!(source.is_char_boundary(end));
+                assert_eq!(token.modifiers, 0);
+                (source[start..end].to_string(), token.token_type, line)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn symbol_table_records_declarations_references_and_asset_metadata() {
+        let symbols = analysis_symbols();
+
+        // Four constants, nine functions, four underlyings, two state
+        // variables and one local declaration.
+        assert_eq!(symbols.declarations.len(), 20);
+        for (name, kind, type_hint, doc) in [
+            ("SPX", SymbolKind::Underlying, "float", "Underlying equity"),
+            (
+                "EURUSD",
+                SymbolKind::Underlying,
+                "float",
+                "Underlying FX pair",
+            ),
+            (
+                "WTI",
+                SymbolKind::Underlying,
+                "float",
+                "Underlying commodity",
+            ),
+            (
+                "USD3M",
+                SymbolKind::Underlying,
+                "float",
+                "Underlying interest rate",
+            ),
+            (
+                "active",
+                SymbolKind::StateVar,
+                "bool",
+                "State variable (mutable across dates)",
+            ),
+            (
+                "accrued",
+                SymbolKind::StateVar,
+                "float",
+                "State variable (mutable across dates)",
+            ),
+            ("perf", SymbolKind::Local, "float", "Local variable"),
+        ] {
+            let declaration = symbols
+                .declarations
+                .iter()
+                .find(|declaration| declaration.name == name)
+                .unwrap_or_else(|| panic!("missing declaration {name}"));
+            assert_eq!(declaration.kind, kind);
+            assert_eq!(declaration.type_hint, type_hint);
+            assert_eq!(declaration.doc, doc);
+        }
+
+        let referenced_names: Vec<_> = symbols
+            .references
+            .iter()
+            .map(|reference| reference.name.as_str())
+            .collect();
+        for expected in [
+            "SPX", "active", "perf", "max", "accrued", "price", "WTI", "notional",
+        ] {
+            assert!(
+                referenced_names.contains(&expected),
+                "missing reference {expected}: {referenced_names:?}"
+            );
+        }
+
+        let set_active = symbols
+            .references
+            .iter()
+            .find(|reference| {
+                reference.name == "active"
+                    && &ANALYSIS_SOURCE[reference.span.start..reference.span.end] == "active"
+                    && ANALYSIS_SOURCE[..reference.span.start].ends_with("set ")
+            })
+            .expect("set target should be recorded as a reference");
+        assert_eq!(set_active.kind, SymbolKind::StateVar);
+        assert_eq!(
+            &ANALYSIS_SOURCE[set_active.def_span.start..set_active.def_span.start + 6],
+            "active"
+        );
+
+        assert!(symbols.declaration_at(usize::MAX).is_none());
+        assert!(symbols.reference_at(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn branch_and_schedule_locals_do_not_leak_into_sibling_scopes() {
+        let source = "\
+product \"Scopes\"
+    notional: 100
+    maturity: 2.0
+    schedule annual from 1.0 to 1.0
+        if is_final then
+            let branch_only = 1.0
+            pay branch_only
+        else
+            pay branch_only
+        pay branch_only
+    schedule annual from 2.0 to 2.0
+        pay branch_only
+";
+        let ast = parser::parse(lexer::tokenize(source).unwrap()).unwrap();
+        let symbols = build_symbol_table(&ast, source);
+
+        assert_eq!(
+            symbols
+                .declarations
+                .iter()
+                .filter(|declaration| declaration.name == "branch_only")
+                .count(),
+            1
+        );
+        let branch_references: Vec<_> = symbols
+            .references
+            .iter()
+            .filter(|reference| reference.name == "branch_only")
+            .collect();
+        assert_eq!(branch_references.len(), 1);
+        assert_eq!(
+            branch_references[0].span.start,
+            nth_offset(source, "branch_only", 1)
+        );
+        assert_eq!(
+            branch_references[0].def_span.start,
+            source.find("let branch_only").unwrap()
+        );
+    }
+
+    #[test]
+    fn product_declarations_after_schedule_resolve_forward_references() {
+        let source = "\
+product \"Forward declarations\"
+    notional: 100
+    maturity: 1.0
+    schedule annual from 1.0 to 1.0
+        let performance = SPX / 100
+        if active then
+            pay performance
+            set active = false
+    underlyings
+        SPX = equity(0)
+    state
+        active: bool = true
+";
+        let ast = parser::parse(lexer::tokenize(source).unwrap()).unwrap();
+        let symbols = build_symbol_table(&ast, source);
+
+        for name in ["SPX", "active"] {
+            let declaration = symbols
+                .declarations
+                .iter()
+                .find(|declaration| declaration.name == name)
+                .unwrap_or_else(|| panic!("missing declaration {name}"));
+            let references: Vec<_> = symbols
+                .references
+                .iter()
+                .filter(|reference| reference.name == name)
+                .collect();
+            assert!(!references.is_empty(), "missing reference {name}");
+            assert!(
+                references
+                    .iter()
+                    .all(|reference| reference.def_span == declaration.def_span)
+            );
+            assert!(references[0].span.start < declaration.def_span.start);
+        }
+    }
+
+    #[test]
+    fn completions_cover_every_editor_context() {
+        let symbols = analysis_symbols();
+
+        let top_level = completions("", &symbols, 0);
+        assert_eq!(
+            labels(&top_level),
+            ["notional:", "maturity:", "underlyings", "state", "schedule"]
+        );
+        assert!(
+            top_level
+                .iter()
+                .all(|item| item.kind == CompletionCandidateKind::Keyword)
+        );
+
+        let after_schedule_source = "schedule ";
+        let frequencies = completions(after_schedule_source, &symbols, after_schedule_source.len());
+        assert_eq!(
+            labels(&frequencies),
+            ["monthly", "quarterly", "semi_annual", "annual"]
+        );
+        assert!(
+            frequencies
+                .iter()
+                .all(|item| item.kind == CompletionCandidateKind::EnumMember)
+        );
+
+        let statement_source = "schedule annual from 1.0 to 1.0\n        ";
+        assert_eq!(
+            labels(&completions(
+                statement_source,
+                &symbols,
+                statement_source.len()
+            )),
+            ["let", "if", "pay", "redeem", "set", "skip"]
+        );
+
+        let set_source = "schedule annual from 1.0 to 1.0\n        set ";
+        let state_items = completions(set_source, &symbols, set_source.len());
+        assert_eq!(labels(&state_items), ["active", "accrued"]);
+        assert!(state_items.iter().all(|item| {
+            item.kind == CompletionCandidateKind::Variable
+                && item.detail.is_some()
+                && item.documentation.is_none()
+        }));
+
+        let type_source = "state\n    active:";
+        assert_eq!(
+            labels(&completions(type_source, &symbols, type_source.len())),
+            ["bool", "float"]
+        );
+
+        let expression_source = "schedule annual from 1.0 to 1.0\n        active +";
+        let expression_items =
+            completions(expression_source, &symbols, expression_source.len() + 100);
+        for (label, kind) in [
+            ("SPX", CompletionCandidateKind::Variable),
+            ("active", CompletionCandidateKind::Variable),
+            ("perf", CompletionCandidateKind::Variable),
+            ("notional", CompletionCandidateKind::Constant),
+            ("worst_of", CompletionCandidateKind::Function),
+        ] {
+            let item = expression_items
+                .iter()
+                .find(|item| item.label == label)
+                .unwrap_or_else(|| panic!("missing expression completion {label}"));
+            assert_eq!(item.kind, kind);
+            assert!(item.detail.is_some());
+            assert!(item.documentation.is_some());
+        }
+    }
+
+    #[test]
+    fn hover_and_goto_definition_resolve_each_symbol_kind() {
+        let symbols = analysis_symbols();
+
+        let spx_reference = nth_offset(ANALYSIS_SOURCE, "SPX", 1);
+        let spx_hover = hover_info(ANALYSIS_SOURCE, &symbols, spx_reference).unwrap();
+        assert_eq!(spx_hover.markdown, "`SPX: float` — underlying equity");
+        assert_eq!(
+            goto_definition(ANALYSIS_SOURCE, &symbols, spx_reference),
+            Some(Span::new(
+                nth_offset(ANALYSIS_SOURCE, "SPX", 0),
+                nth_offset(ANALYSIS_SOURCE, "SPX", 0) + "SPX = equity(0".len()
+            ))
+        );
+
+        let state_reference = nth_offset(ANALYSIS_SOURCE, "active", 1);
+        assert!(
+            hover_info(ANALYSIS_SOURCE, &symbols, state_reference)
+                .unwrap()
+                .markdown
+                .contains("state variable")
+        );
+        assert_eq!(
+            goto_definition(ANALYSIS_SOURCE, &symbols, state_reference)
+                .unwrap()
+                .start,
+            nth_offset(ANALYSIS_SOURCE, "active", 0)
+        );
+
+        let local_reference = nth_offset(ANALYSIS_SOURCE, "perf", 1);
+        assert!(
+            hover_info(ANALYSIS_SOURCE, &symbols, local_reference)
+                .unwrap()
+                .markdown
+                .contains("local variable")
+        );
+        assert_eq!(
+            goto_definition(ANALYSIS_SOURCE, &symbols, local_reference)
+                .unwrap()
+                .start,
+            ANALYSIS_SOURCE.find("let perf").unwrap()
+        );
+
+        let function_reference = nth_offset(ANALYSIS_SOURCE, "max", 0);
+        let function_hover = hover_info(ANALYSIS_SOURCE, &symbols, function_reference).unwrap();
+        assert_eq!(
+            function_hover.markdown,
+            "`max(a: float, b: float) -> float` — Maximum of two values"
+        );
+        assert!(goto_definition(ANALYSIS_SOURCE, &symbols, function_reference).is_none());
+
+        let builtin_reference = ANALYSIS_SOURCE.rfind("notional").unwrap();
+        assert!(
+            hover_info(ANALYSIS_SOURCE, &symbols, builtin_reference)
+                .unwrap()
+                .markdown
+                .contains("built-in")
+        );
+        assert!(goto_definition(ANALYSIS_SOURCE, &symbols, builtin_reference).is_none());
+
+        let declaration_offset = nth_offset(ANALYSIS_SOURCE, "accrued", 0);
+        let declaration_hover = hover_info(ANALYSIS_SOURCE, &symbols, declaration_offset).unwrap();
+        assert_eq!(declaration_hover.start, declaration_offset);
+        assert!(declaration_hover.markdown.contains("accrued: float"));
+
+        assert!(hover_info(ANALYSIS_SOURCE, &symbols, ANALYSIS_SOURCE.len()).is_none());
+        assert!(goto_definition(ANALYSIS_SOURCE, &symbols, 0).is_none());
+    }
+
+    #[test]
+    fn keyword_hover_documents_all_language_keywords() {
+        for (word, expected) in [
+            ("product", "structured product"),
+            ("notional", "face value"),
+            ("maturity", "year fractions"),
+            ("underlyings", "underlying assets"),
+            ("state", "persist across observation dates"),
+            ("schedule", "observation schedule"),
+            ("let", "local variable"),
+            ("if", "Conditional branch"),
+            ("then", "conditional branch"),
+            ("else", "Alternative branch"),
+            ("pay", "cashflow payment"),
+            ("redeem", "terminate the product"),
+            ("set", "state variable"),
+            ("skip", "without payment"),
+            ("and", "AND"),
+            ("or", "OR"),
+            ("not", "NOT"),
+            ("from", "start date"),
+            ("to", "end date"),
+            ("monthly", "every month"),
+            ("quarterly", "every quarter"),
+            ("semi_annual", "every 6 months"),
+            ("annual", "every year"),
+            ("true", "Boolean literal"),
+            ("false", "Boolean literal"),
+            ("bool", "Boolean type"),
+            ("float", "Floating-point"),
+            ("asset", "underlying by index"),
+            ("equity", "Equity underlying"),
+            ("fx", "FX pair"),
+            ("commodity", "Commodity underlying"),
+            ("rate", "Interest rate underlying"),
+        ] {
+            let hover = keyword_hover(word, word.len() / 2).unwrap();
+            assert_eq!(hover.start, 0);
+            assert_eq!(hover.end, word.len());
+            assert!(
+                hover.markdown.contains(expected),
+                "{word:?} hover was {:?}",
+                hover.markdown
+            );
+        }
+
+        assert!(keyword_hover("unknown", 2).is_none());
+        assert!(keyword_hover(" ", 0).is_none());
+        assert!(keyword_hover("product", 100).is_none());
+    }
+
+    #[test]
+    fn semantic_tokens_classify_and_delta_encode_source_tokens() {
+        let symbols = analysis_symbols();
+        let decoded = decoded_semantic_tokens(ANALYSIS_SOURCE, &symbols);
+
+        for (text, token_type) in [
+            ("product", TOKEN_KEYWORD),
+            ("\"Analysis\"", TOKEN_STRING),
+            ("100", TOKEN_NUMBER),
+            ("semi_annual", TOKEN_ENUM_MEMBER),
+            ("SPX", TOKEN_VARIABLE),
+            ("max", TOKEN_FUNCTION),
+            ("not", TOKEN_OPERATOR),
+            (">=", TOKEN_OPERATOR),
+            ("+", TOKEN_OPERATOR),
+        ] {
+            assert!(
+                decoded
+                    .iter()
+                    .any(|(actual, actual_type, _)| actual == text && *actual_type == token_type),
+                "missing semantic token ({text:?}, {token_type}); decoded={decoded:?}"
+            );
+        }
+
+        assert!(decoded.windows(2).all(|pair| pair[0].2 <= pair[1].2));
+        assert!(
+            !decoded
+                .iter()
+                .any(|(text, _, _)| matches!(text.as_str(), "(" | ")" | ":" | ","))
+        );
+        assert!(semantic_token_data("product \"unterminated", &symbols).is_empty());
+    }
+
+    #[test]
+    fn parse_and_diagnose_maps_lex_parse_and_compile_errors_to_source_spans() {
+        let lex_source = "product \"Bad\"\n    notional: @\n";
+        let (ast, product, diagnostics) = parse_and_diagnose(lex_source);
+        assert!(ast.is_none());
+        assert!(product.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        let at = lex_source.find('@').unwrap();
+        assert_eq!((diagnostics[0].start, diagnostics[0].end), (at, at + 1));
+        assert!(diagnostics[0].message.contains("unexpected character"));
+
+        let parse_source = "product \"Bad\"\n    pay 1\n";
+        let (ast, product, diagnostics) = parse_and_diagnose(parse_source);
+        assert!(ast.is_none());
+        assert!(product.is_none());
+        let pay = parse_source.find("pay").unwrap();
+        assert_eq!((diagnostics[0].start, diagnostics[0].end), (pay, pay + 3));
+        assert!(diagnostics[0].message.contains("unexpected token"));
+
+        let compile_source = "\
+product \"Bad\"
+    notional: 100
+    maturity: 1.0
+    schedule annual from 1.0 to 1.0
+        pay undefined_value
+";
+        let (ast, product, diagnostics) = parse_and_diagnose(compile_source);
+        assert!(ast.is_some());
+        assert!(product.is_none());
+        let undefined = compile_source.find("undefined_value").unwrap();
+        assert_eq!(
+            (diagnostics[0].start, diagnostics[0].end),
+            (undefined, undefined + "undefined_value".len())
+        );
+        assert!(diagnostics[0].message.contains("undefined variable"));
+
+        let missing_notional = "product \"Bad\"\n    maturity: 1.0\n";
+        let (ast, product, diagnostics) = parse_and_diagnose(missing_notional);
+        assert!(ast.is_some());
+        assert!(product.is_none());
+        assert_eq!((diagnostics[0].start, diagnostics[0].end), (0, 1));
+        assert_eq!(diagnostics[0].message, "missing notional declaration");
+
+        let eval = error_to_diagnostic(&DslError::EvalError("path failed".into()));
+        assert_eq!(eval.severity, DiagnosticSeverity::Error);
+        assert_eq!((eval.start, eval.end), (0, 1));
+        assert_eq!(eval.message, "path failed");
+    }
+
+    #[test]
+    fn analysis_helpers_handle_unknown_types_unresolved_targets_and_empty_scopes() {
+        let source = "\
+product \"Partial\"
+    notional: 100
+    state
+        custom: decimal = 0.0
+    schedule annual from 1.0 to 1.0
+        set missing = custom
+";
+        let ast = parser::parse(lexer::tokenize(source).unwrap()).unwrap();
+        assert!(lint_warnings(&ast).is_empty());
+        let symbols = build_symbol_table(&ast, source);
+
+        let custom = symbols
+            .declarations
+            .iter()
+            .find(|declaration| declaration.name == "custom")
+            .unwrap();
+        assert_eq!(custom.type_hint, "unknown");
+        assert!(
+            symbols
+                .references
+                .iter()
+                .all(|reference| reference.name != "missing")
+        );
+
+        assert!(!is_in_state_block("ordinary text"));
+        assert!(!is_in_schedule_body("ordinary text"));
+        assert!(line_is_statement_start("pay 1.0"));
+        assert!(!line_is_statement_start("custom +"));
+
+        let synthetic = SymbolTable {
+            declarations: vec![],
+            references: vec![SymbolRef {
+                name: "synthetic".into(),
+                span: Span::new(0, 9),
+                def_span: Span::new(0, 0),
+                kind: SymbolKind::Underlying,
+                type_hint: "float",
+                doc: "Synthetic test symbol",
+            }],
+        };
+        assert!(goto_definition("synthetic", &synthetic, 1).is_none());
+    }
 
     #[test]
     fn line_col_to_offset_clamps_to_char_boundary() {

--- a/src/dsl/market.rs
+++ b/src/dsl/market.rs
@@ -346,6 +346,442 @@ mod tests {
         }
     }
 
+    fn assert_invalid(asset: AssetMarketData, expected: &str) {
+        let error = market_with(asset).validate().unwrap_err().to_string();
+        assert!(
+            error.contains(expected),
+            "expected {expected:?} in validation error, got {error:?}"
+        );
+    }
+
+    fn valid_equity() -> AssetMarketData {
+        AssetMarketData::Equity {
+            spot: 100.0,
+            vol: 0.2,
+            dividend_yield: 0.01,
+        }
+    }
+
+    fn valid_fx() -> AssetMarketData {
+        AssetMarketData::Fx {
+            spot: 1.1,
+            vol: 0.15,
+            domestic_rate: 0.03,
+            foreign_rate: 0.02,
+        }
+    }
+
+    fn valid_commodity() -> AssetMarketData {
+        AssetMarketData::Commodity {
+            spot: 75.0,
+            vol: 0.3,
+            convenience_yield: 0.01,
+            kappa: 0.4,
+            mu: 4.0,
+        }
+    }
+
+    fn valid_rate() -> AssetMarketData {
+        AssetMarketData::Rate {
+            initial_rate: -0.005,
+            vol: 0.01,
+            mean_reversion: 0.1,
+            long_run_mean: 0.04,
+        }
+    }
+
+    #[test]
+    fn accessors_and_bumps_cover_every_asset_variant_without_changing_other_fields() {
+        let equity = valid_equity();
+        assert_eq!(equity.initial_value(), 100.0);
+        assert_eq!(equity.vol(), 0.2);
+        match equity.with_spot_bump(2.5) {
+            AssetMarketData::Equity {
+                spot,
+                vol,
+                dividend_yield,
+            } => {
+                assert_eq!(spot, 102.5);
+                assert_eq!(vol, 0.2);
+                assert_eq!(dividend_yield, 0.01);
+            }
+            _ => panic!("spot bump changed equity variant"),
+        }
+        match equity.with_vol_bump(0.025) {
+            AssetMarketData::Equity {
+                spot,
+                vol,
+                dividend_yield,
+            } => {
+                assert_eq!(spot, 100.0);
+                assert_eq!(vol, 0.225);
+                assert_eq!(dividend_yield, 0.01);
+            }
+            _ => panic!("vol bump changed equity variant"),
+        }
+
+        let fx = valid_fx();
+        assert_eq!(fx.initial_value(), 1.1);
+        assert_eq!(fx.vol(), 0.15);
+        match fx.with_spot_bump(0.02) {
+            AssetMarketData::Fx {
+                spot,
+                vol,
+                domestic_rate,
+                foreign_rate,
+            } => {
+                assert_eq!(spot, 1.1 + 0.02);
+                assert_eq!(vol, 0.15);
+                assert_eq!(domestic_rate, 0.03);
+                assert_eq!(foreign_rate, 0.02);
+            }
+            _ => panic!("spot bump changed FX variant"),
+        }
+        match fx.with_vol_bump(-0.01) {
+            AssetMarketData::Fx {
+                spot,
+                vol,
+                domestic_rate,
+                foreign_rate,
+            } => {
+                assert_eq!(spot, 1.1);
+                assert_eq!(vol, 0.15 - 0.01);
+                assert_eq!(domestic_rate, 0.03);
+                assert_eq!(foreign_rate, 0.02);
+            }
+            _ => panic!("vol bump changed FX variant"),
+        }
+
+        let commodity = valid_commodity();
+        assert_eq!(commodity.initial_value(), 75.0);
+        assert_eq!(commodity.vol(), 0.3);
+        match commodity.with_spot_bump(-1.5) {
+            AssetMarketData::Commodity {
+                spot,
+                vol,
+                convenience_yield,
+                kappa,
+                mu,
+            } => {
+                assert_eq!(spot, 73.5);
+                assert_eq!(vol, 0.3);
+                assert_eq!(convenience_yield, 0.01);
+                assert_eq!(kappa, 0.4);
+                assert_eq!(mu, 4.0);
+            }
+            _ => panic!("spot bump changed commodity variant"),
+        }
+        match commodity.with_vol_bump(0.05) {
+            AssetMarketData::Commodity {
+                spot,
+                vol,
+                convenience_yield,
+                kappa,
+                mu,
+            } => {
+                assert_eq!(spot, 75.0);
+                assert_eq!(vol, 0.3 + 0.05);
+                assert_eq!(convenience_yield, 0.01);
+                assert_eq!(kappa, 0.4);
+                assert_eq!(mu, 4.0);
+            }
+            _ => panic!("vol bump changed commodity variant"),
+        }
+
+        let rate = valid_rate();
+        assert_eq!(rate.initial_value(), -0.005);
+        assert_eq!(rate.vol(), 0.01);
+        match rate.with_spot_bump(0.001) {
+            AssetMarketData::Rate {
+                initial_rate,
+                vol,
+                mean_reversion,
+                long_run_mean,
+            } => {
+                assert_eq!(initial_rate, -0.005 + 0.001);
+                assert_eq!(vol, 0.01);
+                assert_eq!(mean_reversion, 0.1);
+                assert_eq!(long_run_mean, 0.04);
+            }
+            _ => panic!("spot bump changed rate variant"),
+        }
+        match rate.with_vol_bump(0.0025) {
+            AssetMarketData::Rate {
+                initial_rate,
+                vol,
+                mean_reversion,
+                long_run_mean,
+            } => {
+                assert_eq!(initial_rate, -0.005);
+                assert_eq!(vol, 0.0125);
+                assert_eq!(mean_reversion, 0.1);
+                assert_eq!(long_run_mean, 0.04);
+            }
+            _ => panic!("vol bump changed rate variant"),
+        }
+    }
+
+    #[test]
+    fn mixed_asset_market_validates_and_returns_values_in_asset_order() {
+        let market = MultiAssetMarket {
+            assets: vec![valid_equity(), valid_fx(), valid_commodity(), valid_rate()],
+            correlation: vec![
+                vec![1.0, 0.1, -0.2, 0.0],
+                vec![0.1, 1.0, 0.25, -0.1],
+                vec![-0.2, 0.25, 1.0, 0.15],
+                vec![0.0, -0.1, 0.15, 1.0],
+            ],
+            rate: 0.03,
+        };
+
+        market.validate().unwrap();
+        assert_eq!(market.initial_spots(), [100.0, 1.1, 75.0, -0.005]);
+
+        let single = MultiAssetMarket::single(90.0, 0.25, 0.04, 0.015);
+        single.validate().unwrap();
+        assert_eq!(single.initial_spots(), [90.0]);
+        assert_eq!(single.correlation, [[1.0]]);
+        match &single.assets[0] {
+            AssetMarketData::Equity {
+                spot,
+                vol,
+                dividend_yield,
+            } => assert_eq!((*spot, *vol, *dividend_yield), (90.0, 0.25, 0.015)),
+            _ => panic!("single market must contain equity data"),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_empty_and_misshaped_correlation_matrices() {
+        let empty = MultiAssetMarket {
+            assets: vec![],
+            correlation: vec![],
+            rate: 0.03,
+        };
+        assert!(
+            empty
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("at least one asset")
+        );
+
+        let wrong_rows = MultiAssetMarket {
+            assets: vec![valid_equity(), valid_fx()],
+            correlation: vec![vec![1.0, 0.2]],
+            rate: 0.03,
+        };
+        assert!(
+            wrong_rows
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("rows (1) must match number of assets (2)")
+        );
+
+        let wrong_columns = MultiAssetMarket {
+            assets: vec![valid_equity(), valid_fx()],
+            correlation: vec![vec![1.0, 0.2], vec![0.2]],
+            rate: 0.03,
+        };
+        assert!(
+            wrong_columns
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("row 1 has 1 columns, expected 2")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_positive_spots_and_volatilities() {
+        for (asset, expected) in [
+            (
+                AssetMarketData::Equity {
+                    spot: 0.0,
+                    vol: 0.2,
+                    dividend_yield: 0.01,
+                },
+                "equity asset 0 spot must be > 0",
+            ),
+            (
+                AssetMarketData::Equity {
+                    spot: 100.0,
+                    vol: 0.0,
+                    dividend_yield: 0.01,
+                },
+                "equity asset 0 vol must be > 0",
+            ),
+            (
+                AssetMarketData::Fx {
+                    spot: -1.0,
+                    vol: 0.15,
+                    domestic_rate: 0.03,
+                    foreign_rate: 0.02,
+                },
+                "FX asset 0 spot must be > 0",
+            ),
+            (
+                AssetMarketData::Fx {
+                    spot: 1.1,
+                    vol: -0.15,
+                    domestic_rate: 0.03,
+                    foreign_rate: 0.02,
+                },
+                "FX asset 0 vol must be > 0",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: 0.0,
+                    vol: 0.3,
+                    convenience_yield: 0.01,
+                    kappa: 0.4,
+                    mu: 4.0,
+                },
+                "commodity asset 0 spot must be > 0",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: 75.0,
+                    vol: 0.0,
+                    convenience_yield: 0.01,
+                    kappa: 0.4,
+                    mu: 4.0,
+                },
+                "commodity asset 0 vol must be > 0",
+            ),
+            (
+                AssetMarketData::Rate {
+                    initial_rate: -0.01,
+                    vol: 0.0,
+                    mean_reversion: 0.1,
+                    long_run_mean: 0.04,
+                },
+                "rate asset 0 vol must be > 0",
+            ),
+        ] {
+            assert_invalid(asset, expected);
+        }
+    }
+
+    #[test]
+    fn validate_rejects_each_non_finite_asset_parameter() {
+        for (asset, expected) in [
+            (
+                AssetMarketData::Equity {
+                    spot: 100.0,
+                    vol: f64::INFINITY,
+                    dividend_yield: 0.01,
+                },
+                "equity asset 0 vol must be finite",
+            ),
+            (
+                AssetMarketData::Equity {
+                    spot: 100.0,
+                    vol: 0.2,
+                    dividend_yield: f64::NEG_INFINITY,
+                },
+                "equity asset 0 dividend yield must be finite",
+            ),
+            (
+                AssetMarketData::Fx {
+                    spot: f64::NAN,
+                    vol: 0.15,
+                    domestic_rate: 0.03,
+                    foreign_rate: 0.02,
+                },
+                "FX asset 0 spot must be finite",
+            ),
+            (
+                AssetMarketData::Fx {
+                    spot: 1.1,
+                    vol: f64::NAN,
+                    domestic_rate: 0.03,
+                    foreign_rate: 0.02,
+                },
+                "FX asset 0 vol must be finite",
+            ),
+            (
+                AssetMarketData::Fx {
+                    spot: 1.1,
+                    vol: 0.15,
+                    domestic_rate: 0.03,
+                    foreign_rate: f64::NAN,
+                },
+                "FX asset 0 foreign rate must be finite",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: f64::NAN,
+                    vol: 0.3,
+                    convenience_yield: 0.01,
+                    kappa: 0.4,
+                    mu: 4.0,
+                },
+                "commodity asset 0 spot must be finite",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: 75.0,
+                    vol: f64::INFINITY,
+                    convenience_yield: 0.01,
+                    kappa: 0.4,
+                    mu: 4.0,
+                },
+                "commodity asset 0 vol must be finite",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: 75.0,
+                    vol: 0.3,
+                    convenience_yield: f64::NAN,
+                    kappa: 0.4,
+                    mu: 4.0,
+                },
+                "commodity asset 0 convenience yield must be finite",
+            ),
+            (
+                AssetMarketData::Commodity {
+                    spot: 75.0,
+                    vol: 0.3,
+                    convenience_yield: 0.01,
+                    kappa: 0.4,
+                    mu: f64::NAN,
+                },
+                "commodity asset 0 mu must be finite",
+            ),
+            (
+                AssetMarketData::Rate {
+                    initial_rate: f64::NAN,
+                    vol: 0.01,
+                    mean_reversion: 0.1,
+                    long_run_mean: 0.04,
+                },
+                "rate asset 0 initial rate must be finite",
+            ),
+            (
+                AssetMarketData::Rate {
+                    initial_rate: 0.03,
+                    vol: f64::NAN,
+                    mean_reversion: 0.1,
+                    long_run_mean: 0.04,
+                },
+                "rate asset 0 vol must be finite",
+            ),
+            (
+                AssetMarketData::Rate {
+                    initial_rate: 0.03,
+                    vol: 0.01,
+                    mean_reversion: f64::NAN,
+                    long_run_mean: 0.04,
+                },
+                "rate asset 0 mean reversion must be finite",
+            ),
+        ] {
+            assert_invalid(asset, expected);
+        }
+    }
+
     #[test]
     fn validate_rejects_non_finite_top_level_market_values() {
         let mut market = MultiAssetMarket::single(100.0, 0.2, f64::NAN, 0.01);

--- a/src/engines/analytic/bs_simd.rs
+++ b/src/engines/analytic/bs_simd.rs
@@ -1620,4 +1620,81 @@ mod tests {
             );
         }
     }
+
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    #[test]
+    fn forced_avx2_price_greek_and_cdf_kernels_match_scalar_oracles() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            eprintln!("skipping direct AVX2 coverage: AVX2+FMA unavailable");
+            return;
+        }
+
+        // Nine lanes force two vector chunks plus the scalar tail even on an
+        // AVX-512 host, where normal runtime dispatch would never enter AVX2.
+        let spots = [72.0, 85.0, 95.0, 100.0, 105.0, 115.0, 130.0, 160.0, 210.0];
+        let strikes = [100.0; 9];
+        let (r, q, vol, t) = (0.037, 0.012, 0.24, 1.35);
+
+        let xs = [-8.0, -3.0, -1.0, -0.1, 0.0, 0.3, 1.5, 4.0, 8.0];
+        let mut cdf = [0.0; 9];
+        unsafe { avx2_impl::normal_cdf_batch_avx2(&xs, &mut cdf) };
+        for (actual, x) in cdf.into_iter().zip(xs) {
+            let expected = normal_cdf_approx(x);
+            assert!(
+                (actual - expected).abs() <= 3.0e-7,
+                "x={x} actual={actual} expected={expected}"
+            );
+        }
+
+        for is_call in [true, false] {
+            let mut prices = [0.0; 9];
+            unsafe {
+                avx2_impl::bs_price_batch_avx2(&spots, &strikes, r, q, vol, t, is_call, &mut prices)
+            };
+            for i in 0..spots.len() {
+                let expected = bs_price_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+                let scale = expected.abs().max(1.0);
+                assert!(
+                    (prices[i] - expected).abs() <= 2.0e-12 * scale,
+                    "lane={i} call={is_call} actual={} expected={expected}",
+                    prices[i]
+                );
+            }
+
+            let mut delta = [0.0; 9];
+            let mut gamma = [0.0; 9];
+            let mut vega = [0.0; 9];
+            let mut theta = [0.0; 9];
+            unsafe {
+                avx2_impl::bs_greeks_batch_avx2(
+                    &spots, &strikes, r, q, vol, t, is_call, &mut delta, &mut gamma, &mut vega,
+                    &mut theta,
+                )
+            };
+            for i in 0..spots.len() {
+                let expected = bs_greeks_scalar(spots[i], strikes[i], r, q, vol, t, is_call);
+                for (name, actual, reference) in [
+                    ("delta", delta[i], expected.0),
+                    ("gamma", gamma[i], expected.1),
+                    ("vega", vega[i], expected.2),
+                    ("theta", theta[i], expected.3),
+                ] {
+                    let scale = reference.abs().max(1.0);
+                    assert!(
+                        (actual - reference).abs() <= 3.0e-12 * scale,
+                        "{name} lane={i} call={is_call} actual={actual} expected={reference}"
+                    );
+                }
+            }
+        }
+
+        // Exercise the AVX2 kernels' deterministic expiry/zero-vol guard.
+        let mut intrinsic = [0.0; 9];
+        unsafe {
+            avx2_impl::bs_price_batch_avx2(&spots, &strikes, r, q, 0.0, t, true, &mut intrinsic)
+        };
+        for (actual, spot) in intrinsic.into_iter().zip(spots) {
+            assert_eq!(actual, bs_price_scalar(spot, 100.0, r, q, 0.0, t, true));
+        }
+    }
 }

--- a/src/engines/monte_carlo/mc_engine.rs
+++ b/src/engines/monte_carlo/mc_engine.rs
@@ -2763,4 +2763,234 @@ mod tests {
         assert_eq!(first.price, third.price);
         assert_eq!(first.stderr, third.stderr);
     }
+
+    #[test]
+    fn arena_pricer_covers_guards_expiry_and_discrete_dividend_fallback() {
+        let market = Market::builder()
+            .spot(100.0)
+            .rate(0.03)
+            .dividend_yield(0.0)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let mut arena = PricingArena::with_capacity(32, 8);
+
+        let option = VanillaOption::european_call(100.0, 1.0);
+        assert!(
+            mc_european_with_arena(&option, &market, 0, 8, &mut arena)
+                .price
+                .is_nan()
+        );
+
+        let american = VanillaOption::american_call(100.0, 1.0);
+        assert!(
+            mc_european_with_arena(&american, &market, 32, 8, &mut arena)
+                .price
+                .is_nan()
+        );
+
+        let expired = VanillaOption::european_put(105.0, 0.0);
+        let expired_result = mc_european_with_arena(&expired, &market, 32, 8, &mut arena);
+        assert_eq!(expired_result.price, 5.0);
+        assert_eq!(expired_result.stderr, Some(0.0));
+
+        let schedule =
+            DividendSchedule::new(vec![DividendEvent::cash(0.5, 1.25).unwrap()]).unwrap();
+        let dividend_market = Market::builder()
+            .spot(100.0)
+            .rate(0.03)
+            .dividend_yield(0.0)
+            .dividend_schedule(schedule)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let arena_result = mc_european_with_arena(&option, &dividend_market, 257, 7, &mut arena);
+        let generic_result = MonteCarloPricingEngine::new(257, 7, ARENA_MC_SEED)
+            .price(&option, &dividend_market)
+            .unwrap();
+        assert_eq!(arena_result.price, generic_result.price);
+        assert_eq!(arena_result.stderr, generic_result.stderr);
+        assert_eq!(arena_result.diagnostics, generic_result.diagnostics);
+    }
+
+    #[test]
+    fn asian_path_semantics_cover_floating_strike_and_geometric_averages() {
+        let path = [100.0, 80.0, 120.0];
+        let observation_times = vec![0.0, 0.5, 1.0];
+
+        let floating_call = AsianOption::new(
+            OptionType::Call,
+            100.0,
+            1.0,
+            AsianSpec {
+                averaging: Averaging::Arithmetic,
+                strike_type: StrikeType::Floating,
+                observation_times: observation_times.clone(),
+            },
+        );
+        assert_eq!(floating_call.reference_strike(97.0), 97.0);
+        assert_eq!(floating_call.payoff_from_path(&path), 20.0);
+
+        let floating_put = AsianOption::new(
+            OptionType::Put,
+            100.0,
+            1.0,
+            AsianSpec {
+                averaging: Averaging::Geometric,
+                strike_type: StrikeType::Floating,
+                observation_times,
+            },
+        );
+        let geometric_average = ((100.0_f64.ln() + 80.0_f64.ln() + 120.0_f64.ln()) / 3.0).exp();
+        assert_eq!(floating_put.reference_strike(103.0), 103.0);
+        assert_eq!(floating_put.payoff_from_path(&path), 0.0);
+
+        let floating_geometric_call = AsianOption {
+            option_type: OptionType::Call,
+            ..floating_put.clone()
+        };
+        assert!(
+            (floating_geometric_call.payoff_from_path(&path) - (120.0 - geometric_average)).abs()
+                <= 4.0 * f64::EPSILON * 120.0
+        );
+        assert!(
+            floating_geometric_call
+                .control_variate(
+                    &Market::builder()
+                        .spot(100.0)
+                        .rate(0.03)
+                        .dividend_yield(0.0)
+                        .flat_vol(0.2)
+                        .build()
+                        .unwrap(),
+                    0.2,
+                )
+                .is_none()
+        );
+    }
+
+    fn arithmetic_asian_for_guard_tests(
+        averaging: Averaging,
+        strike_type: StrikeType,
+    ) -> AsianOption {
+        AsianOption::new(
+            OptionType::Call,
+            100.0,
+            1.0,
+            AsianSpec {
+                averaging,
+                strike_type,
+                observation_times: vec![0.5, 1.0],
+            },
+        )
+    }
+
+    #[test]
+    fn arithmetic_asian_engine_rejects_unsupported_contracts_and_empty_work() {
+        let market = Market::builder()
+            .spot(100.0)
+            .rate(0.02)
+            .dividend_yield(0.0)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let arithmetic_fixed =
+            arithmetic_asian_for_guard_tests(Averaging::Arithmetic, StrikeType::Fixed);
+        let geometric_fixed =
+            arithmetic_asian_for_guard_tests(Averaging::Geometric, StrikeType::Fixed);
+        let arithmetic_floating =
+            arithmetic_asian_for_guard_tests(Averaging::Arithmetic, StrikeType::Floating);
+
+        assert!(
+            ArithmeticAsianMC::new(32, 4, 1)
+                .price(&geometric_fixed, &market)
+                .unwrap_err()
+                .to_string()
+                .contains("Averaging::Arithmetic")
+        );
+        assert!(
+            ArithmeticAsianMC::new(32, 4, 1)
+                .price(&arithmetic_floating, &market)
+                .unwrap_err()
+                .to_string()
+                .contains("StrikeType::Fixed")
+        );
+        assert!(
+            ArithmeticAsianMC::new(0, 4, 1)
+                .price(&arithmetic_fixed, &market)
+                .is_err()
+        );
+        assert!(
+            ArithmeticAsianMC::new(32, 0, 1)
+                .price(&arithmetic_fixed, &market)
+                .is_err()
+        );
+
+        assert!(
+            MonteCarloPricingEngine::new(0, 4, 1)
+                .price(&VanillaOption::european_call(100.0, 1.0), &market)
+                .is_err()
+        );
+        assert!(
+            MonteCarloPricingEngine::new(32, 0, 1)
+                .price(&VanillaOption::european_call(100.0, 1.0), &market)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn arithmetic_asian_discrete_dividend_disables_control_variate_exactly() {
+        let schedule = DividendSchedule::new(vec![DividendEvent::cash(0.5, 2.0).unwrap()]).unwrap();
+        let market = Market::builder()
+            .spot(100.0)
+            .rate(0.02)
+            .dividend_yield(0.0)
+            .dividend_schedule(schedule)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let option = arithmetic_asian_for_guard_tests(Averaging::Arithmetic, StrikeType::Fixed);
+        let with_requested_cv = ArithmeticAsianMC::new(512, 8, 77)
+            .with_control_variate(true)
+            .price(&option, &market)
+            .unwrap();
+        let without_cv = ArithmeticAsianMC::new(512, 8, 77)
+            .with_control_variate(false)
+            .price(&option, &market)
+            .unwrap();
+        assert_eq!(with_requested_cv.price, without_cv.price);
+        assert_eq!(with_requested_cv.stderr, without_cv.stderr);
+    }
+
+    #[test]
+    fn generic_engine_zero_maturity_and_configuration_accessors_are_exact() {
+        let market = Market::builder()
+            .spot(90.0)
+            .rate(0.02)
+            .dividend_yield(0.0)
+            .flat_vol(0.2)
+            .build()
+            .unwrap();
+        let expired = VanillaOption::european_put(100.0, 0.0);
+        let result = MonteCarloPricingEngine::new(16, 4, 1)
+            .price(&expired, &market)
+            .unwrap();
+        assert_eq!(result.price, 10.0);
+        assert_eq!(result.stderr, Some(0.0));
+        assert_eq!(result.diagnostics.get("num_steps"), Some(&0.0));
+
+        let engine = MonteCarloPricingEngine::new(64, 8, 1)
+            .with_rng_kind(FastRngKind::Pcg64)
+            .with_randomized_streams()
+            .with_accuracy_tier(AccuracyTier::Fast)
+            .with_execution_policy(ExecutionPolicy::Scalar);
+        assert_eq!(engine.rng_kind(), FastRngKind::Pcg64);
+        assert!(!engine.is_reproducible());
+        assert_eq!(engine.effective_accuracy_tier(), AccuracyTier::Fast);
+        assert_eq!(
+            engine.resolve_execution_backend(&expired, &market).unwrap(),
+            ExecutionBackend::Scalar
+        );
+        assert!(engine.with_seed(99).is_reproducible());
+    }
 }

--- a/src/engines/monte_carlo/mc_simd.rs
+++ b/src/engines/monte_carlo/mc_simd.rs
@@ -721,6 +721,41 @@ mod tests {
         );
     }
 
+    #[cfg(all(feature = "simd", target_arch = "x86_64"))]
+    #[test]
+    fn forced_avx2_terminal_and_full_path_kernels_match_on_avx512_hosts() {
+        if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
+            eprintln!("skipping direct AVX2 coverage: AVX2+FMA unavailable");
+            return;
+        }
+
+        let args = (97.0, 0.03, 0.005, 0.31, 2.0, 19, 11, 7);
+        let terminal = unsafe {
+            simulate_gbm_terminal_soa_avx2(
+                args.0, args.1, args.2, args.3, args.4, args.5, args.6, args.7,
+            )
+        };
+        let paths = unsafe {
+            simulate_gbm_paths_soa_avx2(
+                args.0, args.1, args.2, args.3, args.4, args.5, args.6, args.7,
+            )
+        };
+
+        assert_eq!(terminal, paths.terminal());
+        assert_eq!(paths.num_paths, 19);
+        assert_eq!(paths.num_steps, 11);
+        assert!(terminal.iter().all(|spot| spot.is_finite() && *spot > 0.0));
+
+        // Reproducible streams must be stable when calling the forced backend
+        // directly, independently of the host's normal AVX-512 preference.
+        let repeated = unsafe {
+            simulate_gbm_terminal_soa_avx2(
+                args.0, args.1, args.2, args.3, args.4, args.5, args.6, args.7,
+            )
+        };
+        assert_eq!(terminal, repeated);
+    }
+
     #[cfg(all(feature = "simd", target_arch = "aarch64"))]
     #[test]
     fn neon_soa_matches_scalar_stream_and_tail() {

--- a/src/instruments/basket.rs
+++ b/src/instruments/basket.rs
@@ -36,14 +36,14 @@ pub struct BasketOption {
 impl BasketOption {
     /// Validates basket fields.
     pub fn validate(&self) -> Result<(), PricingError> {
-        if self.strike < 0.0 {
+        if !self.strike.is_finite() || self.strike < 0.0 {
             return Err(PricingError::InvalidInput(
-                "basket strike must be >= 0".to_string(),
+                "basket strike must be finite and >= 0".to_string(),
             ));
         }
-        if self.maturity < 0.0 {
+        if !self.maturity.is_finite() || self.maturity < 0.0 {
             return Err(PricingError::InvalidInput(
-                "basket maturity must be >= 0".to_string(),
+                "basket maturity must be finite and >= 0".to_string(),
             ));
         }
 
@@ -95,14 +95,14 @@ impl OutperformanceBasketOption {
                 "outperformance lagger weights cannot be empty".to_string(),
             ));
         }
-        if self.strike < 0.0 {
+        if !self.strike.is_finite() || self.strike < 0.0 {
             return Err(PricingError::InvalidInput(
-                "outperformance strike must be >= 0".to_string(),
+                "outperformance strike must be finite and >= 0".to_string(),
             ));
         }
-        if self.maturity < 0.0 {
+        if !self.maturity.is_finite() || self.maturity < 0.0 {
             return Err(PricingError::InvalidInput(
-                "outperformance maturity must be >= 0".to_string(),
+                "outperformance maturity must be finite and >= 0".to_string(),
             ));
         }
         if self.lagger_weights.iter().any(|w| !w.is_finite()) {
@@ -163,6 +163,11 @@ impl QuantoBasketOption {
                 "quanto asset_fx_corr entries must be finite and in [-1, 1]".to_string(),
             ));
         }
+        if !self.domestic_rate.is_finite() || !self.foreign_rate.is_finite() {
+            return Err(PricingError::InvalidInput(
+                "quanto domestic and foreign rates must be finite".to_string(),
+            ));
+        }
         Ok(())
     }
 }
@@ -170,5 +175,227 @@ impl QuantoBasketOption {
 impl Instrument for QuantoBasketOption {
     fn instrument_type(&self) -> &str {
         "QuantoBasketOption"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn average_basket() -> BasketOption {
+        BasketOption {
+            weights: vec![0.4, 0.6],
+            strike: 100.0,
+            maturity: 1.0,
+            is_call: true,
+            basket_type: BasketType::Average,
+        }
+    }
+
+    #[test]
+    fn basket_variants_validate_and_report_instrument_types() {
+        let average = average_basket();
+        let best_of = BasketOption {
+            weights: vec![],
+            basket_type: BasketType::BestOf,
+            ..average.clone()
+        };
+        let worst_of = BasketOption {
+            basket_type: BasketType::WorstOf,
+            ..best_of.clone()
+        };
+        for basket in [&average, &best_of, &worst_of] {
+            assert!(basket.validate().is_ok());
+            assert_eq!(basket.instrument_type(), "BasketOption");
+        }
+
+        let outperformance = OutperformanceBasketOption {
+            leader_index: 0,
+            lagger_weights: vec![0.5, 0.5],
+            strike: 1.0,
+            maturity: 2.0,
+            option_type: OptionType::Call,
+        };
+        assert!(outperformance.validate().is_ok());
+        assert_eq!(
+            outperformance.instrument_type(),
+            "OutperformanceBasketOption"
+        );
+
+        let quanto = QuantoBasketOption {
+            basket: average,
+            fx_rate: 1.1,
+            fx_vol: 0.12,
+            asset_fx_corr: vec![-0.2, 0.3],
+            domestic_rate: 0.04,
+            foreign_rate: 0.02,
+        };
+        assert!(quanto.validate().is_ok());
+        assert_eq!(quanto.instrument_type(), "QuantoBasketOption");
+    }
+
+    #[test]
+    fn basket_validation_rejects_each_invalid_domain() {
+        let base = average_basket();
+        let invalid_baskets = [
+            BasketOption {
+                strike: -1.0,
+                ..base.clone()
+            },
+            BasketOption {
+                maturity: -1.0,
+                ..base.clone()
+            },
+            BasketOption {
+                weights: vec![f64::NAN],
+                ..base.clone()
+            },
+            BasketOption {
+                weights: vec![],
+                ..base.clone()
+            },
+        ];
+        for basket in invalid_baskets {
+            assert!(basket.validate().is_err(), "unexpectedly valid: {basket:?}");
+        }
+
+        let outperformance = OutperformanceBasketOption {
+            leader_index: 0,
+            lagger_weights: vec![0.5, 0.5],
+            strike: 1.0,
+            maturity: 1.0,
+            option_type: OptionType::Put,
+        };
+        for invalid in [
+            OutperformanceBasketOption {
+                lagger_weights: vec![],
+                ..outperformance.clone()
+            },
+            OutperformanceBasketOption {
+                strike: -1.0,
+                ..outperformance.clone()
+            },
+            OutperformanceBasketOption {
+                maturity: -1.0,
+                ..outperformance.clone()
+            },
+            OutperformanceBasketOption {
+                lagger_weights: vec![0.5, f64::INFINITY],
+                ..outperformance.clone()
+            },
+        ] {
+            assert!(
+                invalid.validate().is_err(),
+                "unexpectedly valid: {invalid:?}"
+            );
+        }
+
+        let quanto = QuantoBasketOption {
+            basket: base,
+            fx_rate: 1.1,
+            fx_vol: 0.12,
+            asset_fx_corr: vec![0.1, -0.2],
+            domestic_rate: 0.04,
+            foreign_rate: 0.02,
+        };
+        for invalid in [
+            QuantoBasketOption {
+                fx_rate: 0.0,
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                fx_vol: -0.1,
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                asset_fx_corr: vec![1.1],
+                ..quanto.clone()
+            },
+        ] {
+            assert!(
+                invalid.validate().is_err(),
+                "unexpectedly valid: {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn basket_validation_rejects_nonfinite_scalar_fields() {
+        let basket = average_basket();
+        let outperformance = OutperformanceBasketOption {
+            leader_index: 0,
+            lagger_weights: vec![0.5, 0.5],
+            strike: 1.0,
+            maturity: 1.0,
+            option_type: OptionType::Put,
+        };
+        let quanto = QuantoBasketOption {
+            basket: basket.clone(),
+            fx_rate: 1.1,
+            fx_vol: 0.12,
+            asset_fx_corr: vec![0.1, -0.2],
+            domestic_rate: 0.04,
+            foreign_rate: 0.02,
+        };
+
+        for invalid in [
+            BasketOption {
+                strike: f64::NAN,
+                ..basket.clone()
+            },
+            BasketOption {
+                maturity: f64::NAN,
+                ..basket
+            },
+        ] {
+            assert!(
+                invalid.validate().is_err(),
+                "unexpectedly valid: {invalid:?}"
+            );
+        }
+
+        for invalid in [
+            OutperformanceBasketOption {
+                strike: f64::NAN,
+                ..outperformance.clone()
+            },
+            OutperformanceBasketOption {
+                maturity: f64::NAN,
+                ..outperformance
+            },
+        ] {
+            assert!(
+                invalid.validate().is_err(),
+                "unexpectedly valid: {invalid:?}"
+            );
+        }
+
+        for invalid in [
+            QuantoBasketOption {
+                fx_rate: f64::NAN,
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                fx_vol: f64::NAN,
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                asset_fx_corr: vec![f64::NAN],
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                domestic_rate: f64::NAN,
+                ..quanto.clone()
+            },
+            QuantoBasketOption {
+                foreign_rate: f64::NAN,
+                ..quanto
+            },
+        ] {
+            assert!(
+                invalid.validate().is_err(),
+                "unexpectedly valid: {invalid:?}"
+            );
+        }
     }
 }

--- a/src/instruments/exotic.rs
+++ b/src/instruments/exotic.rs
@@ -142,91 +142,110 @@ impl ExoticOption {
     pub fn validate(&self) -> Result<(), PricingError> {
         match self {
             Self::LookbackFloating(spec) => {
-                if spec.expiry < 0.0 {
+                if !spec.expiry.is_finite() || spec.expiry < 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "lookback expiry must be >= 0".to_string(),
+                        "lookback expiry must be finite and >= 0".to_string(),
                     ));
                 }
                 if let Some(extreme) = spec.observed_extreme
-                    && extreme <= 0.0
+                    && (!extreme.is_finite() || extreme <= 0.0)
                 {
                     return Err(PricingError::InvalidInput(
-                        "lookback observed_extreme must be > 0".to_string(),
+                        "lookback observed_extreme must be finite and > 0".to_string(),
                     ));
                 }
             }
             Self::LookbackFixed(spec) => {
-                if spec.strike <= 0.0 {
+                if !spec.strike.is_finite() || spec.strike <= 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "lookback fixed strike must be > 0".to_string(),
+                        "lookback fixed strike must be finite and > 0".to_string(),
                     ));
                 }
-                if spec.expiry < 0.0 {
+                if !spec.expiry.is_finite() || spec.expiry < 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "lookback fixed expiry must be >= 0".to_string(),
+                        "lookback fixed expiry must be finite and >= 0".to_string(),
                     ));
                 }
                 if let Some(extreme) = spec.observed_extreme
-                    && extreme <= 0.0
+                    && (!extreme.is_finite() || extreme <= 0.0)
                 {
                     return Err(PricingError::InvalidInput(
-                        "lookback fixed observed_extreme must be > 0".to_string(),
+                        "lookback fixed observed_extreme must be finite and > 0".to_string(),
                     ));
                 }
             }
             Self::Chooser(spec) => {
-                if spec.strike <= 0.0 {
+                if !spec.strike.is_finite() || spec.strike <= 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "chooser strike must be > 0".to_string(),
+                        "chooser strike must be finite and > 0".to_string(),
                     ));
                 }
-                if spec.expiry < 0.0 {
+                if !spec.expiry.is_finite() || spec.expiry < 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "chooser expiry must be >= 0".to_string(),
+                        "chooser expiry must be finite and >= 0".to_string(),
                     ));
                 }
-                if spec.choose_time < 0.0 || spec.choose_time > spec.expiry {
+                if !spec.choose_time.is_finite()
+                    || spec.choose_time < 0.0
+                    || spec.choose_time > spec.expiry
+                {
                     return Err(PricingError::InvalidInput(
-                        "chooser choose_time must lie in [0, expiry]".to_string(),
+                        "chooser choose_time must be finite and lie in [0, expiry]".to_string(),
                     ));
                 }
             }
             Self::Quanto(spec) => {
-                if spec.strike <= 0.0 {
+                if !spec.strike.is_finite() || spec.strike <= 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "quanto strike must be > 0".to_string(),
+                        "quanto strike must be finite and > 0".to_string(),
                     ));
                 }
-                if spec.expiry < 0.0 {
+                if !spec.expiry.is_finite() || spec.expiry < 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "quanto expiry must be >= 0".to_string(),
+                        "quanto expiry must be finite and >= 0".to_string(),
                     ));
                 }
-                if spec.fx_rate <= 0.0 {
+                if !spec.fx_rate.is_finite() || spec.fx_rate <= 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "quanto fx_rate must be > 0".to_string(),
+                        "quanto fx_rate must be finite and > 0".to_string(),
                     ));
                 }
-                if spec.fx_vol < 0.0 {
+                if !spec.foreign_rate.is_finite() {
                     return Err(PricingError::InvalidInput(
-                        "quanto fx_vol must be >= 0".to_string(),
+                        "quanto foreign_rate must be finite".to_string(),
                     ));
                 }
-                if spec.asset_fx_corr < -1.0 || spec.asset_fx_corr > 1.0 {
+                if !spec.fx_vol.is_finite() || spec.fx_vol < 0.0 {
                     return Err(PricingError::InvalidInput(
-                        "quanto asset_fx_corr must be in [-1, 1]".to_string(),
+                        "quanto fx_vol must be finite and >= 0".to_string(),
+                    ));
+                }
+                if !spec.asset_fx_corr.is_finite()
+                    || spec.asset_fx_corr < -1.0
+                    || spec.asset_fx_corr > 1.0
+                {
+                    return Err(PricingError::InvalidInput(
+                        "quanto asset_fx_corr must be finite and in [-1, 1]".to_string(),
                     ));
                 }
             }
             Self::Compound(spec) => {
-                if spec.compound_strike <= 0.0 || spec.underlying_strike <= 0.0 {
+                if !spec.compound_strike.is_finite()
+                    || !spec.underlying_strike.is_finite()
+                    || spec.compound_strike <= 0.0
+                    || spec.underlying_strike <= 0.0
+                {
                     return Err(PricingError::InvalidInput(
-                        "compound strikes must be > 0".to_string(),
+                        "compound strikes must be finite and > 0".to_string(),
                     ));
                 }
-                if spec.compound_expiry < 0.0 || spec.underlying_expiry < 0.0 {
+                if !spec.compound_expiry.is_finite()
+                    || !spec.underlying_expiry.is_finite()
+                    || spec.compound_expiry < 0.0
+                    || spec.underlying_expiry < 0.0
+                {
                     return Err(PricingError::InvalidInput(
-                        "compound expiries must be >= 0".to_string(),
+                        "compound expiries must be finite and >= 0".to_string(),
                     ));
                 }
                 if spec.compound_expiry > spec.underlying_expiry {
@@ -244,5 +263,281 @@ impl ExoticOption {
 impl Instrument for ExoticOption {
     fn instrument_type(&self) -> &str {
         "ExoticOption"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookback_constructors_create_valid_contracts() {
+        for option in [
+            ExoticOption::lookback_floating_call(1.0),
+            ExoticOption::lookback_floating_put(1.0),
+            ExoticOption::lookback_fixed_call(100.0, 1.0),
+            ExoticOption::lookback_fixed_put(100.0, 1.0),
+        ] {
+            assert!(option.validate().is_ok());
+            assert_eq!(option.instrument_type(), "ExoticOption");
+        }
+    }
+
+    #[test]
+    fn lookback_validation_rejects_each_invalid_domain() {
+        let invalid = [
+            ExoticOption::lookback_floating_call(-1.0),
+            ExoticOption::LookbackFloating(LookbackFloatingOption {
+                option_type: OptionType::Put,
+                expiry: 1.0,
+                observed_extreme: Some(0.0),
+            }),
+            ExoticOption::lookback_fixed_call(0.0, 1.0),
+            ExoticOption::lookback_fixed_put(100.0, -1.0),
+            ExoticOption::LookbackFixed(LookbackFixedOption {
+                option_type: OptionType::Call,
+                strike: 100.0,
+                expiry: 1.0,
+                observed_extreme: Some(-1.0),
+            }),
+        ];
+        for option in invalid {
+            assert!(option.validate().is_err(), "unexpectedly valid: {option:?}");
+        }
+    }
+
+    #[test]
+    fn exotic_validation_rejects_nonfinite_scalar_fields() {
+        let floating = LookbackFloatingOption {
+            option_type: OptionType::Call,
+            expiry: 1.0,
+            observed_extreme: Some(90.0),
+        };
+        let fixed = LookbackFixedOption {
+            option_type: OptionType::Put,
+            strike: 100.0,
+            expiry: 1.0,
+            observed_extreme: Some(110.0),
+        };
+        let chooser = ChooserOption {
+            strike: 100.0,
+            expiry: 1.0,
+            choose_time: 0.5,
+        };
+        let quanto = QuantoOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            fx_rate: 1.2,
+            foreign_rate: 0.02,
+            fx_vol: 0.15,
+            asset_fx_corr: -0.35,
+        };
+        let compound = CompoundOption {
+            option_type: OptionType::Put,
+            underlying_option_type: OptionType::Call,
+            compound_strike: 8.0,
+            underlying_strike: 100.0,
+            compound_expiry: 0.5,
+            underlying_expiry: 1.0,
+        };
+
+        let invalid = [
+            ExoticOption::LookbackFloating(LookbackFloatingOption {
+                expiry: f64::NAN,
+                ..floating.clone()
+            }),
+            ExoticOption::LookbackFloating(LookbackFloatingOption {
+                observed_extreme: Some(f64::NAN),
+                ..floating
+            }),
+            ExoticOption::LookbackFixed(LookbackFixedOption {
+                strike: f64::NAN,
+                ..fixed.clone()
+            }),
+            ExoticOption::LookbackFixed(LookbackFixedOption {
+                expiry: f64::NAN,
+                ..fixed.clone()
+            }),
+            ExoticOption::LookbackFixed(LookbackFixedOption {
+                observed_extreme: Some(f64::NAN),
+                ..fixed
+            }),
+            ExoticOption::Chooser(ChooserOption {
+                strike: f64::NAN,
+                ..chooser.clone()
+            }),
+            ExoticOption::Chooser(ChooserOption {
+                expiry: f64::NAN,
+                ..chooser.clone()
+            }),
+            ExoticOption::Chooser(ChooserOption {
+                choose_time: f64::NAN,
+                ..chooser
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                strike: f64::NAN,
+                ..quanto.clone()
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                expiry: f64::NAN,
+                ..quanto.clone()
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                fx_rate: f64::NAN,
+                ..quanto.clone()
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                foreign_rate: f64::NAN,
+                ..quanto.clone()
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                fx_vol: f64::NAN,
+                ..quanto.clone()
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                asset_fx_corr: f64::NAN,
+                ..quanto
+            }),
+            ExoticOption::Compound(CompoundOption {
+                compound_strike: f64::NAN,
+                ..compound.clone()
+            }),
+            ExoticOption::Compound(CompoundOption {
+                underlying_strike: f64::NAN,
+                ..compound.clone()
+            }),
+            ExoticOption::Compound(CompoundOption {
+                compound_expiry: f64::NAN,
+                ..compound.clone()
+            }),
+            ExoticOption::Compound(CompoundOption {
+                underlying_expiry: f64::NAN,
+                ..compound
+            }),
+        ];
+
+        for option in invalid {
+            assert!(option.validate().is_err(), "unexpectedly valid: {option:?}");
+        }
+    }
+
+    #[test]
+    fn chooser_quanto_and_compound_validation_cover_all_contract_rules() {
+        let chooser = ExoticOption::Chooser(ChooserOption {
+            strike: 100.0,
+            expiry: 2.0,
+            choose_time: 0.75,
+        });
+        let quanto = ExoticOption::Quanto(QuantoOption {
+            option_type: OptionType::Call,
+            strike: 100.0,
+            expiry: 1.0,
+            fx_rate: 1.2,
+            foreign_rate: 0.02,
+            fx_vol: 0.15,
+            asset_fx_corr: -0.35,
+        });
+        let compound = ExoticOption::Compound(CompoundOption {
+            option_type: OptionType::Put,
+            underlying_option_type: OptionType::Call,
+            compound_strike: 8.0,
+            underlying_strike: 100.0,
+            compound_expiry: 0.5,
+            underlying_expiry: 1.0,
+        });
+        for option in [&chooser, &quanto, &compound] {
+            assert!(option.validate().is_ok());
+        }
+
+        let invalid = [
+            ExoticOption::Chooser(ChooserOption {
+                strike: 0.0,
+                expiry: 1.0,
+                choose_time: 0.5,
+            }),
+            ExoticOption::Chooser(ChooserOption {
+                strike: 100.0,
+                expiry: -1.0,
+                choose_time: 0.0,
+            }),
+            ExoticOption::Chooser(ChooserOption {
+                strike: 100.0,
+                expiry: 1.0,
+                choose_time: 1.5,
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                option_type: OptionType::Call,
+                strike: 0.0,
+                expiry: 1.0,
+                fx_rate: 1.0,
+                foreign_rate: 0.0,
+                fx_vol: 0.2,
+                asset_fx_corr: 0.0,
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                option_type: OptionType::Call,
+                strike: 100.0,
+                expiry: -1.0,
+                fx_rate: 1.0,
+                foreign_rate: 0.0,
+                fx_vol: 0.2,
+                asset_fx_corr: 0.0,
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                option_type: OptionType::Call,
+                strike: 100.0,
+                expiry: 1.0,
+                fx_rate: 0.0,
+                foreign_rate: 0.0,
+                fx_vol: 0.2,
+                asset_fx_corr: 0.0,
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                option_type: OptionType::Call,
+                strike: 100.0,
+                expiry: 1.0,
+                fx_rate: 1.0,
+                foreign_rate: 0.0,
+                fx_vol: -0.1,
+                asset_fx_corr: 0.0,
+            }),
+            ExoticOption::Quanto(QuantoOption {
+                option_type: OptionType::Call,
+                strike: 100.0,
+                expiry: 1.0,
+                fx_rate: 1.0,
+                foreign_rate: 0.0,
+                fx_vol: 0.2,
+                asset_fx_corr: 1.1,
+            }),
+            ExoticOption::Compound(CompoundOption {
+                option_type: OptionType::Call,
+                underlying_option_type: OptionType::Put,
+                compound_strike: 0.0,
+                underlying_strike: 100.0,
+                compound_expiry: 0.5,
+                underlying_expiry: 1.0,
+            }),
+            ExoticOption::Compound(CompoundOption {
+                option_type: OptionType::Call,
+                underlying_option_type: OptionType::Put,
+                compound_strike: 5.0,
+                underlying_strike: 100.0,
+                compound_expiry: -0.5,
+                underlying_expiry: 1.0,
+            }),
+            ExoticOption::Compound(CompoundOption {
+                option_type: OptionType::Call,
+                underlying_option_type: OptionType::Put,
+                compound_strike: 5.0,
+                underlying_strike: 100.0,
+                compound_expiry: 1.5,
+                underlying_expiry: 1.0,
+            }),
+        ];
+        for option in invalid {
+            assert!(option.validate().is_err(), "unexpectedly valid: {option:?}");
+        }
     }
 }

--- a/src/instruments/funding_rate_swap.rs
+++ b/src/instruments/funding_rate_swap.rs
@@ -193,6 +193,7 @@ mod tests {
     use chrono::{DateTime, NaiveDate, Utc};
 
     use super::FundingRateSwap;
+    use crate::core::Instrument;
     use crate::rates::{FundingRateCurve, YieldCurve};
 
     fn dt(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
@@ -288,5 +289,76 @@ mod tests {
         let expected = expected_interval_pnl * 0.99 + expected_interval_pnl * 0.97;
 
         assert_relative_eq!(mtm, expected, epsilon = 1.0e-12);
+    }
+
+    #[test]
+    fn constructor_and_standard_interval_pnl_match_eight_hour_convention() {
+        let swap = FundingRateSwap::new(
+            -2_500_000.0,
+            0.10,
+            dt(2026, 1, 1, 0),
+            dt(2026, 1, 2, 0),
+            "  Binance  ",
+            "BTCUSDT",
+        );
+        assert_eq!(swap.settlement_interval_hours, 8);
+        assert!(swap.validate().is_ok());
+        assert_eq!(swap.instrument_type(), "FundingRateSwap");
+        assert_relative_eq!(swap.interval_year_fraction(), 8.0 / 8_760.0, epsilon = 0.0);
+
+        let expected = (0.13 - 0.10) * (-2_500_000.0) * (8.0 / 8_760.0);
+        assert_relative_eq!(
+            FundingRateSwap::interval_pnl(0.10, 0.13, -2_500_000.0),
+            expected,
+            epsilon = 2.0e-15
+        );
+    }
+
+    #[test]
+    fn validation_and_schedule_cover_all_early_returns() {
+        let base = FundingRateSwap::new(
+            1_000.0,
+            0.10,
+            dt(2026, 1, 1, 0),
+            dt(2026, 1, 2, 0),
+            "Bybit",
+            "ETHUSDT",
+        );
+        let invalid = [
+            FundingRateSwap {
+                notional: 0.0,
+                ..base.clone()
+            },
+            FundingRateSwap {
+                fixed_rate: f64::NAN,
+                ..base.clone()
+            },
+            FundingRateSwap {
+                maturity: base.entry_time,
+                ..base.clone()
+            },
+            FundingRateSwap {
+                settlement_interval_hours: 0,
+                ..base.clone()
+            },
+            FundingRateSwap {
+                venue: "  ".to_string(),
+                ..base.clone()
+            },
+            FundingRateSwap {
+                asset: String::new(),
+                ..base.clone()
+            },
+        ];
+        for swap in invalid {
+            assert!(swap.validate().is_err(), "unexpectedly valid: {swap:?}");
+        }
+
+        let mut zero_interval = base.clone();
+        zero_interval.settlement_interval_hours = 0;
+        assert!(zero_interval.settlement_schedule().is_empty());
+        let mut reversed = base;
+        reversed.maturity = reversed.entry_time;
+        assert!(reversed.settlement_schedule().is_empty());
     }
 }

--- a/src/instruments/real_option.rs
+++ b/src/instruments/real_option.rs
@@ -176,3 +176,127 @@ impl Instrument for RealOptionInstrument {
         "RealOption"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model() -> RealOptionBinomialSpec {
+        RealOptionBinomialSpec {
+            project_value: 120.0,
+            volatility: 0.3,
+            risk_free_rate: 0.05,
+            maturity: 2.0,
+            steps: 200,
+            cash_flows: vec![DiscreteCashFlow {
+                time: 1.0,
+                amount: 4.0,
+            }],
+        }
+    }
+
+    #[test]
+    fn real_option_enum_dispatches_validation_and_instrument_type() {
+        let options = [
+            RealOptionInstrument::Defer(DeferInvestmentOption {
+                model: model(),
+                investment_cost: 100.0,
+            }),
+            RealOptionInstrument::Expand(ExpandOption {
+                model: model(),
+                expansion_multiplier: 1.5,
+                expansion_cost: 25.0,
+            }),
+            RealOptionInstrument::Abandon(AbandonmentOption {
+                model: model(),
+                salvage_value: 70.0,
+            }),
+        ];
+        for option in options {
+            assert!(option.validate().is_ok());
+            assert_eq!(option.instrument_type(), "RealOption");
+        }
+    }
+
+    #[test]
+    fn binomial_spec_rejects_each_invalid_field() {
+        let base = model();
+        let invalid = [
+            RealOptionBinomialSpec {
+                project_value: 0.0,
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                volatility: -0.1,
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                risk_free_rate: f64::NAN,
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                maturity: 0.0,
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                steps: 0,
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                cash_flows: vec![DiscreteCashFlow {
+                    time: -0.1,
+                    amount: 1.0,
+                }],
+                ..base.clone()
+            },
+            RealOptionBinomialSpec {
+                cash_flows: vec![DiscreteCashFlow {
+                    time: 0.5,
+                    amount: f64::INFINITY,
+                }],
+                ..base
+            },
+        ];
+        for spec in invalid {
+            assert!(spec.validate().is_err(), "unexpectedly valid: {spec:?}");
+        }
+    }
+
+    #[test]
+    fn real_option_specific_terms_are_validated() {
+        assert!(
+            DeferInvestmentOption {
+                model: model(),
+                investment_cost: 0.0,
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            ExpandOption {
+                model: model(),
+                expansion_multiplier: 0.0,
+                expansion_cost: 20.0,
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            ExpandOption {
+                model: model(),
+                expansion_multiplier: 1.5,
+                expansion_cost: 0.0,
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            AbandonmentOption {
+                model: model(),
+                salvage_value: f64::NAN,
+            }
+            .validate()
+            .is_err()
+        );
+    }
+}

--- a/src/instruments/weather.rs
+++ b/src/instruments/weather.rs
@@ -425,4 +425,130 @@ mod tests {
 
         assert!(high < low);
     }
+
+    #[test]
+    fn cumulative_degree_day_dispatch_matches_exact_daily_sums() {
+        let temperatures = [60.0, 65.0, 70.0, 80.0];
+        assert_eq!(cumulative_hdd(&temperatures, 65.0), 5.0);
+        assert_eq!(cumulative_cdd(&temperatures, 65.0), 20.0);
+        assert_eq!(
+            cumulative_degree_days(&temperatures, 65.0, DegreeDayType::HDD),
+            5.0
+        );
+        assert_eq!(
+            cumulative_degree_days(&temperatures, 65.0, DegreeDayType::CDD),
+            20.0
+        );
+        assert_eq!(cumulative_hdd(&[], 65.0), 0.0);
+        assert_eq!(cumulative_cdd(&[], 65.0), 0.0);
+    }
+
+    #[test]
+    fn weather_swap_payer_receiver_and_historical_prices_match_cashflows() {
+        let payer = WeatherSwap {
+            index_type: DegreeDayType::CDD,
+            strike: 100.0,
+            tick_size: 20.0,
+            notional: 5.0,
+            is_payer: true,
+            discount_rate: 0.03,
+            maturity: 0.5,
+        };
+        let receiver = WeatherSwap {
+            is_payer: false,
+            ..payer
+        };
+        assert_eq!(payer.payoff(112.0).unwrap(), 1_200.0);
+        assert_eq!(receiver.payoff(112.0).unwrap(), -1_200.0);
+
+        let historical = [90.0, 100.0, 125.0];
+        let expected_index = historical.iter().sum::<f64>() / historical.len() as f64;
+        let expected = 5.0 * 20.0 * (expected_index - 100.0) * (-0.03_f64 * 0.5).exp();
+        assert!(
+            (payer.price_from_historical_indices(&historical).unwrap() - expected).abs()
+                <= 8.0 * f64::EPSILON * expected.abs().max(1.0)
+        );
+        assert_eq!(payer.instrument_type(), "WeatherSwap");
+    }
+
+    #[test]
+    fn weather_put_burn_analysis_matches_temperature_path_cashflows() {
+        let option = WeatherOption {
+            index_type: DegreeDayType::CDD,
+            option_type: OptionType::Put,
+            strike: 12.0,
+            tick_size: 10.0,
+            notional: 2.0,
+            discount_rate: 0.04,
+            maturity: 0.25,
+        };
+        assert_eq!(option.payoff(7.0).unwrap(), 100.0);
+        assert_eq!(option.payoff(15.0).unwrap(), 0.0);
+
+        let paths = vec![vec![70.0, 68.0], vec![80.0, 60.0]];
+        // CDD indices versus 65F are 8 and 15, hence put payoffs 80 and 0.
+        let expected = 40.0 * (-0.04_f64 * 0.25).exp();
+        let actual = option
+            .price_burn_from_temperature_history(&paths, 65.0)
+            .unwrap();
+        assert!((actual - expected).abs() <= 8.0 * f64::EPSILON * expected);
+        assert_eq!(option.instrument_type(), "WeatherOption");
+    }
+
+    #[test]
+    fn zero_loss_cat_bond_matches_exact_discounted_coupon_strip() {
+        let bond = CatastropheBond {
+            principal: 1_000.0,
+            coupon_rate: 0.08,
+            risk_free_rate: 0.03,
+            maturity: 2.0,
+            coupon_frequency: 2,
+            loss_intensity: 0.0,
+            expected_loss_per_event: 0.75,
+        };
+        let coupon = 1_000.0 * 0.08 / 2.0;
+        let expected = (1..=4)
+            .map(|period| coupon * (-0.03 * period as f64 / 2.0).exp())
+            .sum::<f64>()
+            + 1_000.0 * (-0.03_f64 * 2.0).exp();
+        let actual = bond.price().unwrap();
+        assert!((actual - expected).abs() <= 8.0 * f64::EPSILON * expected);
+        assert_eq!(bond.instrument_type(), "CatastropheBond");
+    }
+
+    #[test]
+    fn weather_products_reject_empty_and_non_finite_histories() {
+        let swap = WeatherSwap {
+            index_type: DegreeDayType::HDD,
+            strike: 100.0,
+            tick_size: 1.0,
+            notional: 1.0,
+            is_payer: true,
+            discount_rate: 0.0,
+            maturity: 1.0,
+        };
+        assert!(swap.price_from_historical_indices(&[]).is_err());
+        assert!(swap.price_from_historical_indices(&[f64::NAN]).is_err());
+
+        let option = WeatherOption {
+            index_type: DegreeDayType::CDD,
+            option_type: OptionType::Call,
+            strike: 100.0,
+            tick_size: 1.0,
+            notional: 1.0,
+            discount_rate: 0.0,
+            maturity: 1.0,
+        };
+        assert!(option.price_burn_analysis(&[]).is_err());
+        assert!(
+            option
+                .price_burn_from_temperature_history(&[vec![]], 65.0)
+                .is_err()
+        );
+        assert!(
+            option
+                .price_burn_from_temperature_history(&[vec![60.0]], f64::NAN)
+                .is_err()
+        );
+    }
 }

--- a/src/market/fx.rs
+++ b/src/market/fx.rs
@@ -1649,6 +1649,114 @@ mod tests {
         }
     }
 
+    fn flat_surface_quote(expiry: f64, atm_vol: f64) -> FxVolExpiryQuote {
+        FxVolExpiryQuote {
+            expiry,
+            smile: FxSmileMarketQuote {
+                atm_vol,
+                pillars: vec![
+                    FxRrBfPillar {
+                        delta: 0.10,
+                        risk_reversal: 0.0,
+                        butterfly: 0.0,
+                    },
+                    FxRrBfPillar {
+                        delta: 0.25,
+                        risk_reversal: 0.0,
+                        butterfly: 0.0,
+                    },
+                ],
+                atm_convention: FxAtmConvention::Forward,
+                delta_convention: FxDeltaConvention::Forward,
+                premium_currency: PremiumCurrency::Domestic,
+            },
+        }
+    }
+
+    #[test]
+    fn surface_interior_expiry_matches_total_variance_interpolation() {
+        let t0: f64 = 0.5;
+        let t1: f64 = 2.0;
+        let t: f64 = 1.0;
+        let v0: f64 = 0.09;
+        let v1: f64 = 0.15;
+        let curve = FxForwardCurve::from_deposit_rates(
+            vec![t0, t1],
+            vec![0.03, 0.03],
+            vec![0.01, 0.01],
+            vec![0.0, 0.0],
+        )
+        .unwrap();
+        let surface = FxVolSurface::from_market_quotes(
+            1.10,
+            curve,
+            vec![flat_surface_quote(t0, v0), flat_surface_quote(t1, v1)],
+        )
+        .unwrap();
+
+        let weight = (t - t0) / (t1 - t0);
+        let expected = ((v0 * v0 * t0 + weight * (v1 * v1 * t1 - v0 * v0 * t0)) / t).sqrt();
+
+        for delta in [-0.25, 0.0, 0.25] {
+            assert_relative_eq!(
+                surface.vol_at_signed_delta(t, delta).unwrap(),
+                expected,
+                epsilon = 3.0e-16
+            );
+        }
+        for strike in [0.90, 1.10, 1.30] {
+            assert_relative_eq!(surface.vol(strike, t).unwrap(), expected, epsilon = 3.0e-16);
+        }
+
+        // Surface endpoint extrapolation is deliberately flat in total smile
+        // selection rather than extending the variance slope.
+        assert_eq!(surface.vol_at_signed_delta(0.25, 0.25).unwrap(), v0);
+        assert_eq!(surface.vol_at_signed_delta(3.0, -0.25).unwrap(), v1);
+    }
+
+    #[test]
+    fn smile_signed_delta_and_reconstructed_pillars_round_trip() {
+        let quote = forward_delta_test_quote();
+        let slice = FxSmileSlice::new(0.75, 1.12, 0.04, 0.015, quote.clone()).unwrap();
+
+        for target in [-0.25, -0.10, 0.10, 0.25] {
+            let strike = slice.strike_from_signed_delta(target).unwrap();
+            let option_type = if target > 0.0 {
+                OptionType::Call
+            } else {
+                OptionType::Put
+            };
+            let recovered = fx_delta(
+                option_type,
+                slice.spot,
+                strike,
+                slice.domestic_rate,
+                slice.foreign_rate,
+                slice.vol_at_signed_delta(target),
+                slice.expiry,
+                quote.delta_convention,
+                quote.premium_currency,
+            )
+            .unwrap();
+            // Forward-delta inversion uses the Acklam inverse-normal
+            // approximation.  The measured delta residual on this grid is
+            // 2.47e-10 at the 10-delta put; 5e-10 retains roughly 2x
+            // headroom for cross-platform libm differences.
+            assert_relative_eq!(recovered, target, epsilon = 5.0e-10);
+        }
+
+        let reconstructed = slice.reconstruct_pillars();
+        for (actual, expected) in reconstructed.iter().zip(quote.sorted_pillars()) {
+            assert_eq!(actual.delta, expected.delta);
+            assert_relative_eq!(
+                actual.risk_reversal,
+                expected.risk_reversal,
+                epsilon = 3.0e-17
+            );
+            assert_relative_eq!(actual.butterfly, expected.butterfly, epsilon = 3.0e-17);
+        }
+    }
+
     #[test]
     fn ndf_settlement_and_pv_match_market_standard_formula() {
         let pair = FxPair::from_code("USD/INR").unwrap();
@@ -1668,6 +1776,66 @@ mod tests {
             settlement_inr * (-0.06_f64 * 0.5).exp(),
             epsilon = 1.0e-10
         );
+    }
+
+    #[test]
+    fn ndf_direction_and_settlement_currency_match_exact_cashflows() {
+        let fixing: f64 = 83.0;
+        let strike: f64 = 82.0;
+        let notional: f64 = 1_000_000.0;
+        let rd: f64 = 0.06;
+        let rf: f64 = 0.025;
+        let expiry: f64 = 0.5;
+
+        for settlement_currency in [
+            NdfSettlementCurrency::Domestic,
+            NdfSettlementCurrency::Foreign,
+        ] {
+            for is_long_base in [true, false] {
+                let ndf = NdfContract {
+                    pair: FxPair::from_code("USD/INR").unwrap(),
+                    notional_base: notional,
+                    agreed_forward: strike,
+                    settlement_currency,
+                    is_long_base,
+                };
+                let sign = if is_long_base { 1.0 } else { -1.0 };
+                let domestic = sign * notional * (fixing - strike);
+                let (expected_settlement, discount_rate) = match settlement_currency {
+                    NdfSettlementCurrency::Domestic => (domestic, rd),
+                    NdfSettlementCurrency::Foreign => (domestic / fixing, rf),
+                };
+
+                assert_relative_eq!(
+                    ndf.settlement_amount(fixing).unwrap(),
+                    expected_settlement,
+                    epsilon = 2.0e-12
+                );
+                assert_relative_eq!(
+                    ndf.present_value(fixing, rd, rf, expiry).unwrap(),
+                    expected_settlement * (-discount_rate * expiry).exp(),
+                    epsilon = 2.0e-12
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn canonical_pair_follows_market_rank_then_lexicographic_order() {
+        assert_eq!(
+            canonical_pair("usd", "jpy").unwrap(),
+            ("USD".to_string(), "JPY".to_string())
+        );
+        assert_eq!(
+            canonical_pair("USD", "EUR").unwrap(),
+            ("EUR".to_string(), "USD".to_string())
+        );
+        assert_eq!(
+            canonical_pair("PLN", "MXN").unwrap(),
+            ("MXN".to_string(), "PLN".to_string())
+        );
+        assert!(canonical_pair("USD", "USD").is_err());
+        assert!(canonical_pair("US", "JPY").is_err());
     }
 
     #[test]

--- a/src/math/correlation.rs
+++ b/src/math/correlation.rs
@@ -682,6 +682,7 @@ pub fn copula_uniforms_to_normals(uniforms: &[f64], out_normals: &mut [f64]) -> 
 mod tests {
     use super::*;
     use crate::math::fast_rng::{FastRng, FastRngKind};
+    use approx::assert_relative_eq;
 
     #[test]
     fn higham_projection_repairs_non_psd_matrix() {
@@ -795,5 +796,371 @@ mod tests {
         .expect("t-copula sample");
 
         assert!(u.iter().all(|x| x.is_finite() && *x > 0.0 && *x < 1.0));
+    }
+
+    #[test]
+    fn one_factor_matrix_and_sampling_match_theoretical_moments() {
+        let loadings = vec![0.75, -0.4, 1.0];
+        let model = FactorCorrelationModel::OneFactor {
+            loadings: loadings.clone(),
+        };
+        assert_eq!(model.n_assets(), 3);
+        assert_eq!(model.n_factors(), 1);
+        model.validate().unwrap();
+
+        let expected = vec![
+            vec![1.0, -0.3, 0.75],
+            vec![-0.3, 1.0, -0.4],
+            vec![0.75, -0.4, 1.0],
+        ];
+        let actual = model.correlation_matrix().unwrap();
+        for (actual_row, expected_row) in actual.iter().zip(&expected) {
+            for (actual_entry, expected_entry) in actual_row.iter().zip(expected_row) {
+                assert_relative_eq!(*actual_entry, *expected_entry, epsilon = 2.0 * f64::EPSILON);
+            }
+        }
+
+        let n = 120_000usize;
+        let mut rng = FastRng::from_seed(FastRngKind::Xoshiro256PlusPlus, 0xC0FF_EE11);
+        let mut sums = [0.0; 3];
+        let mut cross = [[0.0; 3]; 3];
+        let mut sample = [0.0; 3];
+        for _ in 0..n {
+            model
+                .sample_correlated_normals(&mut rng, &mut sample)
+                .unwrap();
+            for i in 0..3 {
+                sums[i] += sample[i];
+                for j in 0..3 {
+                    cross[i][j] += sample[i] * sample[j];
+                }
+            }
+        }
+
+        let n_f64 = n as f64;
+        let means = sums.map(|sum| sum / n_f64);
+        let mean_band = 6.0 / n_f64.sqrt();
+        for (i, mean) in means.iter().enumerate() {
+            assert!(mean.abs() < mean_band, "asset {i}: mean={mean}");
+        }
+        for i in 0..3 {
+            for j in 0..3 {
+                let covariance = cross[i][j] / n_f64 - means[i] * means[j];
+                let rho = expected[i][j];
+                // For jointly normal unit-variance variables,
+                // Var(XY) = 1 + rho^2.  Six standard errors gives a
+                // distribution-derived sampling budget, not a flat band.
+                let covariance_band = 6.0 * ((1.0 + rho * rho) / n_f64).sqrt();
+                assert!(
+                    (covariance - rho).abs() < covariance_band,
+                    "({i},{j}): covariance={covariance}, rho={rho}, band={covariance_band}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn factor_models_reject_every_shape_and_parameter_error() {
+        for model in [
+            FactorCorrelationModel::OneFactor { loadings: vec![] },
+            FactorCorrelationModel::OneFactor {
+                loadings: vec![f64::NAN],
+            },
+            FactorCorrelationModel::OneFactor {
+                loadings: vec![1.001],
+            },
+            FactorCorrelationModel::MultiFactor { loadings: vec![] },
+            FactorCorrelationModel::MultiFactor {
+                loadings: vec![vec![]],
+            },
+            FactorCorrelationModel::MultiFactor {
+                loadings: vec![vec![0.2], vec![0.1, 0.2]],
+            },
+            FactorCorrelationModel::MultiFactor {
+                loadings: vec![vec![f64::INFINITY]],
+            },
+            FactorCorrelationModel::MultiFactor {
+                loadings: vec![vec![0.8, 0.8]],
+            },
+        ] {
+            assert!(model.validate().is_err(), "model should fail: {model:?}");
+            assert!(model.correlation_matrix().is_err());
+        }
+
+        let one_factor = FactorCorrelationModel::OneFactor {
+            loadings: vec![0.4, 0.6],
+        };
+        let mut rng = FastRng::from_seed(FastRngKind::Xoshiro256PlusPlus, 9);
+        assert!(
+            one_factor
+                .sample_correlated_normals(&mut rng, &mut [0.0])
+                .is_err()
+        );
+
+        let multi_factor = FactorCorrelationModel::MultiFactor {
+            loadings: vec![vec![0.5, 0.1], vec![-0.2, 0.7]],
+        };
+        assert_eq!(multi_factor.n_assets(), 2);
+        assert_eq!(multi_factor.n_factors(), 2);
+        let corr = multi_factor.correlation_matrix().unwrap();
+        assert_relative_eq!(corr[0][0], 1.0, epsilon = f64::EPSILON);
+        assert_relative_eq!(corr[0][1], -0.03, epsilon = f64::EPSILON);
+        assert_relative_eq!(corr[1][0], -0.03, epsilon = f64::EPSILON);
+        assert_relative_eq!(corr[1][1], 1.0, epsilon = f64::EPSILON);
+        let mut out = [0.0; 2];
+        multi_factor
+            .sample_correlated_normals(&mut rng, &mut out)
+            .unwrap();
+        assert!(out.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn correlation_stress_scenarios_match_sequential_arithmetic() {
+        let base = vec![
+            vec![1.0, 0.2, -0.4],
+            vec![0.2, 1.0, 0.7],
+            vec![-0.4, 0.7, 1.0],
+        ];
+        let stressed = apply_correlation_stress(
+            &base,
+            &[
+                CorrelationStressScenario::ScaleOffDiagonal { factor: 2.0 },
+                CorrelationStressScenario::AdditiveShift { shift: 0.1 },
+                CorrelationStressScenario::FloorOffDiagonal { floor: -0.6 },
+                CorrelationStressScenario::CapOffDiagonal { cap: 0.8 },
+                CorrelationStressScenario::OverridePair {
+                    i: 0,
+                    j: 2,
+                    value: -0.25,
+                },
+            ],
+            false,
+            PsdProjectionConfig::default(),
+        )
+        .unwrap();
+        let expected = [[1.0, 0.5, -0.25], [0.5, 1.0, 0.8], [-0.25, 0.8, 1.0]];
+        for (actual_row, expected_row) in stressed.iter().zip(expected) {
+            for (actual, expected) in actual_row.iter().zip(expected_row) {
+                assert_relative_eq!(*actual, expected, epsilon = 2.0 * f64::EPSILON);
+            }
+        }
+
+        let bad = vec![
+            vec![1.0, 0.95, 0.95],
+            vec![0.95, 1.0, -0.95],
+            vec![0.95, -0.95, 1.0],
+        ];
+        let repaired =
+            apply_correlation_stress(&bad, &[], true, PsdProjectionConfig::default()).unwrap();
+        assert!(is_positive_semidefinite(&repaired, 1.0e-8));
+        validate_correlation_matrix(&repaired, 3).unwrap();
+    }
+
+    #[test]
+    fn correlation_stress_rejects_invalid_scenario_parameters() {
+        let base = vec![vec![1.0, 0.2], vec![0.2, 1.0]];
+        let invalid = vec![
+            CorrelationStressScenario::ScaleOffDiagonal { factor: f64::NAN },
+            CorrelationStressScenario::AdditiveShift {
+                shift: f64::INFINITY,
+            },
+            CorrelationStressScenario::FloorOffDiagonal { floor: -1.01 },
+            CorrelationStressScenario::CapOffDiagonal { cap: 1.01 },
+            CorrelationStressScenario::OverridePair {
+                i: 0,
+                j: 0,
+                value: 0.2,
+            },
+            CorrelationStressScenario::OverridePair {
+                i: 0,
+                j: 2,
+                value: 0.2,
+            },
+            CorrelationStressScenario::OverridePair {
+                i: 0,
+                j: 1,
+                value: f64::NAN,
+            },
+        ];
+        for scenario in invalid {
+            assert!(
+                apply_correlation_stress(
+                    &base,
+                    &[scenario],
+                    false,
+                    PsdProjectionConfig::default(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn matrix_validation_repair_cholesky_and_multiplication_cover_boundaries() {
+        for (matrix, n_assets) in [
+            (vec![], 1),
+            (vec![vec![1.0], vec![0.0]], 2),
+            (vec![vec![0.9, 0.0], vec![0.0, 1.0]], 2),
+            (vec![vec![1.0, 1.1], vec![1.1, 1.0]], 2),
+            (vec![vec![1.0, 0.2], vec![0.3, 1.0]], 2),
+        ] {
+            assert!(validate_correlation_matrix(&matrix, n_assets).is_err());
+        }
+        assert_eq!(min_eigenvalue_symmetric(&[]), None);
+        assert_eq!(min_eigenvalue_symmetric(&[vec![1.0, 0.0]]), None);
+        assert!(!is_positive_semidefinite(&[], 1.0e-12));
+        assert!(nearest_correlation_matrix_higham(&[], PsdProjectionConfig::default()).is_err());
+        assert!(
+            nearest_correlation_matrix_higham(
+                &[vec![1.0, 1.0e7], vec![1.0e7, 1.0]],
+                PsdProjectionConfig::default(),
+            )
+            .is_err()
+        );
+
+        let valid = vec![vec![1.0, 0.25], vec![0.25, 1.0]];
+        let (unchanged, was_repaired) =
+            validate_or_repair_correlation_matrix(&valid, 2, PsdProjectionConfig::default())
+                .unwrap();
+        assert_eq!(unchanged, valid);
+        assert!(!was_repaired);
+
+        let bad = vec![
+            vec![1.0, 0.95, 0.95],
+            vec![0.95, 1.0, -0.95],
+            vec![0.95, -0.95, 1.0],
+        ];
+        let (_, was_repaired) =
+            validate_or_repair_correlation_matrix(&bad, 3, PsdProjectionConfig::default()).unwrap();
+        assert!(was_repaired);
+
+        assert!(cholesky_lower_psd(&[], 1.0e-12).is_none());
+        assert!(cholesky_lower_psd(&[vec![1.0, 0.0]], 1.0e-12).is_none());
+        assert!(cholesky_lower_psd(&[vec![1.0, 2.0], vec![2.0, 1.0]], 1.0e-12).is_none());
+
+        let lower = vec![
+            vec![2.0, 0.0, 0.0],
+            vec![3.0, 4.0, 0.0],
+            vec![-1.0, 2.0, 5.0],
+        ];
+        let mut product = [0.0; 3];
+        correlate_normals(&lower, &[0.5, -1.0, 2.0], &mut product);
+        assert_eq!(product, [1.0, -2.5, 7.5]);
+    }
+
+    #[test]
+    fn gaussian_and_student_t_copula_transforms_cover_success_and_errors() {
+        let mut rng = FastRng::from_seed(FastRngKind::Xoshiro256PlusPlus, 73);
+        let normals = [-2.0, 0.0, 1.5];
+        let mut uniforms = [0.0; 3];
+        map_copula_normals_to_uniforms(&normals, CopulaFamily::Gaussian, &mut rng, &mut uniforms)
+            .unwrap();
+        let mut round_trip = [0.0; 3];
+        copula_uniforms_to_normals(&uniforms, &mut round_trip).unwrap();
+        for (actual, expected) in round_trip.iter().zip(normals) {
+            // The inverse uses the repository's documented BSM rational
+            // approximation, whose measured absolute error is below 5e-9.
+            assert_relative_eq!(*actual, expected, epsilon = 5.0e-9);
+        }
+
+        let mut extremes = [0.0; 2];
+        map_copula_normals_to_uniforms(
+            &[f64::NEG_INFINITY, f64::INFINITY],
+            CopulaFamily::Gaussian,
+            &mut rng,
+            &mut extremes,
+        )
+        .unwrap();
+        assert_eq!(extremes, [COPULA_UNIFORM_MIN, COPULA_UNIFORM_MAX]);
+        copula_uniforms_to_normals(&extremes, &mut [0.0; 2]).unwrap();
+
+        let mut t_uniforms = [0.0; 2];
+        map_copula_normals_to_uniforms(
+            &[0.0, 0.0],
+            CopulaFamily::StudentT {
+                degrees_of_freedom: 2,
+            },
+            &mut rng,
+            &mut t_uniforms,
+        )
+        .unwrap();
+        for uniform in t_uniforms {
+            assert_relative_eq!(uniform, 0.5, epsilon = 2.0 * f64::EPSILON);
+        }
+        assert!(
+            map_copula_normals_to_uniforms(
+                &[0.0],
+                CopulaFamily::StudentT {
+                    degrees_of_freedom: 1,
+                },
+                &mut rng,
+                &mut [0.0],
+            )
+            .is_err()
+        );
+        assert!(copula_uniforms_to_normals(&[0.5], &mut [0.0; 2]).is_err());
+
+        let identity = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+        assert!(
+            sample_copula_uniforms_from_cholesky(
+                &identity,
+                CopulaFamily::Gaussian,
+                &mut rng,
+                &mut [0.0],
+            )
+            .is_err()
+        );
+        let mut sampled = [0.0; 2];
+        sample_copula_uniforms_from_cholesky(
+            &identity,
+            CopulaFamily::Gaussian,
+            &mut rng,
+            &mut sampled,
+        )
+        .unwrap();
+        assert!(sampled.iter().all(|u| *u > 0.0 && *u < 1.0));
+
+        let factor_model = FactorCorrelationModel::OneFactor {
+            loadings: vec![0.3, -0.6],
+        };
+        assert!(
+            sample_copula_uniforms_from_factor_model(
+                &factor_model,
+                CopulaFamily::Gaussian,
+                &mut rng,
+                &mut [0.0],
+            )
+            .is_err()
+        );
+        sample_copula_uniforms_from_factor_model(
+            &factor_model,
+            CopulaFamily::Gaussian,
+            &mut rng,
+            &mut sampled,
+        )
+        .unwrap();
+        assert!(sampled.iter().all(|u| *u > 0.0 && *u < 1.0));
+    }
+
+    #[test]
+    fn fractional_shape_gamma_boosting_matches_chi_square_moments() {
+        // nu < 2 exercises the Gamma(shape < 1) boosting identity used by the
+        // general chi-square sampler (the copula API itself restricts nu>=2).
+        let nu = 0.75_f64;
+        let n = 160_000usize;
+        let mut rng = FastRng::from_seed(FastRngKind::Xoshiro256PlusPlus, 0x51A9_E123);
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        for _ in 0..n {
+            let sample = sample_chi_square(nu, &mut rng);
+            sum += sample;
+            sum_sq += sample * sample;
+        }
+        let mean = sum / n as f64;
+        let variance = sum_sq / n as f64 - mean * mean;
+        let mean_band = 6.0 * (2.0 * nu / n as f64).sqrt();
+        let variance_band = 6.0 * ((8.0 * nu * nu + 48.0 * nu) / n as f64).sqrt();
+        assert!((mean - nu).abs() < mean_band);
+        assert!((variance - 2.0 * nu).abs() < variance_band);
     }
 }

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -1137,8 +1137,10 @@ impl NelsonSiegelInterpolator {
         extrapolation: ExtrapolationMode,
     ) -> Result<Self, InterpolationError> {
         validate_xy(&x, &y, 1)?;
-        if tau <= 0.0 {
-            return Err(InterpolationError::InvalidInput("tau must be > 0"));
+        if !tau.is_finite() || tau <= 0.0 {
+            return Err(InterpolationError::InvalidInput(
+                "tau must be finite and > 0",
+            ));
         }
         Ok(Self {
             x,
@@ -1728,6 +1730,26 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
 
+    fn five_point_value_derivative(interpolator: &dyn Interpolator, x: f64) -> f64 {
+        // A symmetric five-point stencil has O(h^4) truncation error.  The
+        // power-of-two step avoids representation error in the offsets and is
+        // small enough that every local-spline probe remains in one segment.
+        let h = 2.0_f64.powi(-13);
+        (interpolator.value(x - 2.0 * h).unwrap() - 8.0 * interpolator.value(x - h).unwrap()
+            + 8.0 * interpolator.value(x + h).unwrap()
+            - interpolator.value(x + 2.0 * h).unwrap())
+            / (12.0 * h)
+    }
+
+    fn assert_derivative_matches_five_point(interpolator: &dyn Interpolator, x: f64) {
+        let analytic = interpolator.derivative(x).unwrap();
+        let finite_difference = five_point_value_derivative(interpolator, x);
+        // For the cubic interpolators the stencil is exact apart from binary64
+        // roundoff; for parametric curves its O(h^4) term is below 1e-14 on
+        // the rate-sized fixtures used here.  2e-11 leaves libm headroom.
+        assert_relative_eq!(analytic, finite_difference, epsilon = 2.0e-11);
+    }
+
     #[test]
     fn linear_jacobian_matches_weights() {
         let itp = LinearInterpolator::new(
@@ -2035,5 +2057,674 @@ mod tests {
             itp.value(3.0),
             Err(InterpolationError::ExtrapolationDisabled)
         ));
+    }
+
+    #[test]
+    fn linear_and_step_extrapolation_values_derivatives_and_jacobians_are_exact() {
+        let x = vec![1.0, 2.0, 4.0];
+        let y = vec![10.0, 20.0, 40.0];
+        let linear =
+            LinearInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Linear).unwrap();
+        for (xq, value, jacobian) in [
+            (0.0, 0.0, vec![2.0, -1.0, 0.0]),
+            (6.0, 60.0, vec![0.0, -1.0, 2.0]),
+        ] {
+            assert_eq!(linear.value(xq).unwrap(), value);
+            assert_eq!(linear.derivative(xq).unwrap(), 10.0);
+            assert_eq!(linear.jacobian(xq).unwrap(), jacobian);
+        }
+
+        let flat = LinearInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Flat).unwrap();
+        for (xq, value, jacobian) in [
+            (0.0, 10.0, vec![1.0, 0.0, 0.0]),
+            (6.0, 40.0, vec![0.0, 0.0, 1.0]),
+        ] {
+            assert_eq!(flat.value(xq).unwrap(), value);
+            assert_eq!(flat.derivative(xq).unwrap(), 0.0);
+            assert_eq!(flat.jacobian(xq).unwrap(), jacobian);
+        }
+
+        let disabled =
+            LinearInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Error).unwrap();
+        for xq in [0.0, 6.0] {
+            assert_eq!(
+                disabled.value(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                disabled.derivative(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                disabled.jacobian(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+        }
+
+        // A step interpolator treats "linear" extrapolation as a constant
+        // endpoint extension; this is deliberate for piecewise funding rates.
+        let step =
+            PiecewiseConstantInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Linear)
+                .unwrap();
+        assert_eq!(step.value(0.0).unwrap(), 10.0);
+        assert_eq!(step.value(6.0).unwrap(), 40.0);
+        assert_eq!(step.jacobian(0.0).unwrap(), vec![1.0, 0.0, 0.0]);
+        assert_eq!(step.jacobian(6.0).unwrap(), vec![0.0, 0.0, 1.0]);
+
+        let step_disabled =
+            PiecewiseConstantInterpolator::new(x, y, ExtrapolationMode::Error).unwrap();
+        for xq in [0.0, 6.0] {
+            assert_eq!(
+                step_disabled.value(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                step_disabled.jacobian(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            // The derivative of the step function is zero away from jumps,
+            // independently of its endpoint-value policy.
+            assert_eq!(step_disabled.derivative(xq).unwrap(), 0.0);
+        }
+    }
+
+    #[test]
+    fn log_linear_extrapolation_matches_global_exponential_curve() {
+        let x = vec![0.0, 1.0, 2.0];
+        let y = vec![1.0, 1.0_f64.exp(), 2.0_f64.exp()];
+        let linear =
+            LogLinearInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Linear).unwrap();
+        for xq in [-1.0_f64, 3.0] {
+            let expected = xq.exp();
+            assert_relative_eq!(linear.value(xq).unwrap(), expected, epsilon = 4.0e-15);
+            assert_relative_eq!(linear.derivative(xq).unwrap(), expected, epsilon = 4.0e-15);
+        }
+        let left = linear.jacobian(-1.0).unwrap();
+        let left_value = (-1.0_f64).exp();
+        let expected_left = [2.0 * left_value / y[0], -left_value / y[1], 0.0];
+        let right = linear.jacobian(3.0).unwrap();
+        let right_value = 3.0_f64.exp();
+        let expected_right = [0.0, -right_value / y[1], 2.0 * right_value / y[2]];
+        for (actual, expected) in left.iter().zip(expected_left) {
+            assert_relative_eq!(*actual, expected, epsilon = 8.0 * f64::EPSILON);
+        }
+        for (actual, expected) in right.iter().zip(expected_right) {
+            assert_relative_eq!(*actual, expected, epsilon = 8.0 * f64::EPSILON);
+        }
+
+        let flat =
+            LogLinearInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Flat).unwrap();
+        assert_eq!(flat.value(-1.0).unwrap(), y[0]);
+        assert_eq!(flat.value(3.0).unwrap(), y[2]);
+        assert_eq!(flat.derivative(-1.0).unwrap(), 0.0);
+        assert_eq!(flat.derivative(3.0).unwrap(), 0.0);
+        assert_eq!(flat.jacobian(-1.0).unwrap(), vec![1.0, 0.0, 0.0]);
+        assert_eq!(flat.jacobian(3.0).unwrap(), vec![0.0, 0.0, 1.0]);
+
+        let disabled = LogLinearInterpolator::new(x, y, ExtrapolationMode::Error).unwrap();
+        for xq in [-1.0_f64, 3.0] {
+            assert_eq!(
+                disabled.value(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                disabled.derivative(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                disabled.jacobian(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+        }
+    }
+
+    #[test]
+    fn pchip_endpoint_filters_and_two_node_paths_match_exact_slopes() {
+        let two_node = HermiteMonotoneInterpolator::new(
+            vec![0.0, 2.0],
+            vec![1.0, 5.0],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(two_node.slopes, vec![2.0, 2.0]);
+        assert_eq!(two_node.value(1.0).unwrap(), 3.0);
+        assert_eq!(two_node.derivative(1.0).unwrap(), 2.0);
+
+        let two_node_monotone = MonotoneConvexInterpolator::new(
+            vec![0.0, 2.0],
+            vec![1.0, 5.0],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(two_node_monotone.slopes, vec![2.0, 2.0]);
+
+        let two_node_tension = TensionSplineInterpolator::new(
+            vec![0.0, 2.0],
+            vec![1.0, 5.0],
+            0.25,
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(two_node_tension.slopes, vec![1.5, 1.5]);
+
+        // Opposite-sign neighboring secants zero the interior slope.  A large
+        // reversal clamps the endpoint to three times the adjacent secant.
+        let left_clamped = HermiteMonotoneInterpolator::new(
+            vec![0.0, 1.0, 2.0],
+            vec![0.0, 1.0, -3.0],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(left_clamped.slopes[0], 3.0);
+        assert_eq!(left_clamped.slopes[1], 0.0);
+
+        let right_clamped = HermiteMonotoneInterpolator::new(
+            vec![0.0, 1.0, 2.0],
+            vec![-3.0, 1.0, 0.0],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(right_clamped.slopes[1], 0.0);
+        assert_eq!(right_clamped.slopes[2], -3.0);
+
+        let endpoints_zeroed = HermiteMonotoneInterpolator::new(
+            vec![0.0, 1.0, 2.0, 3.0],
+            vec![0.0, 1.0, 100.0, 101.0],
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(endpoints_zeroed.slopes[0], 0.0);
+        assert_eq!(endpoints_zeroed.slopes[3], 0.0);
+    }
+
+    #[test]
+    fn hermite_and_log_cubic_cover_derivatives_jacobians_and_endpoint_modes() {
+        let x = vec![0.0, 1.0, 2.0];
+        let affine_y = vec![1.0, 3.0, 5.0];
+        let hermite = HermiteMonotoneInterpolator::new(
+            x.clone(),
+            affine_y.clone(),
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_derivative_matches_five_point(&hermite, 0.4);
+        for (xq, expected) in [(-1.0, -1.0), (3.0, 7.0)] {
+            assert_eq!(hermite.value(xq).unwrap(), expected);
+            assert_eq!(hermite.derivative(xq).unwrap(), 2.0);
+            let jacobian = hermite.jacobian(xq).unwrap();
+            // The central-difference Jacobian's measured translation-identity
+            // residual is 4.36e-10 on this extrapolation fixture.
+            assert_relative_eq!(jacobian.iter().sum::<f64>(), 1.0, epsilon = 6.0e-10);
+        }
+
+        let mut hermite_flat = hermite.clone();
+        hermite_flat.extrapolation = ExtrapolationMode::Flat;
+        assert_eq!(hermite_flat.value(-1.0).unwrap(), 1.0);
+        assert_eq!(hermite_flat.value(3.0).unwrap(), 5.0);
+        assert_eq!(hermite_flat.derivative(-1.0).unwrap(), 0.0);
+        assert_eq!(hermite_flat.derivative(3.0).unwrap(), 0.0);
+
+        let mut hermite_disabled = hermite;
+        hermite_disabled.extrapolation = ExtrapolationMode::Error;
+        for xq in [-1.0, 3.0] {
+            assert_eq!(
+                hermite_disabled.value(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                hermite_disabled.derivative(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                hermite_disabled.jacobian(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+        }
+
+        let exponential_y = vec![1.0, 1.0_f64.exp(), 2.0_f64.exp()];
+        let log_cubic =
+            LogCubicMonotoneInterpolator::new(x, exponential_y.clone(), ExtrapolationMode::Linear)
+                .unwrap();
+        assert_derivative_matches_five_point(&log_cubic, 0.4);
+        for xq in [-1.0_f64, 3.0] {
+            let expected = xq.exp();
+            assert_relative_eq!(log_cubic.value(xq).unwrap(), expected, epsilon = 4.0e-15);
+            assert_relative_eq!(
+                log_cubic.derivative(xq).unwrap(),
+                expected,
+                epsilon = 4.0e-15
+            );
+            let jacobian = log_cubic.jacobian(xq).unwrap();
+            // Log-cubic interpolation is homogeneous (rather than translation
+            // equivariant) in the raw positive ordinates, so Euler's identity
+            // is J*y = value.
+            assert_relative_eq!(
+                jacobian
+                    .iter()
+                    .zip(&exponential_y)
+                    .map(|(j, yi)| j * yi)
+                    .sum::<f64>(),
+                expected,
+                epsilon = 8.0e-9
+            );
+        }
+
+        let mut log_flat = log_cubic.clone();
+        log_flat.extrapolation = ExtrapolationMode::Flat;
+        assert_eq!(log_flat.value(-1.0).unwrap(), exponential_y[0]);
+        assert_eq!(log_flat.value(3.0).unwrap(), exponential_y[2]);
+        assert_eq!(log_flat.derivative(-1.0).unwrap(), 0.0);
+        assert_eq!(log_flat.derivative(3.0).unwrap(), 0.0);
+
+        let mut log_disabled = log_cubic;
+        log_disabled.extrapolation = ExtrapolationMode::Error;
+        for xq in [-1.0, 3.0] {
+            assert_eq!(
+                log_disabled.value(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                log_disabled.derivative(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+            assert_eq!(
+                log_disabled.jacobian(xq),
+                Err(InterpolationError::ExtrapolationDisabled)
+            );
+        }
+    }
+
+    #[test]
+    fn constructors_reject_each_invalid_input_class() {
+        assert_eq!(
+            LinearInterpolator::new(vec![1.0, 2.0], vec![0.01], ExtrapolationMode::Flat)
+                .unwrap_err(),
+            InterpolationError::InvalidInput("x and y must have same length")
+        );
+        assert_eq!(
+            LinearInterpolator::new(vec![1.0], vec![0.01], ExtrapolationMode::Flat).unwrap_err(),
+            InterpolationError::InvalidInput("not enough interpolation nodes")
+        );
+        assert_eq!(
+            LinearInterpolator::new(vec![1.0, 1.0], vec![0.01, 0.02], ExtrapolationMode::Flat,)
+                .unwrap_err(),
+            InterpolationError::InvalidInput("x must be strictly increasing")
+        );
+        assert_eq!(
+            LinearInterpolator::new(
+                vec![1.0, f64::INFINITY],
+                vec![0.01, 0.02],
+                ExtrapolationMode::Flat,
+            )
+            .unwrap_err(),
+            InterpolationError::InvalidInput("x and y must be finite")
+        );
+        assert_eq!(
+            LogLinearInterpolator::new(vec![1.0, 2.0], vec![0.99, 0.0], ExtrapolationMode::Flat,)
+                .unwrap_err(),
+            InterpolationError::InvalidInput("y must be strictly positive")
+        );
+        assert_eq!(
+            LogCubicMonotoneInterpolator::new(
+                vec![1.0, 2.0],
+                vec![0.99, -0.1],
+                ExtrapolationMode::Flat,
+            )
+            .unwrap_err(),
+            InterpolationError::InvalidInput("y must be strictly positive")
+        );
+
+        for tension in [-f64::EPSILON, 1.0 + f64::EPSILON, f64::NAN] {
+            assert_eq!(
+                TensionSplineInterpolator::new(
+                    vec![1.0, 2.0],
+                    vec![0.01, 0.02],
+                    tension,
+                    ExtrapolationMode::Flat,
+                )
+                .unwrap_err(),
+                InterpolationError::InvalidInput("tension must be in [0, 1]")
+            );
+        }
+
+        for tau in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert_eq!(
+                NelsonSiegelInterpolator::from_params(
+                    vec![1.0],
+                    vec![0.02],
+                    0.02,
+                    -0.01,
+                    0.01,
+                    tau,
+                    ExtrapolationMode::Flat,
+                )
+                .unwrap_err(),
+                InterpolationError::InvalidInput("tau must be finite and > 0")
+            );
+        }
+        assert_eq!(
+            NelsonSiegelSvenssonInterpolator::fit(
+                vec![1.0, 2.0, 3.0],
+                vec![0.01, 0.02, 0.03],
+                ExtrapolationMode::Flat,
+            )
+            .unwrap_err(),
+            InterpolationError::InvalidInput("not enough interpolation nodes")
+        );
+
+        for (ufr, alpha) in [(f64::NAN, 0.1), (0.03, 0.0), (0.03, f64::INFINITY)] {
+            assert_eq!(
+                SmithWilsonInterpolator::new(
+                    vec![1.0, 2.0],
+                    vec![0.98, 0.95],
+                    ufr,
+                    alpha,
+                    ExtrapolationMode::Flat,
+                )
+                .unwrap_err(),
+                InterpolationError::InvalidInput("ufr must be finite and alpha > 0")
+            );
+        }
+    }
+
+    #[test]
+    fn monotone_convex_matches_affine_curve_derivative_jacobian_and_modes() {
+        let x = vec![0.0, 1.0, 2.0, 4.0];
+        let y = vec![1.0, 3.0, 5.0, 9.0];
+        let linear =
+            MonotoneConvexInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Linear)
+                .unwrap();
+
+        for (xq, expected) in [(-1.0, -1.0), (1.4, 3.8), (5.0, 11.0)] {
+            assert_relative_eq!(linear.value(xq).unwrap(), expected, epsilon = 3.0e-15);
+            assert_relative_eq!(linear.derivative(xq).unwrap(), 2.0, epsilon = 3.0e-15);
+        }
+        assert_derivative_matches_five_point(&linear, 1.4);
+
+        let jacobian = linear.jacobian(1.4).unwrap();
+        // Translation equivariance gives sum(dy/dy_i)=1, while local
+        // homogeneity gives J*y=value.  Together these check the full
+        // finite-difference sensitivity path without percentage bands.
+        assert_relative_eq!(jacobian.iter().sum::<f64>(), 1.0, epsilon = 3.0e-10);
+        assert_relative_eq!(
+            jacobian.iter().zip(&y).map(|(j, yi)| j * yi).sum::<f64>(),
+            linear.value(1.4).unwrap(),
+            epsilon = 3.0e-10
+        );
+
+        let flat =
+            MonotoneConvexInterpolator::new(x.clone(), y.clone(), ExtrapolationMode::Flat).unwrap();
+        assert_eq!(flat.value(-1.0).unwrap(), y[0]);
+        assert_eq!(flat.value(5.0).unwrap(), y[3]);
+        assert_eq!(flat.derivative(-1.0).unwrap(), 0.0);
+        assert_eq!(flat.derivative(5.0).unwrap(), 0.0);
+
+        let disabled = MonotoneConvexInterpolator::new(x, y, ExtrapolationMode::Error).unwrap();
+        for result in [
+            disabled.value(-1.0).map(|_| ()),
+            disabled.derivative(5.0).map(|_| ()),
+            disabled.jacobian(-1.0).map(|_| ()),
+        ] {
+            assert_eq!(result, Err(InterpolationError::ExtrapolationDisabled));
+        }
+    }
+
+    #[test]
+    fn tension_spline_extremes_match_affine_and_smoothstep_oracles() {
+        let affine = TensionSplineInterpolator::new(
+            vec![0.0, 1.0, 2.0, 4.0],
+            vec![1.0, 3.0, 5.0, 9.0],
+            0.0,
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        for (xq, expected) in [(-1.0, -1.0), (1.25, 3.5), (5.0, 11.0)] {
+            assert_relative_eq!(affine.value(xq).unwrap(), expected, epsilon = 3.0e-15);
+            assert_relative_eq!(affine.derivative(xq).unwrap(), 2.0, epsilon = 3.0e-15);
+        }
+        assert_derivative_matches_five_point(&affine, 1.25);
+
+        // At tension=1 all node slopes vanish.  On [0,1], s=1/4 gives
+        // Hermite weights h00=27/32 and h01=5/32 exactly.
+        let smoothstep = TensionSplineInterpolator::new(
+            vec![0.0, 1.0, 2.0],
+            vec![1.0, 3.0, 7.0],
+            1.0,
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_eq!(smoothstep.value(0.25).unwrap(), 1.3125);
+        assert_eq!(smoothstep.derivative(0.25).unwrap(), 2.25);
+        assert_eq!(smoothstep.value(-2.0).unwrap(), 1.0);
+        assert_eq!(smoothstep.value(4.0).unwrap(), 7.0);
+        assert_eq!(smoothstep.derivative(-2.0).unwrap(), 0.0);
+        assert_eq!(smoothstep.derivative(4.0).unwrap(), 0.0);
+
+        let expected_jacobian = [0.84375, 0.15625, 0.0];
+        for (actual, expected) in smoothstep
+            .jacobian(0.25)
+            .unwrap()
+            .iter()
+            .zip(expected_jacobian)
+        {
+            assert_relative_eq!(*actual, expected, epsilon = 2.0e-10);
+        }
+    }
+
+    #[test]
+    fn parametric_curve_derivatives_and_extrapolation_modes_match_identities() {
+        let x = vec![0.5, 1.0, 2.0, 5.0, 10.0];
+        let y = vec![0.012, 0.014, 0.017, 0.022, 0.026];
+        let ns = NelsonSiegelInterpolator::from_params(
+            x.clone(),
+            y,
+            0.028,
+            -0.019,
+            0.014,
+            1.7,
+            ExtrapolationMode::Linear,
+        )
+        .unwrap();
+        assert_derivative_matches_five_point(&ns, 3.25);
+
+        let boundary_value = ns.model_value(10.0);
+        let boundary_derivative = ns.model_derivative(10.0);
+        assert_relative_eq!(
+            ns.value(12.0).unwrap(),
+            boundary_value + 2.0 * boundary_derivative,
+            epsilon = 8.0 * f64::EPSILON
+        );
+        assert_eq!(ns.derivative(12.0).unwrap(), boundary_derivative);
+
+        let mut flat = ns.clone();
+        flat.extrapolation = ExtrapolationMode::Flat;
+        assert_eq!(flat.value(12.0).unwrap(), boundary_value);
+        assert_eq!(flat.derivative(12.0).unwrap(), 0.0);
+
+        let mut disabled = ns;
+        disabled.extrapolation = ExtrapolationMode::Error;
+        assert_eq!(
+            disabled.value(12.0),
+            Err(InterpolationError::ExtrapolationDisabled)
+        );
+        assert_eq!(
+            disabled.derivative(0.25),
+            Err(InterpolationError::ExtrapolationDisabled)
+        );
+    }
+
+    #[test]
+    fn nss_derivative_and_all_extrapolation_modes_match_boundary_identities() {
+        let x = vec![0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 20.0, 30.0];
+        let tau1 = logspace(0.05, 10.0, 28)[15];
+        let tau2 = logspace(0.2, 50.0, 32)[24];
+        let y = x
+            .iter()
+            .map(|t| {
+                let (f1, f2, f3, _, _, _) = nss_basis(*t, tau1, tau2);
+                0.021 - 0.011 * f1 + 0.015 * f2 + 0.006 * f3
+            })
+            .collect();
+        let linear =
+            NelsonSiegelSvenssonInterpolator::fit(x, y, ExtrapolationMode::Linear).unwrap();
+        assert_derivative_matches_five_point(&linear, 4.25);
+
+        let boundary_value = linear.model_value(30.0);
+        let boundary_derivative = linear.model_derivative(30.0);
+        assert_relative_eq!(
+            linear.value(33.0).unwrap(),
+            boundary_value + 3.0 * boundary_derivative,
+            epsilon = 8.0 * f64::EPSILON
+        );
+        assert_eq!(linear.derivative(33.0).unwrap(), boundary_derivative);
+
+        let mut flat = linear.clone();
+        flat.extrapolation = ExtrapolationMode::Flat;
+        assert_eq!(flat.value(33.0).unwrap(), boundary_value);
+        assert_eq!(flat.derivative(33.0).unwrap(), 0.0);
+
+        let mut disabled = linear;
+        disabled.extrapolation = ExtrapolationMode::Error;
+        for result in [
+            disabled.value(33.0).map(|_| ()),
+            disabled.derivative(0.25).map(|_| ()),
+            disabled.jacobian(33.0).map(|_| ()),
+        ] {
+            assert_eq!(result, Err(InterpolationError::ExtrapolationDisabled));
+        }
+    }
+
+    #[test]
+    fn smith_wilson_derivative_pillar_jacobian_and_modes_match_exact_identities() {
+        let x = vec![1.0, 2.0, 5.0, 10.0, 20.0];
+        let y = vec![0.99, 0.965, 0.90, 0.80, 0.64];
+        let linear =
+            SmithWilsonInterpolator::new(x.clone(), y, 0.032, 0.12, ExtrapolationMode::Linear)
+                .unwrap();
+        assert_derivative_matches_five_point(&linear, 7.0);
+
+        // Calibration is exact at every liquid pillar, hence dy(x_i)/dy_j is
+        // the identity matrix.  This directly anchors every Jacobian column.
+        for (i, pillar) in x.iter().enumerate() {
+            for (j, actual) in linear.jacobian(*pillar).unwrap().iter().enumerate() {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert_relative_eq!(*actual, expected, epsilon = 8.0e-9);
+            }
+        }
+
+        let boundary_value = linear.model_value(20.0);
+        let boundary_derivative = linear.model_derivative(20.0);
+        assert_relative_eq!(
+            linear.value(22.0).unwrap(),
+            boundary_value + 2.0 * boundary_derivative,
+            epsilon = 8.0 * f64::EPSILON
+        );
+        assert_eq!(linear.derivative(22.0).unwrap(), boundary_derivative);
+
+        let mut flat = linear.clone();
+        flat.extrapolation = ExtrapolationMode::Flat;
+        assert_eq!(flat.value(22.0).unwrap(), boundary_value);
+        assert_eq!(flat.derivative(22.0).unwrap(), 0.0);
+
+        let mut disabled = linear;
+        disabled.extrapolation = ExtrapolationMode::Error;
+        for result in [
+            disabled.value(22.0).map(|_| ()),
+            disabled.derivative(0.5).map(|_| ()),
+            disabled.jacobian(22.0).map(|_| ()),
+        ] {
+            assert_eq!(result, Err(InterpolationError::ExtrapolationDisabled));
+        }
+    }
+
+    #[test]
+    fn any_interpolator_dispatches_every_variant_and_trait_method() {
+        let local_x = vec![1.0, 2.0, 4.0];
+        let local_y = vec![0.99, 0.95, 0.87];
+        let curve_x = vec![0.5, 1.0, 2.0, 5.0, 10.0];
+        let curve_y = vec![0.012, 0.014, 0.017, 0.022, 0.026];
+
+        let variants = vec![
+            AnyInterpolator::Linear(
+                LinearInterpolator::new(
+                    local_x.clone(),
+                    local_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::LogLinear(
+                LogLinearInterpolator::new(
+                    local_x.clone(),
+                    local_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::MonotoneConvex(
+                MonotoneConvexInterpolator::new(
+                    local_x.clone(),
+                    local_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::TensionSpline(
+                TensionSplineInterpolator::new(
+                    local_x.clone(),
+                    local_y.clone(),
+                    0.4,
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::HermiteMonotone(
+                HermiteMonotoneInterpolator::new(
+                    local_x.clone(),
+                    local_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::LogCubicMonotone(
+                LogCubicMonotoneInterpolator::new(local_x, local_y, ExtrapolationMode::Linear)
+                    .unwrap(),
+            ),
+            AnyInterpolator::NelsonSiegel(
+                NelsonSiegelInterpolator::fit(
+                    curve_x.clone(),
+                    curve_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::NelsonSiegelSvensson(
+                NelsonSiegelSvenssonInterpolator::fit(
+                    curve_x.clone(),
+                    curve_y.clone(),
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+            AnyInterpolator::SmithWilson(
+                SmithWilsonInterpolator::new(
+                    curve_x,
+                    curve_y,
+                    0.032,
+                    0.12,
+                    ExtrapolationMode::Linear,
+                )
+                .unwrap(),
+            ),
+        ];
+
+        for interpolator in variants {
+            assert_eq!(interpolator.x().len(), interpolator.y().len());
+            assert!(interpolator.value(3.0).unwrap().is_finite());
+            assert!(interpolator.derivative(3.0).unwrap().is_finite());
+            let jacobian = interpolator.jacobian(3.0).unwrap();
+            assert_eq!(jacobian.len(), interpolator.y().len());
+            assert!(jacobian.iter().all(|entry| entry.is_finite()));
+        }
     }
 }

--- a/src/models/commodity.rs
+++ b/src/models/commodity.rs
@@ -2000,4 +2000,200 @@ mod tests {
             2.0 * (-risk_free_rate * 0.5_f64).exp() + 5.0 * (-risk_free_rate * 0.75_f64).exp();
         assert_relative_eq!(value, expected, epsilon = 2.0e-14);
     }
+
+    #[test]
+    fn deterministic_schwartz_path_wrappers_match_exact_step_recurrences() {
+        let one_factor = SchwartzOneFactor {
+            kappa: 0.7,
+            mu: 4.4,
+            sigma: 0.0,
+        };
+        let initial_spot: f64 = 92.0;
+        let steps = 4;
+        let dt = 0.25;
+        let path = one_factor
+            .simulate_path(initial_spot, 1.0, steps, 123)
+            .unwrap();
+        assert_eq!(path.len(), steps + 1);
+        let mut expected_log = initial_spot.ln();
+        assert_eq!(path[0], initial_spot);
+        for actual in &path[1..] {
+            expected_log = one_factor.step_log_exact(expected_log, dt, 0.0).unwrap();
+            assert_relative_eq!(*actual, expected_log.exp(), epsilon = 3.0e-14);
+        }
+
+        let two_factor = SchwartzSmithTwoFactor {
+            kappa: 1.2,
+            sigma_chi: 0.0,
+            mu_xi: 0.03,
+            sigma_xi: 0.0,
+            rho: -0.4,
+        };
+        let mut chi = 0.12;
+        let mut xi = 4.25;
+        let path = two_factor.simulate_path(chi, xi, 1.0, steps, 987).unwrap();
+        assert_eq!(path.len(), steps + 1);
+        for actual in &path[1..] {
+            (chi, xi) = two_factor.step_exact(chi, xi, dt, 0.0, 0.0).unwrap();
+            assert_relative_eq!(actual.0, chi, epsilon = 2.0e-16);
+            assert_relative_eq!(actual.1, xi, epsilon = 2.0e-16);
+            assert_relative_eq!(actual.2, (chi + xi).exp(), epsilon = 3.0e-14);
+        }
+    }
+
+    #[test]
+    fn commodity_curve_helpers_recover_convenience_yield_and_structure() {
+        let spot: f64 = 100.0;
+        let rate: f64 = 0.04;
+        let storage: f64 = 0.01;
+        let convenience: f64 = 0.025;
+        let quotes: Vec<FuturesQuote> = [0.25_f64, 0.75, 1.5]
+            .into_iter()
+            .map(|maturity| FuturesQuote {
+                maturity,
+                price: spot * ((rate + storage - convenience) * maturity).exp(),
+            })
+            .collect();
+        let curve = CommodityForwardCurve::bootstrap_from_futures(&quotes).unwrap();
+
+        assert_eq!(curve.maturities(), &[0.25, 0.75, 1.5]);
+        assert_eq!(curve.forwards().len(), quotes.len());
+        assert_eq!(curve.interpolation(), ForwardInterpolation::Linear);
+        for (maturity, inferred) in curve.convenience_yield_curve(spot, rate, storage).unwrap() {
+            assert!(maturity > 0.0);
+            assert_relative_eq!(inferred, convenience, epsilon = 2.0e-16);
+        }
+
+        let flat_interp = curve.with_interpolation(ForwardInterpolation::PiecewiseFlat);
+        assert_eq!(
+            flat_interp.interpolation(),
+            ForwardInterpolation::PiecewiseFlat
+        );
+        assert_eq!(flat_interp.forward(0.5), quotes[0].price);
+
+        let flat = CommodityForwardCurve::from_futures_quotes(&[
+            FuturesQuote {
+                maturity: 0.5,
+                price: 100.0,
+            },
+            FuturesQuote {
+                maturity: 1.0,
+                price: 100.0 + 0.5e-10,
+            },
+        ])
+        .unwrap();
+        assert_eq!(flat.structure(), CurveStructure::Flat);
+
+        let mixed = CommodityForwardCurve::from_futures_quotes(&[
+            FuturesQuote {
+                maturity: 0.25,
+                price: 100.0,
+            },
+            FuturesQuote {
+                maturity: 0.5,
+                price: 103.0,
+            },
+            FuturesQuote {
+                maturity: 1.0,
+                price: 99.0,
+            },
+        ])
+        .unwrap();
+        assert_eq!(mixed.structure(), CurveStructure::Mixed);
+        assert!(!mixed.is_contango());
+        assert!(!mixed.is_backwardation());
+    }
+
+    #[test]
+    fn additive_seasonality_applies_and_removes_exact_monthly_adjustments() {
+        let factors = [
+            5.0, 4.0, 3.0, 2.0, 1.0, 0.0, -1.0, -2.0, -3.0, -4.0, -5.0, -6.0,
+        ];
+        let seasonality = CommoditySeasonalityModel::additive(factors).unwrap();
+        assert_eq!(seasonality.mode(), SeasonalityMode::Additive);
+        assert_eq!(seasonality.monthly_factors(), &factors);
+        assert_eq!(seasonality.factor_for_month(1).unwrap(), 5.0);
+        assert_eq!(seasonality.apply(100.0, 1).unwrap(), 105.0);
+        assert_eq!(seasonality.apply(100.0, 12).unwrap(), 94.0);
+
+        let observations = [(1, 105.0), (2, 114.0), (3, 123.0)];
+        assert_eq!(
+            seasonality.deseasonalise(&observations).unwrap(),
+            vec![100.0, 110.0, 120.0]
+        );
+        let returns = seasonality
+            .deseasonalised_log_returns(&observations)
+            .unwrap();
+        assert_relative_eq!(returns[0], 1.1_f64.ln(), epsilon = 2.0e-16);
+        assert_relative_eq!(returns[1], (120.0_f64 / 110.0).ln(), epsilon = 2.0e-16);
+    }
+
+    #[test]
+    fn zero_volatility_spread_put_matches_discounted_intrinsic_value() {
+        let model = TwoFactorSpreadModel {
+            leg_1: TwoFactorCommodityProcess {
+                kappa_fast: 1.5,
+                sigma_fast: 0.0,
+                sigma_slow: 0.0,
+            },
+            leg_2: TwoFactorCommodityProcess {
+                kappa_fast: 2.0,
+                sigma_fast: 0.0,
+                sigma_slow: 0.0,
+            },
+            rho_fast: 0.25,
+            rho_slow: -0.50,
+        };
+        let rate: f64 = 0.03;
+        let maturity: f64 = 1.25;
+        let (price, stderr) = model
+            .price_spread_option_mc(
+                OptionType::Put,
+                90.0,
+                100.0,
+                5.0,
+                1.0,
+                1.0,
+                rate,
+                maturity,
+                8,
+                44,
+            )
+            .unwrap();
+        let expected = 15.0 * (-rate * maturity).exp();
+        assert_relative_eq!(price, expected, epsilon = 2.0e-15);
+        assert_eq!(stderr, 0.0);
+    }
+
+    #[test]
+    fn volume_constrained_put_swing_matches_enumerated_cashflows() {
+        let curve = CommodityForwardCurve::from_futures_quotes(&[
+            FuturesQuote {
+                maturity: 0.25,
+                price: 12.0,
+            },
+            FuturesQuote {
+                maturity: 0.5,
+                price: 8.0,
+            },
+            FuturesQuote {
+                maturity: 0.75,
+                price: 5.0,
+            },
+        ])
+        .unwrap();
+        let swing = VolumeConstrainedSwing {
+            exercise_times: vec![0.25, 0.5, 0.75],
+            strike: 10.0,
+            option_type: OptionType::Put,
+            min_period_volume: 0.0,
+            max_period_volume: 1.0,
+            min_total_volume: 1.0,
+            max_total_volume: 2.0,
+        };
+        let rate: f64 = 0.04;
+        let actual = swing.intrinsic_value(&curve, rate, 3).unwrap();
+        let expected = 2.0 * (-rate * 0.5_f64).exp() + 5.0 * (-rate * 0.75_f64).exp();
+        assert_relative_eq!(actual, expected, epsilon = 2.0e-14);
+    }
 }

--- a/src/rates/calendar.rs
+++ b/src/rates/calendar.rs
@@ -1852,4 +1852,328 @@ mod tests {
             NaiveDate::from_ymd_opt(2025, 12, 20).unwrap()
         );
     }
+
+    #[test]
+    fn frequency_defaults_and_calendar_constructors_cover_public_contract() {
+        assert_eq!(Frequency::Annual.months(), 12);
+        assert_eq!(Frequency::SemiAnnual.months(), 6);
+        assert_eq!(Frequency::Quarterly.months(), 3);
+        assert_eq!(Frequency::Monthly.months(), 1);
+
+        let default = ScheduleConfig::default();
+        assert_eq!(default.calendar, Calendar::weekends_only());
+        assert_eq!(
+            default.business_day_convention,
+            BusinessDayConvention::ModifiedFollowing
+        );
+        assert_eq!(default.stub_convention, StubConvention::ShortBack);
+        assert_eq!(default.roll_convention, RollConvention::None);
+
+        let empty_joint = Calendar::joint(Vec::new());
+        assert!(empty_joint.is_business_day(NaiveDate::from_ymd_opt(2026, 1, 2).unwrap()));
+        assert!(empty_joint.is_holiday(NaiveDate::from_ymd_opt(2026, 1, 3).unwrap()));
+
+        let generated = generate_schedule(
+            NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 4, 2).unwrap(),
+            Frequency::Quarterly,
+        );
+        assert_eq!(
+            generated,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 4, 2).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn custom_calendar_mutations_and_nearest_tie_break_are_deterministic() {
+        let wednesday = NaiveDate::from_ymd_opt(2026, 1, 7).unwrap();
+        let mut custom = CustomCalendar::new(WeekendConvention::SaturdaySunday);
+        custom.add_holiday(wednesday);
+        let calendar = Calendar::custom(custom.clone());
+
+        // Tuesday and Thursday are equally close: Nearest is documented to
+        // resolve the tie in favor of Following.
+        assert_eq!(
+            adjust_business_day(wednesday, BusinessDayConvention::Nearest, &calendar),
+            NaiveDate::from_ymd_opt(2026, 1, 8).unwrap()
+        );
+
+        custom.add_holiday(NaiveDate::from_ymd_opt(2026, 1, 8).unwrap());
+        let calendar = Calendar::custom(custom.clone());
+        assert_eq!(
+            adjust_business_day(wednesday, BusinessDayConvention::Nearest, &calendar),
+            NaiveDate::from_ymd_opt(2026, 1, 6).unwrap()
+        );
+
+        custom.add_business_day_override(wednesday);
+        let calendar = Calendar::custom(custom);
+        assert!(calendar.is_business_day(wednesday));
+        assert_eq!(
+            adjust_business_day(wednesday, BusinessDayConvention::Nearest, &calendar),
+            wednesday
+        );
+    }
+
+    #[test]
+    fn business_day_arithmetic_covers_zero_negative_and_reverse_intervals() {
+        let calendar = Calendar::weekends_only();
+        let friday = NaiveDate::from_ymd_opt(2026, 1, 9).unwrap();
+
+        assert_eq!(add_business_days(friday, 0, &calendar), friday);
+        assert_eq!(
+            add_business_days(friday, -5, &calendar),
+            NaiveDate::from_ymd_opt(2026, 1, 2).unwrap()
+        );
+        assert_eq!(
+            subtract_business_days(friday, -1, &calendar),
+            NaiveDate::from_ymd_opt(2026, 1, 12).unwrap()
+        );
+        assert_eq!(business_day_count(friday, friday, &calendar), 0);
+        assert_eq!(
+            business_day_count(
+                friday,
+                NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(),
+                &calendar
+            ),
+            -5
+        );
+        assert_eq!(
+            year_fraction_business_252(
+                friday,
+                NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(),
+                &calendar
+            ),
+            -5.0 / 252.0
+        );
+
+        // Modified Preceding crosses into January and therefore switches to
+        // Following in February.
+        let february_first = NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+        assert_eq!(
+            adjust_business_day(
+                february_first,
+                BusinessDayConvention::ModifiedPreceding,
+                &calendar
+            ),
+            NaiveDate::from_ymd_opt(2026, 2, 2).unwrap()
+        );
+    }
+
+    #[test]
+    fn front_stub_and_day_of_month_schedules_lock_unadjusted_boundaries() {
+        let start = NaiveDate::from_ymd_opt(2024, 1, 20).unwrap();
+        let end = NaiveDate::from_ymd_opt(2024, 10, 31).unwrap();
+        let base = ScheduleConfig {
+            calendar: Calendar::weekends_only(),
+            business_day_convention: BusinessDayConvention::Unadjusted,
+            stub_convention: StubConvention::ShortFront,
+            roll_convention: RollConvention::EndOfMonth,
+        };
+
+        assert_eq!(
+            generate_schedule_with_config(start, end, Frequency::Quarterly, &base),
+            vec![
+                NaiveDate::from_ymd_opt(2024, 1, 20).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 1, 31).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 30).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 7, 31).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 10, 31).unwrap(),
+            ]
+        );
+        assert_eq!(
+            generate_schedule_with_config(
+                start,
+                end,
+                Frequency::Quarterly,
+                &ScheduleConfig {
+                    stub_convention: StubConvention::LongFront,
+                    ..base
+                }
+            ),
+            vec![
+                NaiveDate::from_ymd_opt(2024, 1, 20).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 30).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 7, 31).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 10, 31).unwrap(),
+            ]
+        );
+
+        let day_31 = ScheduleConfig {
+            calendar: Calendar::weekends_only(),
+            business_day_convention: BusinessDayConvention::Unadjusted,
+            stub_convention: StubConvention::ShortBack,
+            roll_convention: RollConvention::DayOfMonth(31),
+        };
+        assert_eq!(
+            generate_schedule_with_config(
+                NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 5, 20).unwrap(),
+                Frequency::Monthly,
+                &day_31
+            ),
+            vec![
+                NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 2, 29).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 3, 31).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 30).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 5, 20).unwrap(),
+            ]
+        );
+        assert_eq!(
+            generate_schedule_with_config(
+                NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 20).unwrap(),
+                Frequency::Monthly,
+                &ScheduleConfig {
+                    roll_convention: RollConvention::DayOfMonth(0),
+                    ..day_31
+                }
+            ),
+            vec![
+                NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 2, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 3, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2024, 4, 20).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn schedule_edge_cases_cover_imm_steps_collapsed_dates_and_month_arithmetic() {
+        let unadjusted_imm = ScheduleConfig {
+            calendar: Calendar::weekends_only(),
+            business_day_convention: BusinessDayConvention::Unadjusted,
+            stub_convention: StubConvention::ShortBack,
+            roll_convention: RollConvention::Imm,
+        };
+        assert_eq!(
+            generate_schedule_with_config(
+                NaiveDate::from_ymd_opt(2025, 1, 15).unwrap(),
+                NaiveDate::from_ymd_opt(2028, 12, 20).unwrap(),
+                Frequency::Annual,
+                &unadjusted_imm
+            ),
+            vec![
+                NaiveDate::from_ymd_opt(2025, 1, 15).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 12, 17).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 12, 16).unwrap(),
+                NaiveDate::from_ymd_opt(2027, 12, 15).unwrap(),
+                NaiveDate::from_ymd_opt(2028, 12, 20).unwrap(),
+            ]
+        );
+        assert_eq!(
+            generate_schedule_with_config(
+                NaiveDate::from_ymd_opt(2025, 1, 15).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 11, 20).unwrap(),
+                Frequency::Quarterly,
+                &ScheduleConfig {
+                    stub_convention: StubConvention::ShortFront,
+                    ..unadjusted_imm
+                }
+            ),
+            vec![
+                NaiveDate::from_ymd_opt(2025, 1, 15).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 3, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 6, 18).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 9, 17).unwrap(),
+                NaiveDate::from_ymd_opt(2025, 11, 20).unwrap(),
+            ]
+        );
+
+        let collapsed = generate_schedule_with_config(
+            NaiveDate::from_ymd_opt(2021, 1, 30).unwrap(),
+            NaiveDate::from_ymd_opt(2021, 2, 1).unwrap(),
+            Frequency::Monthly,
+            &ScheduleConfig {
+                business_day_convention: BusinessDayConvention::Following,
+                ..ScheduleConfig::default()
+            },
+        );
+        assert_eq!(
+            collapsed,
+            vec![NaiveDate::from_ymd_opt(2021, 2, 1).unwrap()]
+        );
+
+        let non_increasing = generate_schedule_with_config(
+            NaiveDate::from_ymd_opt(2026, 1, 31).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            Frequency::Annual,
+            &ScheduleConfig::default(),
+        );
+        assert_eq!(
+            non_increasing,
+            vec![NaiveDate::from_ymd_opt(2026, 1, 30).unwrap()]
+        );
+
+        assert_eq!(
+            add_months(NaiveDate::from_ymd_opt(2024, 3, 31).unwrap(), -1),
+            NaiveDate::from_ymd_opt(2024, 2, 29).unwrap()
+        );
+        assert_eq!(
+            add_months(NaiveDate::from_ymd_opt(2024, 2, 29).unwrap(), 12),
+            NaiveDate::from_ymd_opt(2025, 2, 28).unwrap()
+        );
+        assert_eq!(
+            add_months(NaiveDate::from_ymd_opt(2026, 1, 31).unwrap(), -13),
+            NaiveDate::from_ymd_opt(2024, 12, 31).unwrap()
+        );
+    }
+
+    #[test]
+    fn imm_and_cds_boundaries_are_inclusive_and_wrap_years() {
+        let imm = NaiveDate::from_ymd_opt(2026, 3, 18).unwrap();
+        assert!(is_imm_date(imm));
+        assert!(!is_imm_date(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()));
+        assert_eq!(next_imm_date(imm), imm);
+        assert_eq!(previous_imm_date(imm), imm);
+        assert_eq!(
+            third_wednesday(2026, 12),
+            NaiveDate::from_ymd_opt(2026, 12, 16).unwrap()
+        );
+        assert_eq!(
+            next_imm_date(NaiveDate::from_ymd_opt(2026, 12, 20).unwrap()),
+            NaiveDate::from_ymd_opt(2027, 3, 17).unwrap()
+        );
+
+        let cds = NaiveDate::from_ymd_opt(2026, 6, 20).unwrap();
+        assert!(is_cds_standard_date(cds));
+        assert!(!is_cds_standard_date(
+            NaiveDate::from_ymd_opt(2026, 6, 19).unwrap()
+        ));
+        assert_eq!(next_cds_date(cds), cds);
+        assert_eq!(previous_cds_date(cds), cds);
+        assert_eq!(
+            next_cds_date(NaiveDate::from_ymd_opt(2026, 12, 21).unwrap()),
+            NaiveDate::from_ymd_opt(2027, 3, 20).unwrap()
+        );
+        assert_eq!(
+            previous_cds_date(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            NaiveDate::from_ymd_opt(2025, 12, 20).unwrap()
+        );
+    }
+
+    #[test]
+    fn representative_observed_and_special_holidays_preserve_business_day_edges() {
+        let nyc = Calendar::nyc();
+        // New Year's Day 2022 fell on Saturday and was observed in the prior year.
+        assert!(nyc.is_holiday(NaiveDate::from_ymd_opt(2021, 12, 31).unwrap()));
+        assert!(nyc.is_business_day(NaiveDate::from_ymd_opt(2021, 6, 18).unwrap()));
+        assert!(nyc.is_holiday(NaiveDate::from_ymd_opt(2022, 6, 20).unwrap()));
+        assert!(nyc.is_holiday(NaiveDate::from_ymd_opt(2024, 11, 28).unwrap()));
+
+        let london = Calendar::london();
+        assert!(london.is_holiday(NaiveDate::from_ymd_opt(1995, 5, 8).unwrap()));
+        assert!(london.is_holiday(NaiveDate::from_ymd_opt(2011, 4, 29).unwrap()));
+        assert!(london.is_holiday(NaiveDate::from_ymd_opt(1999, 12, 31).unwrap()));
+        assert!(london.is_business_day(NaiveDate::from_ymd_opt(2024, 5, 7).unwrap()));
+
+        let target = Calendar::target();
+        assert!(target.is_holiday(NaiveDate::from_ymd_opt(2024, 5, 1).unwrap()));
+        assert!(target.is_holiday(NaiveDate::from_ymd_opt(2024, 12, 26).unwrap()));
+        assert!(target.is_business_day(NaiveDate::from_ymd_opt(2024, 5, 2).unwrap()));
+    }
 }

--- a/src/rates/yield_curve.rs
+++ b/src/rates/yield_curve.rs
@@ -198,6 +198,9 @@ impl YieldCurve {
         if t <= 0.0 {
             return Ok(0.0);
         }
+        if self.tenors.is_empty() {
+            return Ok(0.0);
+        }
 
         let Some(state) = &self.interpolation_state else {
             return Ok(-discount_factor_one_point(
@@ -1082,5 +1085,169 @@ mod tests {
 
         assert!(yc.try_discount_factor(3.0).is_err());
         assert!(yc.discount_factor(3.0).is_nan());
+    }
+
+    #[test]
+    fn empty_curve_has_neutral_rates_and_empty_jacobians() {
+        let curve = YieldCurve::new(Vec::new());
+
+        for t in [-1.0, 0.0, 1.0, 30.0] {
+            assert_eq!(curve.try_discount_factor(t).unwrap(), 1.0);
+            assert_eq!(curve.try_zero_rate(t).unwrap(), 0.0);
+            assert_eq!(curve.try_instantaneous_forward_rate(t).unwrap(), 0.0);
+            assert!(curve.discount_factor_jacobian(t).unwrap().is_empty());
+            assert!(curve.zero_rate_jacobian(t).unwrap().is_empty());
+        }
+
+        assert_eq!(curve.try_forward_rate(1.0, 2.0).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn instantaneous_forwards_match_piecewise_curve_derivatives() {
+        let points = vec![(1.0, 0.97), (2.0, 0.91), (4.0, 0.80)];
+        let log_df = YieldCurve::new_with_settings(
+            points.clone(),
+            settings(YieldCurveInterpolationMethod::LogLinearDiscount),
+        )
+        .unwrap();
+
+        // Between 1y and 2y, log-linear discount interpolation makes the
+        // instantaneous forward exactly ln(P(1)/P(2)) / (2-1).
+        let expected_log_df_forward = (0.97_f64 / 0.91).ln();
+        assert_relative_eq!(
+            log_df.instantaneous_forward_rate(1.5),
+            expected_log_df_forward,
+            epsilon = 16.0 * f64::EPSILON
+        );
+
+        let linear_zero = YieldCurve::new_with_settings(
+            points,
+            settings(YieldCurveInterpolationMethod::LinearZeroRate),
+        )
+        .unwrap();
+        let z1 = -0.97_f64.ln();
+        let z2 = -0.91_f64.ln() / 2.0;
+        let dz = z2 - z1;
+        let expected_linear_zero_forward = (z1 + 0.5 * dz) + 1.5 * dz;
+        assert_relative_eq!(
+            linear_zero.instantaneous_forward_rate(1.5),
+            expected_linear_zero_forward,
+            epsilon = 32.0 * f64::EPSILON
+        );
+
+        // At the origin the zero-rate limit is used.
+        assert_relative_eq!(
+            linear_zero.instantaneous_forward_rate(0.0),
+            z1,
+            epsilon = 16.0 * f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn discount_and_zero_rate_jacobians_match_closed_form_weights() {
+        let df1 = 0.97_f64;
+        let df2 = 0.91_f64;
+        let t = 1.5;
+
+        let log_df = YieldCurve::new_with_settings(
+            vec![(1.0, df1), (2.0, df2)],
+            settings(YieldCurveInterpolationMethod::LogLinearDiscount),
+        )
+        .unwrap();
+        let p = (df1 * df2).sqrt();
+        let expected_df_jac = [p / (2.0 * df1), p / (2.0 * df2)];
+        let expected_zero_jac = [-1.0 / (3.0 * df1), -1.0 / (3.0 * df2)];
+        for (got, expected) in log_df
+            .discount_factor_jacobian(t)
+            .unwrap()
+            .iter()
+            .zip(expected_df_jac)
+        {
+            assert_relative_eq!(*got, expected, epsilon = 32.0 * f64::EPSILON);
+        }
+        for (got, expected) in log_df
+            .zero_rate_jacobian(t)
+            .unwrap()
+            .iter()
+            .zip(expected_zero_jac)
+        {
+            assert_relative_eq!(*got, expected, epsilon = 32.0 * f64::EPSILON);
+        }
+
+        let linear_zero = YieldCurve::new_with_settings(
+            vec![(1.0, df1), (2.0, df2)],
+            settings(YieldCurveInterpolationMethod::LinearZeroRate),
+        )
+        .unwrap();
+        let z = 0.5 * (-df1.ln()) + 0.5 * (-df2.ln() / 2.0);
+        let p = (-z * t).exp();
+        let expected_zero_jac = [-0.5 / df1, -0.25 / df2];
+        let expected_df_jac = [0.75 * p / df1, 0.375 * p / df2];
+        for (got, expected) in linear_zero
+            .zero_rate_jacobian(t)
+            .unwrap()
+            .iter()
+            .zip(expected_zero_jac)
+        {
+            assert_relative_eq!(*got, expected, epsilon = 32.0 * f64::EPSILON);
+        }
+        for (got, expected) in linear_zero
+            .discount_factor_jacobian(t)
+            .unwrap()
+            .iter()
+            .zip(expected_df_jac)
+        {
+            assert_relative_eq!(*got, expected, epsilon = 32.0 * f64::EPSILON);
+        }
+
+        // The synthetic zero-rate origin is linked to the first input node.
+        // Both interpolator weights must therefore map back to pillar zero.
+        let at_half_year = linear_zero.zero_rate_jacobian(0.5).unwrap();
+        assert_relative_eq!(at_half_year[0], -1.0 / df1, epsilon = 16.0 * f64::EPSILON);
+        assert_eq!(at_half_year[1], 0.0);
+
+        assert_eq!(
+            linear_zero.discount_factor_jacobian(0.0).unwrap(),
+            vec![0.0, 0.0]
+        );
+        assert_eq!(
+            linear_zero.zero_rate_jacobian(-1.0).unwrap(),
+            vec![0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn curve_construction_sanitizes_nodes_and_deposit_builder_reprices() {
+        let curve = YieldCurve::new(vec![
+            (2.0, 0.90),
+            (f64::NAN, 0.8),
+            (1.0, 0.96),
+            (1.0 + 5.0e-13, 0.95),
+            (-1.0, 0.9),
+            (3.0, f64::INFINITY),
+        ]);
+        assert_eq!(curve.tenors, vec![(1.0, 0.95), (2.0, 0.90)]);
+
+        let deposits = [(-1.0, 0.10), (0.5, 0.04), (2.0, 0.05)];
+        let deposit_curve = YieldCurveBuilder::from_deposits_with_settings(
+            &deposits,
+            settings(YieldCurveInterpolationMethod::LinearZeroRate),
+        )
+        .unwrap();
+        assert_eq!(deposit_curve.tenors.len(), 2);
+        assert_relative_eq!(
+            deposit_curve.discount_factor(0.5),
+            1.0 / 1.02,
+            epsilon = 8.0 * f64::EPSILON
+        );
+        assert_relative_eq!(
+            deposit_curve.discount_factor(2.0),
+            1.0 / 1.10,
+            epsilon = 8.0 * f64::EPSILON
+        );
+        assert_eq!(
+            deposit_curve.interpolation_settings().method,
+            YieldCurveInterpolationMethod::LinearZeroRate
+        );
     }
 }

--- a/src/vol/builder.rs
+++ b/src/vol/builder.rs
@@ -210,8 +210,11 @@ impl VolSurfaceBuilder {
     }
 
     pub fn build(&self) -> Result<BuiltVolSurface, String> {
-        if self.spot <= 0.0 {
-            return Err("spot must be > 0".to_string());
+        if !self.spot.is_finite() || self.spot <= 0.0 {
+            return Err("spot must be finite and > 0".to_string());
+        }
+        if !self.rate.is_finite() {
+            return Err("rate must be finite".to_string());
         }
 
         if self.quotes.is_empty() {
@@ -228,14 +231,14 @@ impl VolSurfaceBuilder {
         let mut grouped: Vec<(f64, Vec<MarketOptionQuote>)> = Vec::new();
 
         for quote in sorted_quotes {
-            if quote.strike <= 0.0 {
-                return Err("quote strike must be > 0".to_string());
+            if !quote.strike.is_finite() || quote.strike <= 0.0 {
+                return Err("quote strike must be finite and > 0".to_string());
             }
-            if quote.expiry <= 0.0 {
-                return Err("quote expiry must be > 0".to_string());
+            if !quote.expiry.is_finite() || quote.expiry <= 0.0 {
+                return Err("quote expiry must be finite and > 0".to_string());
             }
-            if quote.price <= 0.0 {
-                return Err("quote price must be > 0".to_string());
+            if !quote.price.is_finite() || quote.price <= 0.0 {
+                return Err("quote price must be finite and > 0".to_string());
             }
 
             if let Some((t, bucket)) = grouped.last_mut()
@@ -318,7 +321,32 @@ impl VolSurfaceBuilder {
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
+
+    fn independent_flat_quotes() -> Vec<MarketOptionQuote> {
+        // SciPy 1.17.1 `special.ndtr` Black-Scholes premiums for S=100,
+        // r=1%, q=0 and sigma=25% (same independently generated grid as the
+        // flagship recovery test below, reduced to two strikes per slice).
+        [
+            (80.0, 0.5, 21.129_603_912_480_505),
+            (120.0, 0.5, 1.595_979_359_423_136_4),
+            (80.0, 1.0, 22.890_064_143_625_56),
+            (120.0, 1.0, 3.947_154_079_494_567),
+        ]
+        .into_iter()
+        .map(|(strike, expiry, price)| {
+            MarketOptionQuote::new(strike, expiry, price, OptionType::Call)
+        })
+        .collect()
+    }
+
+    fn constant_slice(vol: f64) -> ExpirySlice {
+        ExpirySlice {
+            strike_spline: CubicSpline::new(vec![80.0, 120.0], vec![vol, vol]).unwrap(),
+        }
+    }
 
     #[test]
     fn builder_recovers_flat_surface_from_independent_scipy_prices() {
@@ -369,5 +397,173 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn built_surface_interpolates_total_variance_and_clamps_expiry_wings() {
+        let surface = BuiltVolSurface {
+            spot: 100.0,
+            rate: 0.03,
+            expiries: vec![0.5, 2.0],
+            slices: vec![constant_slice(0.20), constant_slice(0.30)],
+        };
+
+        assert_eq!(surface.implied_vol(100.0, -1.0), 0.20);
+        assert_eq!(surface.implied_vol(100.0, 0.5), 0.20);
+        assert_eq!(surface.implied_vol(100.0, 2.0), 0.30);
+        assert_eq!(surface.implied_vol(100.0, 3.0), 0.30);
+
+        // At 1.25y the interpolation weight is one half. Total variance is
+        // therefore (0.20^2*0.5 + 0.30^2*2.0)/2 = 0.10, and IV=sqrt(0.10/1.25).
+        assert_relative_eq!(
+            surface.implied_vol(100.0, 1.25),
+            0.08_f64.sqrt(),
+            epsilon = 4.0 * f64::EPSILON
+        );
+
+        let one_slice = BuiltVolSurface {
+            spot: 100.0,
+            rate: 0.0,
+            expiries: vec![1.0],
+            slices: vec![constant_slice(0.18)],
+        };
+        assert_eq!(one_slice.implied_vol(90.0, 10.0), 0.18);
+
+        let empty = BuiltVolSurface {
+            spot: 100.0,
+            rate: 0.0,
+            expiries: Vec::new(),
+            slices: Vec::new(),
+        };
+        assert!(empty.implied_vol(100.0, 1.0).is_nan());
+    }
+
+    #[test]
+    fn builder_chaining_and_analytics_bridges_cover_public_api() {
+        let quotes = independent_flat_quotes();
+        let builder = VolSurfaceBuilder::new(100.0, 0.01)
+            .with_solver_params(0.0, 0)
+            .add_quote(quotes[0])
+            .add_quotes(quotes[1..].to_vec());
+        assert_eq!(builder.tol, 1.0e-14);
+        assert_eq!(builder.max_iter, 1);
+
+        // One iteration is intentionally insufficient for the tight IV solve;
+        // rebuilding with production solver parameters exercises the same
+        // fluent API without weakening the reference tolerance.
+        let builder = builder.with_solver_params(1.0e-13, 100);
+        let (surface, curve) = builder
+            .build_with_forward_variance_curve(&[0.5, 1.0])
+            .unwrap();
+
+        assert_eq!(surface.spot(), 100.0);
+        assert_eq!(surface.rate(), 0.01);
+        assert_eq!(surface.expiries(), &[0.5, 1.0]);
+        assert_eq!(surface.forward_price(-1.0), 100.0);
+        assert_relative_eq!(
+            surface.forward_price(1.0),
+            100.0 * 0.01_f64.exp(),
+            epsilon = 8.0 * f64::EPSILON * 100.0
+        );
+
+        assert_relative_eq!(
+            curve.forward_variance(0.5, 1.0).unwrap(),
+            0.25_f64.powi(2),
+            epsilon = 3.0e-13
+        );
+        let direct_curve = surface.forward_variance_curve(&[0.5, 1.0]).unwrap();
+        assert_eq!(curve, direct_curve);
+
+        let skew = surface.atm_skew_term_structure(&[0.5, 1.0]).unwrap();
+        assert!(skew.points().iter().all(|p| p.skew.abs() <= 2.0e-13));
+
+        let vix = surface
+            .vix_style_index(VixSettings {
+                target_days: 30.0,
+                strike_count: 101,
+                log_moneyness_span: 2.0,
+            })
+            .unwrap();
+        assert!(vix.index.is_finite());
+        assert!(vix.target_variance >= 0.0);
+
+        let local = surface.local_vol(100.0, 0.75);
+        // DupireLocalVol uses finite differences on strike/time; the measured
+        // flat-surface differentiation residual is 2.0842e-7 in this grid.
+        // The remaining 4.16e-8 is cross-platform libm/roundoff headroom.
+        assert_relative_eq!(local, 0.25, epsilon = 2.5e-7);
+
+        // Lock both trait bridges explicitly; these are used by generic local-
+        // and forward-volatility consumers.
+        assert_relative_eq!(
+            LocalVolSurface::implied_vol(&surface, 100.0, 0.75),
+            0.25,
+            epsilon = 3.0e-13
+        );
+        assert_relative_eq!(
+            ForwardVarianceSource::implied_vol(&surface, 100.0, 0.75),
+            0.25,
+            epsilon = 3.0e-13
+        );
+        assert_eq!(ForwardVarianceSource::expiries(&surface), &[0.5, 1.0]);
+    }
+
+    #[test]
+    fn builder_rejects_nonfinite_and_structurally_invalid_inputs() {
+        let valid = independent_flat_quotes();
+
+        assert!(VolSurfaceBuilder::new(100.0, 0.01).build().is_err());
+        for spot in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                VolSurfaceBuilder::from_quotes(spot, 0.01, valid.clone())
+                    .build()
+                    .is_err()
+            );
+        }
+        assert!(
+            VolSurfaceBuilder::from_quotes(100.0, f64::NAN, valid.clone())
+                .build()
+                .is_err()
+        );
+
+        let invalid_fields = [
+            MarketOptionQuote::new(0.0, 1.0, 1.0, OptionType::Call),
+            MarketOptionQuote::new(f64::NAN, 1.0, 1.0, OptionType::Call),
+            MarketOptionQuote::new(100.0, 0.0, 1.0, OptionType::Call),
+            MarketOptionQuote::new(100.0, f64::INFINITY, 1.0, OptionType::Call),
+            MarketOptionQuote::new(100.0, 1.0, 0.0, OptionType::Call),
+            MarketOptionQuote::new(100.0, 1.0, f64::NAN, OptionType::Call),
+        ];
+        for quote in invalid_fields {
+            assert!(
+                VolSurfaceBuilder::from_quotes(100.0, 0.01, vec![quote])
+                    .build()
+                    .is_err()
+            );
+        }
+
+        assert!(
+            VolSurfaceBuilder::from_quotes(100.0, 0.01, vec![valid[0]])
+                .build()
+                .unwrap_err()
+                .contains("at least two strikes")
+        );
+        assert!(
+            VolSurfaceBuilder::from_quotes(100.0, 0.01, vec![valid[0], valid[0]])
+                .build()
+                .unwrap_err()
+                .contains("strictly increasing")
+        );
+
+        let impossible_premium = vec![
+            MarketOptionQuote::new(80.0, 1.0, 150.0, OptionType::Call),
+            MarketOptionQuote::new(120.0, 1.0, 150.0, OptionType::Call),
+        ];
+        assert!(
+            VolSurfaceBuilder::from_quotes(100.0, 0.01, impossible_premium)
+                .build()
+                .unwrap_err()
+                .contains("implied vol solve failed")
+        );
     }
 }

--- a/src/vol/forward.rs
+++ b/src/vol/forward.rs
@@ -250,9 +250,15 @@ impl ForwardVarianceCurve {
         variance_notional: f64,
         risk_free_rate: f64,
     ) -> Result<f64, String> {
-        if strike_variance < 0.0 || variance_notional < 0.0 || !risk_free_rate.is_finite() {
+        if !strike_variance.is_finite()
+            || strike_variance < 0.0
+            || !variance_notional.is_finite()
+            || variance_notional < 0.0
+            || !risk_free_rate.is_finite()
+        {
             return Err(
-                "strike variance, notional, and rate must be finite and non-negative".to_string(),
+                "strike variance and notional must be finite and non-negative; rate must be finite"
+                    .to_string(),
             );
         }
 
@@ -517,6 +523,9 @@ pub fn vix_style_index_from_surface<S: ForwardVarianceSource>(
     if expiries.iter().any(|t| !t.is_finite() || *t <= 0.0) {
         return Err("surface expiries must be finite and > 0".to_string());
     }
+    if expiries.windows(2).any(|w| w[1] <= w[0]) {
+        return Err("surface expiries must be strictly increasing".to_string());
+    }
 
     let (near_idx, next_idx) = bracketing_expiry_indices(expiries, target_t)?;
     let t1 = expiries[near_idx];
@@ -591,12 +600,13 @@ fn model_free_variance_for_expiry<S: ForwardVarianceSource>(
     for i in 0..n {
         let k_log = -span + i as f64 * dk;
         let strike = fwd * k_log.exp();
-        let vol = surface.implied_vol(strike, expiry).max(1e-8);
-        if !vol.is_finite() {
+        let raw_vol = surface.implied_vol(strike, expiry);
+        if !raw_vol.is_finite() {
             return Err(format!(
                 "non-finite implied vol at expiry {expiry}, strike {strike}"
             ));
         }
+        let vol = raw_vol.max(1e-8);
 
         let call = black_76_price(OptionType::Call, fwd, strike, rate, vol, expiry).max(0.0);
         let put = black_76_price(OptionType::Put, fwd, strike, rate, vol, expiry).max(0.0);
@@ -658,7 +668,9 @@ fn interpolate_nodes<P>(
         return value(&points[0]);
     }
 
-    let x = if x.is_finite() { x } else { key(&points[0]) };
+    if x.is_nan() {
+        return f64::NAN;
+    }
     if x <= key(&points[0]) {
         return value(&points[0]);
     }
@@ -815,5 +827,375 @@ mod tests {
         let ts = SabrVolOfVolTermStructure::new(points).unwrap();
         assert_relative_eq!(ts.alpha(1.25), 0.18, epsilon = 1e-12);
         assert_relative_eq!(ts.nu(1.25), 0.5, epsilon = 1e-12);
+    }
+
+    #[derive(Debug, Clone)]
+    struct LogSmileSurface {
+        base_vol: f64,
+        log_moneyness_slope: f64,
+        expiries: Vec<f64>,
+        forward: f64,
+    }
+
+    impl ForwardVarianceSource for LogSmileSurface {
+        fn implied_vol(&self, strike: f64, _expiry: f64) -> f64 {
+            self.base_vol + self.log_moneyness_slope * (strike / self.forward).ln()
+        }
+
+        fn forward_price(&self, _expiry: f64) -> f64 {
+            self.forward
+        }
+
+        fn expiries(&self) -> &[f64] {
+            &self.expiries
+        }
+    }
+
+    #[test]
+    fn forward_variance_curve_interpolates_extrapolates_and_prices_swaps() {
+        let curve = ForwardVarianceCurve::new(vec![(2.0, 0.09), (0.5, 0.02), (1.0, 0.05)]).unwrap();
+
+        assert_eq!(curve.expiries(), vec![0.5, 1.0, 2.0]);
+        assert_eq!(curve.total_variance(-1.0), 0.0);
+        assert_relative_eq!(curve.total_variance(0.25), 0.01, epsilon = f64::EPSILON);
+        assert_relative_eq!(curve.total_variance(0.75), 0.035, epsilon = f64::EPSILON);
+        assert_relative_eq!(
+            curve.total_variance(1.5),
+            0.07,
+            epsilon = 2.0 * f64::EPSILON
+        );
+        assert_relative_eq!(
+            curve.total_variance(3.0),
+            0.13,
+            epsilon = 2.0 * f64::EPSILON
+        );
+
+        let fair_variance = curve.fair_forward_variance_swap(0.5, 1.5).unwrap();
+        assert_relative_eq!(fair_variance, 0.05, epsilon = 2.0 * f64::EPSILON);
+        assert_relative_eq!(
+            curve.fair_forward_vol_swap(0.5, 1.5).unwrap(),
+            0.05_f64.sqrt(),
+            epsilon = 2.0 * f64::EPSILON
+        );
+        assert_relative_eq!(
+            curve.forward_vol(0.5, 1.5).unwrap(),
+            0.05_f64.sqrt(),
+            epsilon = 2.0 * f64::EPSILON
+        );
+
+        let expected_pv = 1_000_000.0 * (0.05 - 0.04) * (-0.03_f64 * 1.5).exp();
+        assert_relative_eq!(
+            curve
+                .price_forward_variance_swap(0.5, 1.5, 0.04, 1_000_000.0, 0.03)
+                .unwrap(),
+            expected_pv,
+            epsilon = 8.0 * f64::EPSILON * expected_pv
+        );
+
+        let one_point = ForwardVarianceCurve::new(vec![(2.0, 0.08)]).unwrap();
+        assert_relative_eq!(one_point.total_variance(3.0), 0.12, epsilon = f64::EPSILON);
+
+        // A total-variance decrease within the constructor's numerical noise
+        // allowance is floored to a zero forward-variance interval.
+        let rounded = ForwardVarianceCurve::new(vec![(0.5, 0.02), (1.0, 0.02 - 1.0e-12)]).unwrap();
+        assert_eq!(rounded.points()[1].forward_variance, 0.0);
+        assert_eq!(rounded.forward_variance(0.5, 1.0).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn forward_variance_inputs_and_surface_data_are_validated() {
+        assert!(ForwardVarianceCurve::new(Vec::new()).is_err());
+        assert!(ForwardVarianceCurve::new(vec![(1.0, 0.02), (1.0, 0.03)]).is_err());
+        assert!(ForwardVarianceCurve::new(vec![(0.0, 0.02)]).is_err());
+        assert!(ForwardVarianceCurve::new(vec![(1.0, -0.02)]).is_err());
+        assert!(ForwardVarianceCurve::new(vec![(f64::NAN, 0.02)]).is_err());
+        assert!(ForwardVarianceCurve::new(vec![(1.0, 0.04), (2.0, 0.01)]).is_err());
+
+        let curve = ForwardVarianceCurve::new(vec![(1.0, 0.04)]).unwrap();
+        for (t1, t2) in [
+            (-1.0, 1.0),
+            (1.0, 1.0),
+            (f64::NAN, 1.0),
+            (0.0, f64::INFINITY),
+        ] {
+            assert!(curve.forward_variance(t1, t2).is_err());
+        }
+        for (strike, notional, rate) in [
+            (-0.01, 1.0, 0.0),
+            (f64::NAN, 1.0, 0.0),
+            (0.01, -1.0, 0.0),
+            (0.01, f64::INFINITY, 0.0),
+            (0.01, 1.0, f64::NAN),
+        ] {
+            assert!(
+                curve
+                    .price_forward_variance_swap(0.0, 1.0, strike, notional, rate)
+                    .is_err()
+            );
+        }
+
+        let valid = FlatSurface {
+            vol: 0.2,
+            expiries: vec![0.5, 1.0],
+            forward: 100.0,
+        };
+        assert!(ForwardVarianceCurve::from_surface(&valid, &[]).is_err());
+        assert!(ForwardVarianceCurve::from_surface(&valid, &[0.0]).is_err());
+        assert!(
+            ForwardVarianceCurve::from_surface(
+                &FlatSurface {
+                    forward: 0.0,
+                    ..valid.clone()
+                },
+                &[0.5]
+            )
+            .is_err()
+        );
+        assert!(
+            ForwardVarianceCurve::from_surface(&FlatSurface { vol: 0.0, ..valid }, &[0.5]).is_err()
+        );
+    }
+
+    #[test]
+    fn atm_skew_matches_log_moneyness_slope_and_interpolates() {
+        let surface = LogSmileSurface {
+            base_vol: 0.22,
+            log_moneyness_slope: -0.035,
+            expiries: vec![0.5, 1.0, 2.0],
+            forward: 100.0,
+        };
+        let skew = AtmSkewTermStructure::from_surface(&surface, &[2.0, 0.5, 1.0]).unwrap();
+        assert_eq!(
+            skew.points().iter().map(|p| p.expiry).collect::<Vec<_>>(),
+            vec![0.5, 1.0, 2.0]
+        );
+        for expiry in [0.1, 0.75, 3.0] {
+            assert_relative_eq!(skew.skew(expiry), -0.035, epsilon = 48.0 * f64::EPSILON);
+        }
+        assert!(skew.skew(f64::NAN).is_nan());
+
+        assert!(AtmSkewTermStructure::from_surface(&surface, &[]).is_err());
+        assert!(AtmSkewTermStructure::from_surface(&surface, &[0.0]).is_err());
+        assert!(AtmSkewTermStructure::from_surface(&surface, &[1.0, 1.0]).is_err());
+        assert!(
+            AtmSkewTermStructure::from_surface(
+                &LogSmileSurface {
+                    forward: 0.0,
+                    ..surface.clone()
+                },
+                &[1.0]
+            )
+            .is_err()
+        );
+        assert!(
+            AtmSkewTermStructure::from_surface(
+                &LogSmileSurface {
+                    base_vol: f64::NAN,
+                    ..surface
+                },
+                &[1.0]
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn heston_and_sabr_term_structures_sort_interpolate_and_validate() {
+        let heston = HestonVolOfVolTermStructure::new(vec![
+            HestonVolOfVolPoint {
+                expiry: 2.0,
+                sigma_v: 0.30,
+            },
+            HestonVolOfVolPoint {
+                expiry: 0.5,
+                sigma_v: 0.60,
+            },
+        ])
+        .unwrap();
+        assert_eq!(heston.points()[0].expiry, 0.5);
+        assert_relative_eq!(heston.sigma_v(1.25), 0.45, epsilon = f64::EPSILON);
+        assert_eq!(heston.sigma_v(0.0), 0.60);
+        assert_eq!(heston.sigma_v(3.0), 0.30);
+        assert!(heston.sigma_v(f64::NAN).is_nan());
+        assert_eq!(heston.sigma_v(f64::NEG_INFINITY), 0.60);
+        assert_eq!(heston.sigma_v(f64::INFINITY), 0.30);
+
+        assert!(HestonVolOfVolTermStructure::new(Vec::new()).is_err());
+        assert!(
+            HestonVolOfVolTermStructure::new(vec![
+                HestonVolOfVolPoint {
+                    expiry: 1.0,
+                    sigma_v: 0.2,
+                },
+                HestonVolOfVolPoint {
+                    expiry: 1.0,
+                    sigma_v: 0.3,
+                },
+            ])
+            .is_err()
+        );
+        for point in [
+            HestonVolOfVolPoint {
+                expiry: 0.0,
+                sigma_v: 0.2,
+            },
+            HestonVolOfVolPoint {
+                expiry: 1.0,
+                sigma_v: -0.2,
+            },
+            HestonVolOfVolPoint {
+                expiry: 1.0,
+                sigma_v: f64::NAN,
+            },
+        ] {
+            assert!(HestonVolOfVolTermStructure::new(vec![point]).is_err());
+        }
+
+        let params = [
+            (
+                2.0,
+                SabrParams {
+                    alpha: 0.16,
+                    beta: 0.5,
+                    rho: -0.2,
+                    nu: 0.40,
+                },
+            ),
+            (
+                0.5,
+                SabrParams {
+                    alpha: 0.20,
+                    beta: 0.7,
+                    rho: -0.1,
+                    nu: 0.60,
+                },
+            ),
+        ];
+        let sabr = SabrVolOfVolTermStructure::from_sabr_params(&params).unwrap();
+        assert_eq!(sabr.points()[0].expiry, 0.5);
+        assert_relative_eq!(sabr.alpha(1.25), 0.18, epsilon = f64::EPSILON);
+        assert_relative_eq!(sabr.nu(1.25), 0.50, epsilon = f64::EPSILON);
+        assert_eq!(sabr.alpha(0.0), 0.20);
+        assert_eq!(sabr.nu(3.0), 0.40);
+
+        assert!(SabrVolOfVolTermStructure::new(Vec::new()).is_err());
+        for point in [
+            SabrVolOfVolPoint {
+                expiry: 0.0,
+                alpha: 0.2,
+                nu: 0.4,
+            },
+            SabrVolOfVolPoint {
+                expiry: 1.0,
+                alpha: 0.0,
+                nu: 0.4,
+            },
+            SabrVolOfVolPoint {
+                expiry: 1.0,
+                alpha: 0.2,
+                nu: -0.4,
+            },
+        ] {
+            assert!(SabrVolOfVolTermStructure::new(vec![point]).is_err());
+        }
+        assert!(
+            SabrVolOfVolTermStructure::new(vec![
+                SabrVolOfVolPoint {
+                    expiry: 1.0,
+                    alpha: 0.2,
+                    nu: 0.4,
+                },
+                SabrVolOfVolPoint {
+                    expiry: 1.0,
+                    alpha: 0.3,
+                    nu: 0.5,
+                },
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vix_selects_boundary_expiries_and_rejects_invalid_surfaces() {
+        let surface = FlatSurface {
+            vol: 0.20,
+            expiries: vec![20.0 / 365.0, 45.0 / 365.0, 90.0 / 365.0],
+            forward: 100.0,
+        };
+        let compact_grid = |target_days| VixSettings {
+            target_days,
+            strike_count: 12,        // Normalized to the next odd count.
+            log_moneyness_span: 0.1, // Normalized to the minimum span.
+        };
+
+        let below = vix_style_index_from_surface(&surface, -0.01, compact_grid(1.0)).unwrap();
+        assert_eq!(below.near_expiry, 20.0 / 365.0);
+        assert_eq!(below.next_expiry, 45.0 / 365.0);
+        assert!(below.index.is_finite());
+
+        let above = vix_style_index_from_surface(&surface, 0.01, compact_grid(365.0)).unwrap();
+        assert_eq!(above.near_expiry, 45.0 / 365.0);
+        assert_eq!(above.next_expiry, 90.0 / 365.0);
+        assert!(above.target_variance >= 0.0);
+
+        assert!(vix_style_index_from_surface(&surface, f64::NAN, compact_grid(30.0)).is_err());
+        assert!(vix_style_index_from_surface(&surface, 0.0, compact_grid(0.0)).is_err());
+        assert!(
+            vix_style_index_from_surface(
+                &FlatSurface {
+                    expiries: vec![0.5],
+                    ..surface.clone()
+                },
+                0.0,
+                compact_grid(30.0)
+            )
+            .is_err()
+        );
+        assert!(
+            vix_style_index_from_surface(
+                &FlatSurface {
+                    expiries: vec![0.5, 0.0],
+                    ..surface.clone()
+                },
+                0.0,
+                compact_grid(30.0)
+            )
+            .is_err()
+        );
+        assert!(
+            vix_style_index_from_surface(
+                &FlatSurface {
+                    expiries: vec![1.0, 0.5],
+                    ..surface.clone()
+                },
+                0.0,
+                compact_grid(30.0)
+            )
+            .unwrap_err()
+            .contains("strictly increasing")
+        );
+        assert!(
+            vix_style_index_from_surface(
+                &FlatSurface {
+                    forward: 0.0,
+                    ..surface.clone()
+                },
+                0.0,
+                compact_grid(30.0)
+            )
+            .is_err()
+        );
+        assert!(
+            vix_style_index_from_surface(
+                &FlatSurface {
+                    vol: f64::NAN,
+                    ..surface
+                },
+                0.0,
+                compact_grid(30.0)
+            )
+            .unwrap_err()
+            .contains("non-finite implied vol")
+        );
     }
 }


### PR DESCRIPTION
## What changed

- Add 84 focused tests across 18 production modules covering DSL analysis and market adapters, interpolation and correlation, curves and volatility, FX, Monte Carlo and SIMD paths, commodity models, and instrument contracts.
- Replace broad behavioral checks with exact identities, deterministic recurrences, finite-difference references, or statistically justified sampling budgets where applicable.
- Force direct AVX2 coverage on AVX-512 hosts so runtime dispatch no longer hides those kernels from CI coverage.
- Exercise validation and edge behavior including non-finite inputs, empty data, expiry boundaries, payoff variants, and public trait bridges.

## Fixes exposed by the tests

- Reject non-finite scalar fields in exotic and basket instruments instead of allowing `Ok(NaN)` pricing paths.
- Handle empty yield curves without panicking and reject malformed volatility/forward inputs.
- Propagate NaN term-structure queries while preserving infinite endpoint extrapolation.
- Keep DSL schedule locals scoped correctly, resolve product declarations regardless of source order, and preserve completion context after trailing whitespace.
- Reject non-finite Nelson-Siegel decay parameters.

## Impact

This closes the largest practical coverage gaps identified by the repository audit while keeping assertions deterministic or tied to explicit numerical error models. The changes are independent of draft PR #196 and target `main` directly.

## Validation

- `cargo test --locked --workspace --all-features -q`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff origin/main...HEAD --check`

All local checks pass. The full workspace run completed with 988 passed library tests, one expected ignored benchmark, and all integration tests and doctests green.
