### PR TITLE
Cover wrapper, DSL, risk, and calibration gaps

### DIFF
--- a/src/calibration/core.rs
+++ b/src/calibration/core.rs
@@ -166,12 +166,10 @@ pub fn matrix_condition_number(jacobian: &DMatrix<f64>) -> f64 {
 
     for s in svd.singular_values.iter() {
         sigma_max = sigma_max.max(*s);
-        if *s > 1e-14 {
-            sigma_min = sigma_min.min(*s);
-        }
+        sigma_min = sigma_min.min(*s);
     }
 
-    if sigma_min.is_finite() && sigma_min > 0.0 {
+    if sigma_min.is_finite() && sigma_min > 1e-14 {
         sigma_max / sigma_min
     } else {
         f64::INFINITY
@@ -187,4 +185,71 @@ pub fn sanitize_convergence(mut c: ConvergenceInfo) -> ConvergenceInfo {
     c.gradient_norm = finite_metric(c.gradient_norm);
     c.step_norm = finite_metric(c.step_norm);
     c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn box_constraints_validate_clamp_and_detect_boundaries_exactly() {
+        for (lower, upper) in [
+            (vec![], vec![]),
+            (vec![0.0], vec![1.0, 2.0]),
+            (vec![f64::NAN], vec![1.0]),
+            (vec![0.0], vec![f64::INFINITY]),
+            (vec![2.0], vec![1.0]),
+        ] {
+            assert!(BoxConstraints::new(lower, upper).is_err());
+        }
+
+        let bounds = BoxConstraints::new(vec![-1.0, 2.0], vec![1.0, 4.0]).unwrap();
+        assert_eq!(bounds.dimension(), 2);
+        assert_eq!(bounds.clamp(&[-3.0, 3.0]), vec![-1.0, 3.0]);
+        assert!(bounds.hits_boundary(&[-1.0, 3.0], 0.0));
+        assert!(bounds.hits_boundary(&[0.0, 4.0 - 5.0e-7], 1.0e-6));
+        assert!(!bounds.hits_boundary(&[0.0, 3.0], 1.0e-6));
+    }
+
+    #[test]
+    fn matrix_helpers_match_exact_rectangular_and_singular_references() {
+        let matrix = DMatrix::from_row_slice(2, 3, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(
+            matrix_to_rows(&matrix),
+            vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]
+        );
+        assert!(matrix_to_rows(&DMatrix::<f64>::zeros(0, 3)).is_empty());
+
+        assert_eq!(matrix_condition_number(&DMatrix::zeros(0, 2)), 1.0);
+        let diagonal = DMatrix::from_diagonal(&nalgebra::DVector::from_vec(vec![4.0, 2.0]));
+        assert!((matrix_condition_number(&diagonal) - 2.0).abs() <= 8.0 * f64::EPSILON);
+
+        let rank_deficient = DMatrix::from_row_slice(2, 2, &[3.0, 0.0, 0.0, 0.0]);
+        assert!(matrix_condition_number(&rank_deficient).is_infinite());
+        assert!(matrix_condition_number(&DMatrix::zeros(2, 2)).is_infinite());
+    }
+
+    #[test]
+    fn finite_metrics_sanitize_nonfinite_optimizer_diagnostics() {
+        assert_eq!(finite_metric(1.25), 1.25);
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(finite_metric(value), f64::MAX);
+        }
+
+        let convergence = ConvergenceInfo {
+            iterations: 7,
+            objective_evaluations: 19,
+            gradient_norm: f64::NAN,
+            step_norm: f64::NEG_INFINITY,
+            converged: false,
+            reason: TerminationReason::NumericalFailure,
+        };
+        let sanitized = sanitize_convergence(convergence);
+        assert_eq!(sanitized.iterations, 7);
+        assert_eq!(sanitized.objective_evaluations, 19);
+        assert_eq!(sanitized.gradient_norm, f64::MAX);
+        assert_eq!(sanitized.step_norm, f64::MAX);
+        assert!(!sanitized.converged);
+        assert_eq!(sanitized.reason, TerminationReason::NumericalFailure);
+    }
 }

--- a/src/calibration/diagnostics.rs
+++ b/src/calibration/diagnostics.rs
@@ -129,3 +129,196 @@ pub fn diagnostics(
         warning_flags: flags,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calibration::core::TerminationReason;
+
+    fn error(id: &str, signed_error: f64, liquid: bool) -> InstrumentError {
+        InstrumentError {
+            id: id.to_string(),
+            market_mid: 0.2,
+            market_bid: None,
+            market_ask: None,
+            model: 0.2 + signed_error,
+            signed_error,
+            effective_error: signed_error,
+            abs_error: signed_error.abs(),
+            weight: 1.0,
+            within_bid_ask: false,
+            liquid,
+        }
+    }
+
+    fn convergence(converged: bool) -> ConvergenceInfo {
+        ConvergenceInfo {
+            iterations: 3,
+            objective_evaluations: 8,
+            gradient_norm: 1.0e-9,
+            step_norm: 2.0e-9,
+            converged,
+            reason: if converged {
+                TerminationReason::GradientTolerance
+            } else {
+                TerminationReason::MaxIterations
+            },
+        }
+    }
+
+    #[test]
+    fn fit_quality_matches_unweighted_population_metrics_and_liquid_subset() {
+        assert_eq!(
+            fit_quality(&[]),
+            FitQuality {
+                rmse: 0.0,
+                mae: 0.0,
+                max_abs_error: 0.0,
+                liquid_rmse: 0.0,
+            }
+        );
+
+        let errors = [error("liquid", 3.0, true), error("illiquid", -4.0, false)];
+        let fit = fit_quality(&errors);
+        assert_eq!(fit.rmse, 12.5_f64.sqrt());
+        assert_eq!(fit.mae, 3.5);
+        assert_eq!(fit.max_abs_error, 4.0);
+        assert_eq!(fit.liquid_rmse, 3.0);
+
+        let no_liquid = [error("a", 3.0, false), error("b", -4.0, false)];
+        assert_eq!(fit_quality(&no_liquid).liquid_rmse, 12.5_f64.sqrt());
+    }
+
+    #[test]
+    fn parameter_stability_uses_zero_base_floor_and_numeric_dimensions() {
+        let stable = parameter_stability(
+            vec!["zero".into(), "level".into()],
+            &[0.0, 2.0],
+            &[5.0e-19, 2.4],
+            0.25,
+        );
+        assert_eq!(stable.parameter_names, ["zero", "level"]);
+        for (actual, expected) in stable.relative_changes.iter().zip([5.0e-7_f64, 0.2_f64]) {
+            let roundoff = 4.0 * f64::EPSILON * expected.max(1.0);
+            assert!((actual - expected).abs() <= roundoff);
+        }
+        assert!((stable.max_relative_change - 0.2).abs() <= 4.0 * f64::EPSILON);
+        assert!(stable.stable);
+
+        let unstable = parameter_stability(vec!["x".into()], &[1.0], &[1.1], 0.05);
+        assert!(!unstable.stable);
+        assert!((unstable.max_relative_change - 0.1).abs() <= f64::EPSILON);
+
+        // Labels are diagnostic metadata: omitting one must not hide a
+        // material numeric change from the stability decision.
+        let missing_labels = parameter_stability(Vec::new(), &[1.0], &[2.0], 0.5);
+        assert!(missing_labels.parameter_names.is_empty());
+        assert_eq!(missing_labels.relative_changes, [1.0]);
+        assert_eq!(missing_labels.max_relative_change, 1.0);
+        assert!(!missing_labels.stable);
+
+        let empty = parameter_stability(Vec::new(), &[], &[], 0.0);
+        assert!(empty.parameter_names.is_empty());
+        assert!(empty.relative_changes.is_empty());
+        assert_eq!(empty.max_relative_change, 0.0);
+        assert!(empty.stable);
+    }
+
+    #[test]
+    fn warning_synthesis_covers_every_flag_and_threshold_boundary() {
+        let fit = FitQuality {
+            rmse: 0.006,
+            mae: 0.006,
+            max_abs_error: 0.006,
+            liquid_rmse: 0.006,
+        };
+        let bounds = BoxConstraints::new(vec![0.0], vec![1.0]).unwrap();
+        let unstable = ParameterStability {
+            parameter_names: vec!["x".into()],
+            relative_changes: vec![0.2],
+            max_relative_change: 0.2,
+            stable: false,
+        };
+        assert_eq!(
+            warning_flags(
+                &convergence(false),
+                f64::INFINITY,
+                &fit,
+                Some(&bounds),
+                Some(&[0.0]),
+                Some(&unstable),
+            ),
+            [
+                CalibrationWarningFlag::NonConvergent,
+                CalibrationWarningFlag::IllConditioned,
+                CalibrationWarningFlag::PoorFit,
+                CalibrationWarningFlag::HitBoundary,
+                CalibrationWarningFlag::UnstableParameters,
+            ]
+        );
+
+        let threshold_fit = FitQuality {
+            rmse: 0.005,
+            mae: 0.005,
+            max_abs_error: 0.005,
+            liquid_rmse: 0.005,
+        };
+        let stable = ParameterStability {
+            parameter_names: vec!["x".into()],
+            relative_changes: vec![0.0],
+            max_relative_change: 0.0,
+            stable: true,
+        };
+        assert!(
+            warning_flags(
+                &convergence(true),
+                1.0e8,
+                &threshold_fit,
+                Some(&bounds),
+                Some(&[0.5]),
+                Some(&stable),
+            )
+            .is_empty()
+        );
+        assert!(
+            warning_flags(
+                &convergence(true),
+                1.0,
+                &threshold_fit,
+                Some(&bounds),
+                None,
+                None,
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn diagnostics_aggregates_fit_stability_and_warning_flags() {
+        let bounds = BoxConstraints::new(vec![-1.0], vec![1.0]).unwrap();
+        let stability = ParameterStability {
+            parameter_names: vec!["rho".into()],
+            relative_changes: vec![0.3],
+            max_relative_change: 0.3,
+            stable: false,
+        };
+        let result = diagnostics(
+            &[error("q", 0.01, true)],
+            &convergence(false),
+            2.0,
+            Some(&bounds),
+            Some(&[0.0]),
+            Some(stability.clone()),
+        );
+        assert_eq!(result.fit_quality.rmse, 0.01);
+        assert_eq!(result.parameter_stability, Some(stability));
+        assert_eq!(
+            result.warning_flags,
+            [
+                CalibrationWarningFlag::NonConvergent,
+                CalibrationWarningFlag::PoorFit,
+                CalibrationWarningFlag::UnstableParameters,
+            ]
+        );
+    }
+}

--- a/src/calibration/hull_white.rs
+++ b/src/calibration/hull_white.rs
@@ -251,4 +251,121 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn helper_paths_decode_fallback_and_penalize_wrong_dimensions_exactly() {
+        assert!(HullWhiteCalibrationParams::from_slice(&[0.1]).is_none());
+        let params = HullWhiteCalibrationParams::from_slice(&[0.07, 0.012]).unwrap();
+        assert_eq!(params.to_vec(), vec![0.07, 0.012]);
+
+        let calibrator = HullWhiteCalibrator::default();
+        assert_eq!(calibrator.name(), "hull-white");
+        assert_eq!(calibrator.initial_guess(&[]), vec![0.05, 0.01]);
+
+        let quotes = [
+            SwaptionVolQuote::new("1x2", 1.0, 2.0, 0.01),
+            SwaptionVolQuote::new("2x5", 2.0, 5.0, 0.012),
+        ];
+        assert!(calibrator.model_vols(&[0.05], &quotes).is_none());
+        assert_eq!(calibrator.residuals(&[0.05], &quotes), vec![1.0e6; 2]);
+        assert_eq!(calibrator.objective(&[0.05], &quotes), 1.0e12);
+    }
+
+    #[test]
+    fn calibration_rejects_empty_and_malformed_quotes() {
+        let calibrator = HullWhiteCalibrator::default();
+        assert_eq!(
+            calibrator.calibrate(&[]).unwrap_err(),
+            "hull-white calibration requires non-empty instrument set"
+        );
+
+        let valid = SwaptionVolQuote::new("q", 1.0, 2.0, 0.01);
+        let invalid = [
+            SwaptionVolQuote {
+                expiry: 0.0,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                expiry: f64::NAN,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                tenor: 0.0,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                tenor: f64::INFINITY,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                market_vol: 0.0,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                market_vol: f64::NAN,
+                ..valid.clone()
+            },
+            SwaptionVolQuote {
+                market_vol: f64::INFINITY,
+                ..valid
+            },
+        ];
+        for quote in invalid {
+            assert_eq!(
+                calibrator.calibrate(&[quote]).unwrap_err(),
+                "invalid Hull-White swaption quote set"
+            );
+        }
+    }
+
+    #[test]
+    fn forced_nonconvergence_and_nelder_mead_fallback_improves_objective() {
+        let quotes = [
+            SwaptionVolQuote::new("1x1", 1.0, 1.0, 0.0103),
+            SwaptionVolQuote::new("2x5", 2.0, 5.0, 0.0074),
+            SwaptionVolQuote::new("5x10", 5.0, 10.0, 0.0041),
+        ];
+        let no_fallback = HullWhiteCalibrator {
+            lm_options: LmOptions {
+                max_iterations: 0,
+                ..LmOptions::default()
+            },
+            use_nelder_mead_fallback: false,
+            ..HullWhiteCalibrator::default()
+        };
+        let result = no_fallback.calibrate(&quotes).unwrap();
+        assert!(!result.convergence.converged);
+        assert_eq!(
+            result.convergence.reason,
+            crate::calibration::TerminationReason::MaxIterations
+        );
+        assert!(
+            result
+                .diagnostics
+                .warning_flags
+                .contains(&crate::calibration::CalibrationWarningFlag::NonConvergent)
+        );
+
+        let fallback = HullWhiteCalibrator {
+            lm_options: LmOptions {
+                max_iterations: 0,
+                ..LmOptions::default()
+            },
+            nm_options: NelderMeadOptions {
+                max_iterations: 80,
+                ..NelderMeadOptions::default()
+            },
+            use_nelder_mead_fallback: true,
+            ..HullWhiteCalibrator::default()
+        };
+        let fallback_result = fallback.calibrate(&quotes).unwrap();
+        assert!(!fallback_result.convergence.converged);
+        assert!(
+            fallback_result.objective < result.objective,
+            "Nelder-Mead fallback did not improve the forced-zero-iteration LM: baseline={}, fallback={}",
+            result.objective,
+            fallback_result.objective
+        );
+        assert_eq!(fallback_result.per_instrument_error.len(), quotes.len());
+    }
 }

--- a/src/calibration/sabr.rs
+++ b/src/calibration/sabr.rs
@@ -197,11 +197,23 @@ impl Calibrator<SabrCalibrationParams> for SabrCalibrator {
         if instruments.is_empty() {
             return Err("sabr calibration requires non-empty instrument set".to_string());
         }
-        if self.forward <= 0.0 || self.maturity <= 0.0 {
-            return Err("sabr forward and maturity must be > 0".to_string());
+        if !self.forward.is_finite()
+            || !self.maturity.is_finite()
+            || self.forward <= 0.0
+            || self.maturity <= 0.0
+        {
+            return Err("sabr forward and maturity must be finite and > 0".to_string());
+        }
+        if self
+            .beta_pin
+            .is_some_and(|beta| !beta.is_finite() || !(0.0..=1.0).contains(&beta))
+        {
+            return Err("sabr beta pin must be finite and in [0, 1]".to_string());
         }
         if instruments.iter().any(|q| {
-            q.strike <= 0.0
+            !q.strike.is_finite()
+                || !q.maturity.is_finite()
+                || q.strike <= 0.0
                 || q.market_vol <= 0.0
                 || !q.market_vol.is_finite()
                 || (q.maturity - self.maturity).abs() > 1e-12
@@ -349,6 +361,217 @@ mod tests {
         assert_eq!(
             result.per_instrument_error.len(),
             roundtrip.per_instrument_error.len()
+        );
+    }
+
+    #[test]
+    fn pinned_and_free_beta_helpers_cover_exact_parameter_layouts() {
+        let pinned = SabrCalibrator::default();
+        assert_eq!(pinned.name(), "sabr");
+        assert_eq!(pinned.bounds().dimension(), 3);
+        assert!(pinned.decode_params(&[0.2, -0.1]).is_none());
+        let pinned_params = pinned.decode_params(&[0.2, -0.1, 0.7]).unwrap();
+        assert_eq!(
+            pinned_params,
+            SabrCalibrationParams {
+                alpha: 0.2,
+                beta: 0.5,
+                rho: -0.1,
+                nu: 0.7,
+            }
+        );
+        assert_eq!(pinned.encode_params(pinned_params), vec![0.2, -0.1, 0.7]);
+
+        let free = SabrCalibrator {
+            beta_pin: None,
+            ..SabrCalibrator::default()
+        };
+        assert_eq!(free.bounds().dimension(), 4);
+        assert!(free.decode_params(&[0.2, 0.7, -0.1]).is_none());
+        let free_params = free.decode_params(&[0.2, 0.7, -0.1, 0.8]).unwrap();
+        assert_eq!(free.encode_params(free_params), vec![0.2, 0.7, -0.1, 0.8]);
+        assert_eq!(free.initial_guess(&[]), vec![2.0, 0.5, -0.2, 0.6]);
+
+        let quotes = [OptionVolQuote::new("atm", 100.0, 1.0, 0.2)];
+        assert!(free.model_vols(&[0.2, 0.7, -0.1], &quotes).is_none());
+        assert_eq!(free.residuals(&[0.2, 0.7, -0.1], &quotes), vec![1.0e6]);
+        assert_eq!(free.objective(&[0.2, 0.7, -0.1], &quotes), 5.0e11);
+
+        let model = free.model_vols(&[0.2, 0.7, -0.1, 0.8], &quotes).unwrap();
+        let oracle = SabrParams {
+            alpha: 0.2,
+            beta: 0.7,
+            rho: -0.1,
+            nu: 0.8,
+        }
+        .implied_vol(100.0, 100.0, 1.0);
+        assert_eq!(model, vec![oracle]);
+    }
+
+    #[test]
+    fn sabr_validation_rejects_nonfinite_domains_and_inconsistent_quotes() {
+        let default = SabrCalibrator::default();
+        assert_eq!(
+            default.calibrate(&[]).unwrap_err(),
+            "sabr calibration requires non-empty instrument set"
+        );
+        let quote = OptionVolQuote::new("q", 100.0, 1.0, 0.2);
+
+        for forward in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let calibrator = SabrCalibrator {
+                forward,
+                ..SabrCalibrator::default()
+            };
+            assert_eq!(
+                calibrator
+                    .calibrate(std::slice::from_ref(&quote))
+                    .unwrap_err(),
+                "sabr forward and maturity must be finite and > 0"
+            );
+        }
+        for maturity in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let calibrator = SabrCalibrator {
+                maturity,
+                ..SabrCalibrator::default()
+            };
+            assert_eq!(
+                calibrator
+                    .calibrate(std::slice::from_ref(&quote))
+                    .unwrap_err(),
+                "sabr forward and maturity must be finite and > 0"
+            );
+        }
+        for beta in [-0.1, 1.1, f64::NAN, f64::INFINITY] {
+            let calibrator = SabrCalibrator {
+                beta_pin: Some(beta),
+                ..SabrCalibrator::default()
+            };
+            assert_eq!(
+                calibrator
+                    .calibrate(std::slice::from_ref(&quote))
+                    .unwrap_err(),
+                "sabr beta pin must be finite and in [0, 1]"
+            );
+        }
+
+        let invalid_quotes = [
+            OptionVolQuote {
+                strike: 0.0,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                strike: f64::NAN,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                strike: f64::INFINITY,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                maturity: 2.0,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                maturity: f64::NAN,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                market_vol: 0.0,
+                ..quote.clone()
+            },
+            OptionVolQuote {
+                market_vol: f64::INFINITY,
+                ..quote
+            },
+        ];
+        for invalid in invalid_quotes {
+            assert_eq!(
+                default.calibrate(&[invalid]).unwrap_err(),
+                "invalid SABR quote set for configured expiry"
+            );
+        }
+    }
+
+    #[test]
+    fn global_search_and_nelder_mead_fallback_improve_free_beta_start() {
+        let true_params = SabrParams {
+            alpha: 0.25,
+            beta: 0.7,
+            rho: -0.2,
+            nu: 0.6,
+        };
+        let quotes: Vec<_> = [80.0, 90.0, 100.0, 110.0, 120.0]
+            .into_iter()
+            .map(|strike| {
+                OptionVolQuote::new(
+                    format!("k{strike:.0}"),
+                    strike,
+                    1.0,
+                    true_params.implied_vol(100.0, strike, 1.0),
+                )
+            })
+            .collect();
+
+        let baseline = SabrCalibrator {
+            beta_pin: None,
+            use_global_search: false,
+            use_nelder_mead_fallback: false,
+            lm_options: LmOptions {
+                max_iterations: 0,
+                ..LmOptions::default()
+            },
+            ..SabrCalibrator::default()
+        }
+        .calibrate(&quotes)
+        .unwrap();
+
+        let global = SabrCalibrator {
+            beta_pin: None,
+            use_global_search: true,
+            use_nelder_mead_fallback: false,
+            de_options: DifferentialEvolutionOptions {
+                max_generations: 24,
+                population_size: 16,
+                seed: 17,
+                ..DifferentialEvolutionOptions::default()
+            },
+            lm_options: LmOptions {
+                max_iterations: 0,
+                ..LmOptions::default()
+            },
+            ..SabrCalibrator::default()
+        };
+        let global_result = global.calibrate(&quotes).unwrap();
+        assert!(
+            global_result.objective < baseline.objective,
+            "differential evolution did not improve the free-beta heuristic: baseline={}, global={}",
+            baseline.objective,
+            global_result.objective
+        );
+        assert_eq!(global_result.per_instrument_error.len(), quotes.len());
+
+        let fallback = SabrCalibrator {
+            beta_pin: None,
+            lm_options: LmOptions {
+                max_iterations: 0,
+                ..LmOptions::default()
+            },
+            nm_options: NelderMeadOptions {
+                max_iterations: 120,
+                ..NelderMeadOptions::default()
+            },
+            use_global_search: false,
+            use_nelder_mead_fallback: true,
+            ..SabrCalibrator::default()
+        };
+        let fallback_result = fallback.calibrate(&quotes).unwrap();
+        assert!(!fallback_result.convergence.converged);
+        assert_eq!(fallback_result.per_instrument_error.len(), quotes.len());
+        assert!(
+            fallback_result.objective < baseline.objective,
+            "Nelder-Mead fallback did not improve the forced-zero-iteration LM: baseline={}, fallback={}",
+            baseline.objective,
+            fallback_result.objective
         );
     }
 }

--- a/src/dsl/error.rs
+++ b/src/dsl/error.rs
@@ -63,11 +63,204 @@ impl From<DslError> for PricingError {
 
 /// Annotates a DSL source string with line/column information for a given span.
 pub fn annotate_source(source: &str, span: Span) -> String {
-    let before = &source[..span.start.min(source.len())];
+    // Spans are byte offsets, but diagnostics are presented to people as
+    // character columns. Clamp externally supplied/deserialized spans and
+    // move an offset inside a multi-byte character back to its boundary so
+    // formatting an error can never panic.
+    let mut offset = span.start.min(source.len());
+    while !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    let before = &source[..offset];
     let line = before.chars().filter(|&c| c == '\n').count() + 1;
     let col = before
-        .rfind('\n')
-        .map_or(span.start, |nl| span.start - nl - 1)
-        + 1;
+        .rsplit('\n')
+        .next()
+        .map_or(1, |line| line.chars().count() + 1);
     format!("line {line}, col {col}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_constructor_and_serde_preserve_byte_range() {
+        let span = Span::new(7, 19);
+
+        assert_eq!(span.start, 7);
+        assert_eq!(span.end, 19);
+        assert_eq!(format!("{span:?}"), "Span { start: 7, end: 19 }");
+
+        let json = serde_json::to_string(&span).expect("Span should serialize");
+        assert_eq!(json, r#"{"start":7,"end":19}"#);
+        assert_eq!(
+            serde_json::from_str::<Span>(&json).expect("Span should deserialize"),
+            span
+        );
+    }
+
+    #[test]
+    fn dsl_error_display_locks_every_category_and_span_form() {
+        let cases = [
+            (
+                DslError::LexError {
+                    message: "unexpected `@`".into(),
+                    span: Span::new(4, 5),
+                },
+                "lex error at 4-5: unexpected `@`",
+            ),
+            (
+                DslError::ParseError {
+                    message: "expected maturity".into(),
+                    span: Span::new(10, 18),
+                },
+                "parse error at 10-18: expected maturity",
+            ),
+            (
+                DslError::CompileError {
+                    message: "undefined variable `coupon`".into(),
+                    span: Some(Span::new(31, 37)),
+                },
+                "compile error at 31-37: undefined variable `coupon`",
+            ),
+            (
+                DslError::CompileError {
+                    message: "missing notional".into(),
+                    span: None,
+                },
+                "compile error: missing notional",
+            ),
+            (
+                DslError::EvalError("asset path is empty".into()),
+                "eval error: asset path is empty",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn dsl_error_implements_std_error_without_a_source() {
+        fn as_std_error(error: &DslError) -> &(dyn std::error::Error + 'static) {
+            error
+        }
+
+        let error = DslError::EvalError("path evaluation failed".into());
+        assert_eq!(
+            as_std_error(&error).to_string(),
+            "eval error: path evaluation failed"
+        );
+        assert!(as_std_error(&error).source().is_none());
+    }
+
+    #[test]
+    fn every_dsl_error_category_converts_to_invalid_input_with_display_context() {
+        let cases = [
+            (
+                DslError::LexError {
+                    message: "bad character".into(),
+                    span: Span::new(1, 2),
+                },
+                "lex error at 1-2: bad character",
+            ),
+            (
+                DslError::ParseError {
+                    message: "bad grammar".into(),
+                    span: Span::new(3, 8),
+                },
+                "parse error at 3-8: bad grammar",
+            ),
+            (
+                DslError::CompileError {
+                    message: "bad type".into(),
+                    span: Some(Span::new(13, 17)),
+                },
+                "compile error at 13-17: bad type",
+            ),
+            (
+                DslError::CompileError {
+                    message: "global failure".into(),
+                    span: None,
+                },
+                "compile error: global failure",
+            ),
+            (
+                DslError::EvalError("non-finite path value".into()),
+                "eval error: non-finite path value",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let pricing_error = PricingError::from(error);
+            assert_eq!(
+                pricing_error,
+                PricingError::InvalidInput(expected.to_string())
+            );
+            assert_eq!(
+                pricing_error.to_string(),
+                format!("invalid input: {expected}")
+            );
+        }
+    }
+
+    #[test]
+    fn annotate_source_reports_one_based_ascii_line_and_column() {
+        let source = "product\n  maturity\n  pay";
+
+        assert_eq!(annotate_source(source, Span::new(0, 7)), "line 1, col 1");
+        assert_eq!(annotate_source(source, Span::new(7, 7)), "line 1, col 8");
+        assert_eq!(annotate_source(source, Span::new(8, 10)), "line 2, col 1");
+        assert_eq!(annotate_source(source, Span::new(12, 20)), "line 2, col 5");
+        assert_eq!(annotate_source(source, Span::new(21, 24)), "line 3, col 3");
+    }
+
+    #[test]
+    fn annotate_source_counts_unicode_characters_not_utf8_bytes() {
+        let source = "προduct\n  βeta";
+        let beta = source.find('β').expect("test fixture contains beta");
+        let eta = source.find("eta").expect("test fixture contains eta");
+
+        assert_eq!(
+            annotate_source(source, Span::new(beta, beta + 2)),
+            "line 2, col 3"
+        );
+        assert_eq!(
+            annotate_source(source, Span::new(eta, eta + 3)),
+            "line 2, col 4"
+        );
+    }
+
+    #[test]
+    fn annotate_source_clamps_out_of_range_and_non_boundary_offsets() {
+        let source = "α\nβ";
+        let inside_alpha = 1;
+
+        assert_eq!(
+            annotate_source(source, Span::new(inside_alpha, usize::MAX)),
+            "line 1, col 1"
+        );
+        assert_eq!(
+            annotate_source(source, Span::new(usize::MAX, usize::MAX)),
+            "line 2, col 2"
+        );
+        assert_eq!(annotate_source("", Span::new(99, 0)), "line 1, col 1");
+    }
+
+    #[test]
+    fn annotate_source_handles_crlf_and_ignores_span_end() {
+        let source = "first\r\nsecond";
+        let second = source.find("second").expect("test fixture contains second");
+
+        assert_eq!(
+            annotate_source(source, Span::new(second, second)),
+            "line 2, col 1"
+        );
+        assert_eq!(
+            annotate_source(source, Span::new(second + 3, 0)),
+            "line 2, col 4"
+        );
+    }
 }

--- a/src/instruments/power.rs
+++ b/src/instruments/power.rs
@@ -71,3 +71,82 @@ impl Instrument for PowerOption {
         "PowerOption"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_invalid(option: &PowerOption, message: &str) {
+        assert_eq!(
+            option.validate(),
+            Err(PricingError::InvalidInput(message.to_string()))
+        );
+    }
+
+    #[test]
+    fn constructors_preserve_terms_and_option_side_through_serialization() {
+        let call = PowerOption::call(10_000.0, 2.0, 0.5);
+        let put = PowerOption::put(85.0, 0.75, 2.25);
+
+        assert_eq!(call, PowerOption::new(OptionType::Call, 10_000.0, 2.0, 0.5));
+        assert_eq!(put, PowerOption::new(OptionType::Put, 85.0, 0.75, 2.25));
+        assert_eq!(call.instrument_type(), "PowerOption");
+        assert_eq!(put.instrument_type(), "PowerOption");
+        assert_eq!(call.validate(), Ok(()));
+        assert_eq!(put.validate(), Ok(()));
+
+        for (option, serialized_side) in [(call, "Call"), (put, "Put")] {
+            let value = serde_json::to_value(&option).expect("serialize power option");
+            assert_eq!(value["option_type"], serialized_side);
+            assert_eq!(value["strike"], option.strike);
+            assert_eq!(value["alpha"], option.alpha);
+            assert_eq!(value["expiry"], option.expiry);
+            assert_eq!(
+                serde_json::from_value::<PowerOption>(value).expect("deserialize power option"),
+                option
+            );
+        }
+    }
+
+    #[test]
+    fn validation_accepts_exact_boundary_values() {
+        let option = PowerOption::call(f64::MIN_POSITIVE, f64::MIN_POSITIVE, 0.0);
+        assert_eq!(option.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validation_rejects_non_finite_and_out_of_domain_fields() {
+        const STRIKE_ERROR: &str = "power option strike must be finite and > 0";
+        const ALPHA_ERROR: &str = "power option alpha must be finite and > 0";
+        const EXPIRY_ERROR: &str = "power option expiry must be finite and >= 0";
+        let base = PowerOption::put(100.0, 1.5, 1.0);
+
+        for strike in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert_invalid(
+                &PowerOption {
+                    strike,
+                    ..base.clone()
+                },
+                STRIKE_ERROR,
+            );
+        }
+        for alpha in [0.0, -1.0, f64::NAN, f64::NEG_INFINITY] {
+            assert_invalid(
+                &PowerOption {
+                    alpha,
+                    ..base.clone()
+                },
+                ALPHA_ERROR,
+            );
+        }
+        for expiry in [-f64::EPSILON, f64::NAN, f64::INFINITY] {
+            assert_invalid(
+                &PowerOption {
+                    expiry,
+                    ..base.clone()
+                },
+                EXPIRY_ERROR,
+            );
+        }
+    }
+}

--- a/src/instruments/rainbow.rs
+++ b/src/instruments/rainbow.rs
@@ -19,24 +19,33 @@ fn validate_common(
     rho: f64,
     t: f64,
 ) -> Result<(), PricingError> {
-    if s1 <= 0.0 || s2 <= 0.0 {
+    if !s1.is_finite() || !s2.is_finite() || s1 <= 0.0 || s2 <= 0.0 {
         return Err(PricingError::InvalidInput(
-            "rainbow spots s1 and s2 must be > 0".to_string(),
+            "rainbow spots s1 and s2 must be finite and > 0".to_string(),
         ));
     }
-    if vol1 <= 0.0 || vol2 <= 0.0 {
+    if !vol1.is_finite() || !vol2.is_finite() || vol1 <= 0.0 || vol2 <= 0.0 {
         return Err(PricingError::InvalidInput(
-            "rainbow volatilities vol1 and vol2 must be > 0".to_string(),
+            "rainbow volatilities vol1 and vol2 must be finite and > 0".to_string(),
         ));
     }
-    if !(-1.0..=1.0).contains(&rho) {
+    if !rho.is_finite() || !(-1.0..=1.0).contains(&rho) {
         return Err(PricingError::InvalidInput(
-            "rainbow correlation rho must be in [-1, 1]".to_string(),
+            "rainbow correlation rho must be finite and in [-1, 1]".to_string(),
         ));
     }
-    if t < 0.0 {
+    if !t.is_finite() || t < 0.0 {
         return Err(PricingError::InvalidInput(
-            "rainbow maturity t must be >= 0".to_string(),
+            "rainbow maturity t must be finite and >= 0".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_rates(q1: f64, q2: f64, r: f64) -> Result<(), PricingError> {
+    if !q1.is_finite() || !q2.is_finite() || !r.is_finite() {
+        return Err(PricingError::InvalidInput(
+            "rainbow rates q1, q2, and r must be finite".to_string(),
         ));
     }
     Ok(())
@@ -60,12 +69,13 @@ pub struct BestOfTwoCallOption {
 impl BestOfTwoCallOption {
     /// Validates option fields.
     pub fn validate(&self) -> Result<(), PricingError> {
-        if self.k < 0.0 {
+        if !self.k.is_finite() || self.k < 0.0 {
             return Err(PricingError::InvalidInput(
-                "best-of strike k must be >= 0".to_string(),
+                "best-of strike k must be finite and >= 0".to_string(),
             ));
         }
-        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)
+        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)?;
+        validate_rates(self.q1, self.q2, self.r)
     }
 }
 
@@ -93,12 +103,13 @@ pub struct WorstOfTwoCallOption {
 impl WorstOfTwoCallOption {
     /// Validates option fields.
     pub fn validate(&self) -> Result<(), PricingError> {
-        if self.k < 0.0 {
+        if !self.k.is_finite() || self.k < 0.0 {
             return Err(PricingError::InvalidInput(
-                "worst-of strike k must be >= 0".to_string(),
+                "worst-of strike k must be finite and >= 0".to_string(),
             ));
         }
-        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)
+        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)?;
+        validate_rates(self.q1, self.q2, self.r)
     }
 }
 
@@ -131,17 +142,282 @@ pub struct TwoAssetCorrelationOption {
 impl TwoAssetCorrelationOption {
     /// Validates option fields.
     pub fn validate(&self) -> Result<(), PricingError> {
-        if self.k1 <= 0.0 || self.k2 <= 0.0 {
+        if !self.k1.is_finite() || !self.k2.is_finite() || self.k1 <= 0.0 || self.k2 <= 0.0 {
             return Err(PricingError::InvalidInput(
-                "correlation option strikes k1 and k2 must be > 0".to_string(),
+                "correlation option strikes k1 and k2 must be finite and > 0".to_string(),
             ));
         }
-        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)
+        validate_common(self.s1, self.s2, self.vol1, self.vol2, self.rho, self.t)?;
+        validate_rates(self.q1, self.q2, self.r)
     }
 }
 
 impl Instrument for TwoAssetCorrelationOption {
     fn instrument_type(&self) -> &str {
         "TwoAssetCorrelationOption"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn best_of() -> BestOfTwoCallOption {
+        BestOfTwoCallOption {
+            s1: 100.0,
+            s2: 95.0,
+            k: 100.0,
+            vol1: 0.20,
+            vol2: 0.25,
+            rho: 0.30,
+            q1: 0.01,
+            q2: 0.02,
+            r: 0.04,
+            t: 1.5,
+        }
+    }
+
+    fn worst_of() -> WorstOfTwoCallOption {
+        let option = best_of();
+        WorstOfTwoCallOption {
+            s1: option.s1,
+            s2: option.s2,
+            k: option.k,
+            vol1: option.vol1,
+            vol2: option.vol2,
+            rho: option.rho,
+            q1: option.q1,
+            q2: option.q2,
+            r: option.r,
+            t: option.t,
+        }
+    }
+
+    fn correlation(option_type: OptionType) -> TwoAssetCorrelationOption {
+        let option = best_of();
+        TwoAssetCorrelationOption {
+            option_type,
+            s1: option.s1,
+            s2: option.s2,
+            k1: 100.0,
+            k2: 90.0,
+            vol1: option.vol1,
+            vol2: option.vol2,
+            rho: option.rho,
+            q1: option.q1,
+            q2: option.q2,
+            r: option.r,
+            t: option.t,
+        }
+    }
+
+    fn assert_invalid(result: Result<(), PricingError>, message: &str) {
+        assert_eq!(result, Err(PricingError::InvalidInput(message.to_string())));
+    }
+
+    #[test]
+    fn rainbow_contracts_accept_boundary_terms_and_report_stable_types() {
+        let best = BestOfTwoCallOption {
+            k: 0.0,
+            rho: -1.0,
+            q1: -0.01,
+            r: -0.04,
+            t: 0.0,
+            ..best_of()
+        };
+        let worst = WorstOfTwoCallOption {
+            k: 0.0,
+            rho: 1.0,
+            q2: -0.02,
+            t: 0.0,
+            ..worst_of()
+        };
+        let call = correlation(OptionType::Call);
+        let put = correlation(OptionType::Put);
+
+        assert_eq!(best.validate(), Ok(()));
+        assert_eq!(worst.validate(), Ok(()));
+        assert_eq!(call.validate(), Ok(()));
+        assert_eq!(put.validate(), Ok(()));
+        assert_eq!(best.instrument_type(), "BestOfTwoCallOption");
+        assert_eq!(worst.instrument_type(), "WorstOfTwoCallOption");
+        assert_eq!(call.instrument_type(), "TwoAssetCorrelationOption");
+
+        for (option, serialized_side) in [(call, "Call"), (put, "Put")] {
+            let value = serde_json::to_value(option).expect("serialize correlation option");
+            assert_eq!(value["option_type"], serialized_side);
+            assert_eq!(
+                serde_json::from_value::<TwoAssetCorrelationOption>(value)
+                    .expect("deserialize correlation option"),
+                option
+            );
+        }
+    }
+
+    #[test]
+    fn rainbow_common_validation_rejects_every_non_finite_or_out_of_domain_field() {
+        const SPOT_ERROR: &str = "rainbow spots s1 and s2 must be finite and > 0";
+        const VOL_ERROR: &str = "rainbow volatilities vol1 and vol2 must be finite and > 0";
+        const RHO_ERROR: &str = "rainbow correlation rho must be finite and in [-1, 1]";
+        const MATURITY_ERROR: &str = "rainbow maturity t must be finite and >= 0";
+        const RATE_ERROR: &str = "rainbow rates q1, q2, and r must be finite";
+
+        for (option, message) in [
+            (
+                BestOfTwoCallOption {
+                    s1: f64::NAN,
+                    ..best_of()
+                },
+                SPOT_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    s2: f64::INFINITY,
+                    ..best_of()
+                },
+                SPOT_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    s1: 0.0,
+                    ..best_of()
+                },
+                SPOT_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    s2: 0.0,
+                    ..best_of()
+                },
+                SPOT_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    vol1: f64::NAN,
+                    ..best_of()
+                },
+                VOL_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    vol2: f64::INFINITY,
+                    ..best_of()
+                },
+                VOL_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    vol2: 0.0,
+                    ..best_of()
+                },
+                VOL_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    vol1: 0.0,
+                    ..best_of()
+                },
+                VOL_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    rho: f64::NAN,
+                    ..best_of()
+                },
+                RHO_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    rho: 1.000_000_000_1,
+                    ..best_of()
+                },
+                RHO_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    t: f64::NAN,
+                    ..best_of()
+                },
+                MATURITY_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    t: -f64::EPSILON,
+                    ..best_of()
+                },
+                MATURITY_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    q1: f64::NAN,
+                    ..best_of()
+                },
+                RATE_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    q2: f64::NEG_INFINITY,
+                    ..best_of()
+                },
+                RATE_ERROR,
+            ),
+            (
+                BestOfTwoCallOption {
+                    r: f64::INFINITY,
+                    ..best_of()
+                },
+                RATE_ERROR,
+            ),
+        ] {
+            assert_invalid(option.validate(), message);
+        }
+    }
+
+    #[test]
+    fn rainbow_strike_validation_covers_each_contract_shape() {
+        const BEST_ERROR: &str = "best-of strike k must be finite and >= 0";
+        const WORST_ERROR: &str = "worst-of strike k must be finite and >= 0";
+        const CORRELATION_ERROR: &str =
+            "correlation option strikes k1 and k2 must be finite and > 0";
+
+        for strike in [-f64::EPSILON, f64::NAN, f64::INFINITY] {
+            assert_invalid(
+                BestOfTwoCallOption {
+                    k: strike,
+                    ..best_of()
+                }
+                .validate(),
+                BEST_ERROR,
+            );
+            assert_invalid(
+                WorstOfTwoCallOption {
+                    k: strike,
+                    ..worst_of()
+                }
+                .validate(),
+                WORST_ERROR,
+            );
+        }
+
+        for option in [
+            TwoAssetCorrelationOption {
+                k1: 0.0,
+                ..correlation(OptionType::Call)
+            },
+            TwoAssetCorrelationOption {
+                k2: -f64::EPSILON,
+                ..correlation(OptionType::Call)
+            },
+            TwoAssetCorrelationOption {
+                k1: f64::NAN,
+                ..correlation(OptionType::Put)
+            },
+            TwoAssetCorrelationOption {
+                k2: f64::INFINITY,
+                ..correlation(OptionType::Put)
+            },
+        ] {
+            assert_invalid(option.validate(), CORRELATION_ERROR);
+        }
     }
 }

--- a/src/instruments/swing.rs
+++ b/src/instruments/swing.rs
@@ -75,6 +75,11 @@ impl SwingOption {
                 "swing exercise_dates must be finite and > 0".to_string(),
             ));
         }
+        if self.exercise_dates.windows(2).any(|w| w[1] <= w[0]) {
+            return Err(PricingError::InvalidInput(
+                "swing exercise_dates must be strictly increasing".to_string(),
+            ));
+        }
         if !self.strike.is_finite() || self.strike <= 0.0 {
             return Err(PricingError::InvalidInput(
                 "swing strike must be finite and > 0".to_string(),
@@ -93,5 +98,133 @@ impl SwingOption {
 impl Instrument for SwingOption {
     fn instrument_type(&self) -> &str {
         "SwingOption"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn option() -> SwingOption {
+        SwingOption::new(1, 2, vec![0.25, 0.50, 1.0], 100.0, 10.0)
+    }
+
+    fn assert_invalid(option: &SwingOption, message: &str) {
+        assert_eq!(
+            option.validate(),
+            Err(PricingError::InvalidInput(message.to_string()))
+        );
+    }
+
+    #[test]
+    fn constructor_preserves_terms_and_serialization_shape() {
+        let swing = option();
+        assert_eq!(swing.min_exercises, 1);
+        assert_eq!(swing.max_exercises, 2);
+        assert_eq!(swing.exercise_dates, vec![0.25, 0.50, 1.0]);
+        assert_eq!(swing.strike, 100.0);
+        assert_eq!(swing.payoff_per_exercise, 10.0);
+        assert_eq!(swing.validate(), Ok(()));
+        assert_eq!(swing.instrument_type(), "SwingOption");
+
+        let value = serde_json::to_value(&swing).expect("serialize swing option");
+        assert_eq!(value["min_exercises"], 1);
+        assert_eq!(value["max_exercises"], 2);
+        assert_eq!(value["exercise_dates"], serde_json::json!([0.25, 0.5, 1.0]));
+        assert_eq!(value["strike"], 100.0);
+        assert_eq!(value["payoff_per_exercise"], 10.0);
+        assert_eq!(
+            serde_json::from_value::<SwingOption>(value).expect("deserialize swing option"),
+            swing
+        );
+    }
+
+    #[test]
+    fn validation_accepts_optional_minimum_and_zero_payoff_boundaries() {
+        let swing = SwingOption::new(0, 3, vec![0.25, 0.50, 1.0], 0.01, 0.0);
+        assert_eq!(swing.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validation_rejects_invalid_rights_and_schedule_shape() {
+        const EMPTY_ERROR: &str = "swing exercise_dates cannot be empty";
+        const MAX_ZERO_ERROR: &str = "swing max_exercises must be > 0";
+        const MIN_MAX_ERROR: &str = "swing min_exercises must be <= max_exercises";
+        const TOO_MANY_ERROR: &str = "swing max_exercises cannot exceed number of exercise_dates";
+        const DATE_ERROR: &str = "swing exercise_dates must be finite and > 0";
+        const ORDER_ERROR: &str = "swing exercise_dates must be strictly increasing";
+
+        assert_invalid(
+            &SwingOption {
+                exercise_dates: vec![],
+                ..option()
+            },
+            EMPTY_ERROR,
+        );
+        assert_invalid(
+            &SwingOption {
+                min_exercises: 0,
+                max_exercises: 0,
+                ..option()
+            },
+            MAX_ZERO_ERROR,
+        );
+        assert_invalid(
+            &SwingOption {
+                min_exercises: 3,
+                max_exercises: 2,
+                ..option()
+            },
+            MIN_MAX_ERROR,
+        );
+        assert_invalid(
+            &SwingOption {
+                max_exercises: 4,
+                ..option()
+            },
+            TOO_MANY_ERROR,
+        );
+
+        for exercise_dates in [
+            vec![0.0, 0.5, 1.0],
+            vec![0.25, f64::NAN, 1.0],
+            vec![0.25, 0.5, f64::INFINITY],
+        ] {
+            assert_invalid(
+                &SwingOption {
+                    exercise_dates,
+                    ..option()
+                },
+                DATE_ERROR,
+            );
+        }
+        for exercise_dates in [vec![0.25, 0.25, 1.0], vec![0.50, 0.25, 1.0]] {
+            assert_invalid(
+                &SwingOption {
+                    exercise_dates,
+                    ..option()
+                },
+                ORDER_ERROR,
+            );
+        }
+    }
+
+    #[test]
+    fn validation_rejects_invalid_strike_and_payoff() {
+        const STRIKE_ERROR: &str = "swing strike must be finite and > 0";
+        const PAYOFF_ERROR: &str = "swing payoff_per_exercise must be finite and >= 0";
+
+        for strike in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert_invalid(&SwingOption { strike, ..option() }, STRIKE_ERROR);
+        }
+        for payoff_per_exercise in [-f64::EPSILON, f64::NAN, f64::INFINITY] {
+            assert_invalid(
+                &SwingOption {
+                    payoff_per_exercise,
+                    ..option()
+                },
+                PAYOFF_ERROR,
+            );
+        }
     }
 }

--- a/src/risk/liquidation.rs
+++ b/src/risk/liquidation.rs
@@ -99,6 +99,7 @@ impl LiquidationSimulator {
         seed: u64,
     ) -> Self {
         validate_position(&position);
+        validate_model(model);
         assert!(
             initial_funding_rate.is_finite(),
             "initial_funding_rate must be finite"
@@ -129,10 +130,21 @@ impl LiquidationSimulator {
 
     /// Estimates liquidation risk under a single stress scenario.
     pub fn simulate_stress(&self, scenario: StressScenario) -> LiquidationRisk {
+        // The simulator fields are public, so repeat constructor invariants at
+        // the calculation boundary after callers may have mutated them.
+        assert!(self.num_paths > 0, "num_paths must be > 0");
+        assert!(self.steps > 0, "steps must be > 0");
+        validate_stress_scenario(scenario);
         let position = stressed_position(self.position, scenario);
+        validate_position(&position);
         let model = self.model.stressed(scenario);
-        let initial_rate =
-            model.normalize_rate(stressed_initial_rate(self.initial_funding_rate, scenario));
+        validate_model(model);
+        let stressed_initial_rate = stressed_initial_rate(self.initial_funding_rate, scenario);
+        assert!(
+            stressed_initial_rate.is_finite(),
+            "stressed initial funding rate must be finite"
+        );
+        let initial_rate = model.normalize_rate(stressed_initial_rate);
         let total_time = position.margin_params.time_to_maturity;
 
         let initial_health = health_at_rate(position, initial_rate, total_time);
@@ -331,6 +343,49 @@ fn validate_position(position: &LiquidationPosition) {
     let _ = MarginCalculator::initial_margin(position.size.abs(), &position.margin_params);
 }
 
+fn validate_model(model: FundingRateModel) {
+    match model {
+        FundingRateModel::Vasicek(model) => {
+            assert!(
+                model.a.is_finite() && model.a >= 0.0,
+                "Vasicek mean reversion must be finite and >= 0"
+            );
+            assert!(model.b.is_finite(), "Vasicek mean rate must be finite");
+            assert!(
+                model.sigma.is_finite() && model.sigma >= 0.0,
+                "Vasicek volatility must be finite and >= 0"
+            );
+        }
+        FundingRateModel::CIR(model) => {
+            assert!(
+                model.a.is_finite() && model.a >= 0.0,
+                "CIR mean reversion must be finite and >= 0"
+            );
+            assert!(
+                model.b.is_finite() && model.b >= 0.0,
+                "CIR mean rate must be finite and >= 0"
+            );
+            assert!(
+                model.sigma.is_finite() && model.sigma >= 0.0,
+                "CIR volatility must be finite and >= 0"
+            );
+        }
+    }
+}
+
+fn validate_stress_scenario(scenario: StressScenario) {
+    match scenario {
+        StressScenario::Baseline => {}
+        StressScenario::LiquidationCascade { vol_multiplier } => assert!(
+            vol_multiplier.is_finite() && vol_multiplier >= 0.0,
+            "cascade volatility multiplier must be finite and >= 0"
+        ),
+        StressScenario::MeanShift { shift } => {
+            assert!(shift.is_finite(), "mean shift must be finite")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -470,5 +525,376 @@ mod tests {
             0.087_500_000_000_000_01,
             "deterministic CIR adverse rate",
         );
+    }
+
+    #[test]
+    fn stress_suite_constructors_and_batch_dispatch_preserve_scenario_order() {
+        assert_eq!(
+            StressScenario::cascade_suite(),
+            vec![
+                StressScenario::LiquidationCascade {
+                    vol_multiplier: 3.0
+                },
+                StressScenario::LiquidationCascade {
+                    vol_multiplier: 5.0
+                },
+                StressScenario::LiquidationCascade {
+                    vol_multiplier: 10.0
+                },
+            ]
+        );
+        assert_eq!(
+            StressScenario::mean_shift_suite(0.02),
+            vec![
+                StressScenario::MeanShift { shift: 0.02 },
+                StressScenario::MeanShift { shift: -0.02 },
+            ]
+        );
+
+        let simulator = LiquidationSimulator::new(
+            LiquidationPosition {
+                size: 100.0,
+                entry_rate: 0.05,
+                collateral: 20.0,
+                margin_params: margin_params(),
+            },
+            FundingRateModel::Vasicek(Vasicek {
+                a: 1.0,
+                b: 0.05,
+                sigma: 0.0,
+            }),
+            0.05,
+            3,
+            4,
+            11,
+        );
+        let scenarios = [
+            StressScenario::Baseline,
+            StressScenario::MeanShift { shift: 0.02 },
+            StressScenario::LiquidationCascade {
+                vol_multiplier: 0.0,
+            },
+        ];
+        let results = simulator.run_stress_scenarios(&scenarios);
+
+        assert_eq!(results.len(), scenarios.len());
+        for (result, scenario) in results.iter().zip(scenarios) {
+            assert_eq!(result.scenario, scenario);
+            assert_eq!(result.risk.prob_liquidation, 0.0);
+            assert_eq!(result.risk.expected_time_to_liquidation, None);
+        }
+        assert_roundoff(
+            results[0].risk.worst_case_funding_rate,
+            0.05,
+            "baseline adverse rate",
+        );
+        assert_roundoff(
+            results[1].risk.worst_case_funding_rate,
+            0.07,
+            "mean-shift adverse rate",
+        );
+        assert_roundoff(
+            results[2].risk.worst_case_funding_rate,
+            0.05,
+            "zero-cascade adverse rate",
+        );
+    }
+
+    #[test]
+    fn zero_vol_vasicek_and_short_cir_paths_lock_both_adverse_directions() {
+        let vasicek = LiquidationSimulator::new(
+            LiquidationPosition {
+                size: 100.0,
+                entry_rate: 0.05,
+                collateral: 20.0,
+                margin_params: margin_params(),
+            },
+            FundingRateModel::Vasicek(Vasicek {
+                a: 0.0,
+                b: 0.25,
+                sigma: 0.0,
+            }),
+            0.05,
+            2,
+            4,
+            9,
+        )
+        .with_rng_kind(FastRngKind::Pcg64);
+        assert_eq!(vasicek.rng_kind, FastRngKind::Pcg64);
+        let vasicek_risk = vasicek.simulate();
+        assert_eq!(vasicek_risk.prob_liquidation, 0.0);
+        assert_eq!(vasicek_risk.expected_time_to_liquidation, None);
+        assert_roundoff(
+            vasicek_risk.worst_case_funding_rate,
+            0.05,
+            "zero-vol Vasicek adverse rate",
+        );
+
+        // With dt=1/4 and zero CIR volatility, r_{n+1}=0.75*r_n.
+        // A short position is harmed by falling rates, so the adverse extreme
+        // after all four steps is 0.2*(3/4)^4 = 0.06328125.
+        let short_cir = LiquidationSimulator::new(
+            LiquidationPosition {
+                size: -100.0,
+                entry_rate: 0.20,
+                collateral: 100.0,
+                margin_params: margin_params(),
+            },
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: 0.0,
+                sigma: 0.0,
+            }),
+            0.20,
+            2,
+            4,
+            10,
+        );
+        let short_cir_risk = short_cir.simulate();
+        assert_eq!(short_cir_risk.prob_liquidation, 0.0);
+        assert_eq!(short_cir_risk.expected_time_to_liquidation, None);
+        assert_roundoff(
+            short_cir_risk.worst_case_funding_rate,
+            0.063_281_250_000_000_01,
+            "zero-vol short CIR adverse rate",
+        );
+    }
+
+    #[test]
+    fn expired_position_and_cir_mean_shift_use_normalized_initial_state() {
+        let mut expired_params = margin_params();
+        expired_params.time_to_maturity = 0.0;
+        let simulator = LiquidationSimulator::new(
+            LiquidationPosition {
+                size: 100.0,
+                entry_rate: 0.05,
+                collateral: 1.0,
+                margin_params: expired_params,
+            },
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: 0.01,
+                sigma: 0.0,
+            }),
+            -0.01,
+            1,
+            1,
+            0,
+        );
+        assert_eq!(
+            simulator.simulate_stress(StressScenario::MeanShift { shift: -0.02 }),
+            LiquidationRisk {
+                prob_liquidation: 0.0,
+                expected_time_to_liquidation: None,
+                worst_case_funding_rate: 0.0,
+            }
+        );
+    }
+
+    #[test]
+    fn cascade_and_mean_shift_transform_models_and_margin_terms_exactly() {
+        let cascade = StressScenario::LiquidationCascade {
+            vol_multiplier: 2.5,
+        };
+        let position = LiquidationPosition {
+            size: 100.0,
+            entry_rate: 0.05,
+            collateral: 20.0,
+            margin_params: margin_params(),
+        };
+        let stressed = stressed_position(position, cascade);
+        assert_roundoff(
+            stressed.margin_params.funding_rate_vol,
+            0.5,
+            "cascade margin volatility",
+        );
+
+        let stressed_vasicek = FundingRateModel::Vasicek(Vasicek {
+            a: 1.0,
+            b: 0.05,
+            sigma: 0.08,
+        })
+        .stressed(cascade);
+        let FundingRateModel::Vasicek(stressed_vasicek) = stressed_vasicek else {
+            panic!("cascade must preserve the Vasicek model variant")
+        };
+        assert_eq!(stressed_vasicek.a, 1.0);
+        assert_eq!(stressed_vasicek.b, 0.05);
+        assert_roundoff(stressed_vasicek.sigma, 0.20, "Vasicek cascade sigma");
+
+        let stressed_cir = FundingRateModel::CIR(CIR {
+            a: 1.0,
+            b: 0.01,
+            sigma: 0.04,
+        })
+        .stressed(cascade);
+        let FundingRateModel::CIR(stressed_cir) = stressed_cir else {
+            panic!("cascade must preserve the CIR model variant")
+        };
+        assert_eq!(stressed_cir.a, 1.0);
+        assert_eq!(stressed_cir.b, 0.01);
+        assert_roundoff(stressed_cir.sigma, 0.10, "CIR cascade sigma");
+
+        assert_eq!(
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: 0.01,
+                sigma: 0.04,
+            })
+            .stressed(StressScenario::MeanShift { shift: -0.02 }),
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: 0.0,
+                sigma: 0.04,
+            })
+        );
+    }
+
+    #[test]
+    fn simulator_rejects_invalid_position_model_grid_and_stress_inputs() {
+        fn panics(f: impl FnOnce() + std::panic::UnwindSafe) -> bool {
+            std::panic::catch_unwind(f).is_err()
+        }
+
+        let valid_position = LiquidationPosition {
+            size: 100.0,
+            entry_rate: 0.05,
+            collateral: 20.0,
+            margin_params: margin_params(),
+        };
+        let valid_model = FundingRateModel::Vasicek(Vasicek {
+            a: 1.0,
+            b: 0.05,
+            sigma: 0.10,
+        });
+        for position in [
+            LiquidationPosition {
+                size: 0.0,
+                ..valid_position
+            },
+            LiquidationPosition {
+                size: f64::NAN,
+                ..valid_position
+            },
+            LiquidationPosition {
+                entry_rate: f64::INFINITY,
+                ..valid_position
+            },
+            LiquidationPosition {
+                collateral: -1.0,
+                ..valid_position
+            },
+            LiquidationPosition {
+                margin_params: MarginParams {
+                    funding_rate_vol: f64::NAN,
+                    ..margin_params()
+                },
+                ..valid_position
+            },
+        ] {
+            assert!(panics(|| {
+                LiquidationSimulator::new(position, valid_model, 0.05, 1, 1, 0);
+            }));
+        }
+
+        for model in [
+            FundingRateModel::Vasicek(Vasicek {
+                a: -1.0,
+                b: 0.05,
+                sigma: 0.10,
+            }),
+            FundingRateModel::Vasicek(Vasicek {
+                a: 1.0,
+                b: f64::NAN,
+                sigma: 0.10,
+            }),
+            FundingRateModel::Vasicek(Vasicek {
+                a: 1.0,
+                b: 0.05,
+                sigma: -0.10,
+            }),
+            FundingRateModel::CIR(CIR {
+                a: f64::INFINITY,
+                b: 0.05,
+                sigma: 0.10,
+            }),
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: -0.05,
+                sigma: 0.10,
+            }),
+            FundingRateModel::CIR(CIR {
+                a: 1.0,
+                b: 0.05,
+                sigma: f64::NAN,
+            }),
+        ] {
+            assert!(panics(|| {
+                LiquidationSimulator::new(valid_position, model, 0.05, 1, 1, 0);
+            }));
+        }
+
+        assert!(panics(|| {
+            LiquidationSimulator::new(valid_position, valid_model, f64::NAN, 1, 1, 0);
+        }));
+        assert!(panics(|| {
+            LiquidationSimulator::new(valid_position, valid_model, 0.05, 0, 1, 0);
+        }));
+        assert!(panics(|| {
+            LiquidationSimulator::new(valid_position, valid_model, 0.05, 1, 0, 0);
+        }));
+
+        let simulator = LiquidationSimulator::new(valid_position, valid_model, 0.05, 1, 1, 0);
+        for scenario in [
+            StressScenario::LiquidationCascade {
+                vol_multiplier: -1.0,
+            },
+            StressScenario::LiquidationCascade {
+                vol_multiplier: f64::NAN,
+            },
+            StressScenario::MeanShift { shift: f64::NAN },
+        ] {
+            assert!(panics(|| {
+                simulator.simulate_stress(scenario);
+            }));
+        }
+
+        let overflow_vol_simulator = LiquidationSimulator::new(
+            valid_position,
+            FundingRateModel::Vasicek(Vasicek {
+                sigma: f64::MAX,
+                ..match valid_model {
+                    FundingRateModel::Vasicek(model) => model,
+                    FundingRateModel::CIR(_) => unreachable!(),
+                }
+            }),
+            0.05,
+            1,
+            1,
+            0,
+        );
+        assert!(panics(|| {
+            overflow_vol_simulator.simulate_stress(StressScenario::LiquidationCascade {
+                vol_multiplier: 2.0,
+            });
+        }));
+
+        let overflow_shift_simulator =
+            LiquidationSimulator::new(valid_position, valid_model, f64::MAX, 1, 1, 0);
+        assert!(panics(|| {
+            overflow_shift_simulator.simulate_stress(StressScenario::MeanShift { shift: f64::MAX });
+        }));
+        assert!(panics(|| {
+            StressScenario::mean_shift_suite(f64::INFINITY);
+        }));
+
+        for (num_paths, steps) in [(0, 1), (1, 0)] {
+            let mut mutated = simulator;
+            mutated.num_paths = num_paths;
+            mutated.steps = steps;
+            assert!(panics(|| {
+                mutated.simulate();
+            }));
+        }
     }
 }

--- a/src/risk/portfolio.rs
+++ b/src/risk/portfolio.rs
@@ -38,6 +38,13 @@ pub struct Position<I> {
 
 impl<I> Position<I> {
     pub fn new(instrument: I, quantity: f64, greeks: Greeks, spot: f64, implied_vol: f64) -> Self {
+        assert!(quantity.is_finite(), "quantity must be finite");
+        assert!(
+            [greeks.delta, greeks.gamma, greeks.vega, greeks.theta]
+                .iter()
+                .all(|value| value.is_finite()),
+            "delta, gamma, vega, and theta must be finite"
+        );
         assert!(
             spot.is_finite() && spot > 0.0,
             "spot must be finite and > 0"
@@ -121,6 +128,9 @@ impl<I> Portfolio<I> {
         vol_shock_pct: f64,
         horizon_years: f64,
     ) -> f64 {
+        assert!(spot_shock_pct.is_finite(), "spot_shock_pct must be finite");
+        assert!(vol_shock_pct.is_finite(), "vol_shock_pct must be finite");
+        assert!(horizon_years.is_finite(), "horizon_years must be finite");
         self.positions
             .iter()
             .map(|p| {
@@ -168,5 +178,111 @@ mod tests {
 
         let pnl = portfolio.scenario_pnl_with_horizon(0.01, 0.10, 1.0 / 252.0);
         assert_relative_eq!(pnl, 25.960_317_460_3, epsilon = 1.0e-10);
+    }
+
+    #[test]
+    fn add_position_and_aggregate_greeks_include_every_signed_contribution() {
+        let mut portfolio = Portfolio::default();
+        assert_eq!(portfolio.aggregate_greeks(), AggregatedGreeks::default());
+
+        portfolio.add_position(Position::new(
+            "first",
+            2.0,
+            greeks(1.5, -0.25, 4.0, -3.0),
+            80.0,
+            0.25,
+        ));
+        portfolio.add_position(Position::new(
+            "second",
+            -4.0,
+            greeks(-0.5, 0.125, -2.0, 0.75),
+            120.0,
+            0.30,
+        ));
+
+        assert_eq!(portfolio.positions[0].instrument, "first");
+        assert_eq!(
+            portfolio.aggregate_greeks(),
+            AggregatedGreeks {
+                delta: 5.0,
+                gamma: -1.0,
+                vega: 16.0,
+                theta: -9.0,
+            }
+        );
+    }
+
+    #[test]
+    fn scenario_pnl_aggregates_position_specific_spot_and_vol_scales_exactly() {
+        let portfolio = Portfolio::new(vec![
+            Position::new("long", 2.0, greeks(0.5, 0.02, 3.0, -4.0), 100.0, 0.20),
+            Position::new("short", -3.0, greeks(-0.25, -0.01, 2.0, 1.0), 80.0, 0.40),
+        ]);
+
+        // Position 1: 2 * (0.5*10 + 0.5*0.02*10^2 + 3*0.02 - 4*0.25) = 10.12.
+        // Position 2: -3 * (-0.25*8 + 0.5*-0.01*8^2 + 2*0.04 + 1*0.25) = 5.97.
+        let expected = 16.09;
+        assert_relative_eq!(
+            portfolio.scenario_pnl_with_horizon(0.10, 0.10, 0.25),
+            expected,
+            epsilon = 16.0 * f64::EPSILON
+        );
+
+        assert_eq!(
+            portfolio.scenario_pnl(-0.05, -0.20),
+            portfolio.scenario_pnl_with_horizon(-0.05, -0.20, 0.0)
+        );
+    }
+
+    #[test]
+    fn position_and_scenario_reject_non_finite_risk_inputs() {
+        fn position_panics(quantity: f64, greeks: Greeks, spot: f64, implied_vol: f64) -> bool {
+            std::panic::catch_unwind(|| {
+                Position::new("invalid", quantity, greeks, spot, implied_vol)
+            })
+            .is_err()
+        }
+
+        let valid = greeks(0.5, 0.1, 2.0, -1.0);
+        assert!(position_panics(f64::NAN, valid, 100.0, 0.2));
+        assert!(position_panics(1.0, valid, 0.0, 0.2));
+        assert!(position_panics(1.0, valid, f64::INFINITY, 0.2));
+        assert!(position_panics(1.0, valid, 100.0, -f64::EPSILON));
+        assert!(position_panics(1.0, valid, 100.0, f64::NAN));
+
+        for invalid_greeks in [
+            greeks(f64::NAN, 0.1, 2.0, -1.0),
+            greeks(0.5, f64::INFINITY, 2.0, -1.0),
+            greeks(0.5, 0.1, f64::NEG_INFINITY, -1.0),
+            greeks(0.5, 0.1, 2.0, f64::NAN),
+        ] {
+            assert!(position_panics(1.0, invalid_greeks, 100.0, 0.2));
+        }
+
+        // Rho is not consumed by this portfolio's aggregation or scenario
+        // approximation, so an unavailable rho must not reject usable risk.
+        assert!(!position_panics(
+            1.0,
+            Greeks {
+                rho: f64::NAN,
+                ..valid
+            },
+            100.0,
+            0.2,
+        ));
+
+        let portfolio = Portfolio::new(vec![Position::new("valid", 1.0, valid, 100.0, 0.2)]);
+        for (spot_shock, vol_shock, horizon) in [
+            (f64::NAN, 0.0, 0.0),
+            (0.0, f64::INFINITY, 0.0),
+            (0.0, 0.0, f64::NEG_INFINITY),
+        ] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    portfolio.scenario_pnl_with_horizon(spot_shock, vol_shock, horizon)
+                })
+                .is_err()
+            );
+        }
     }
 }

--- a/src/risk/var.rs
+++ b/src/risk/var.rs
@@ -95,6 +95,7 @@ pub fn delta_normal_var(
     confidence: f64,
     horizon_days: f64,
 ) -> f64 {
+    assert!(delta.is_finite(), "delta must be finite");
     validate_params(confidence, annual_volatility, horizon_days);
     let z = normal_inv_cdf(confidence);
     let sigma_h = annual_volatility.abs() * (horizon_days / TRADING_DAYS_PER_YEAR).sqrt();
@@ -109,6 +110,8 @@ pub fn delta_gamma_normal_var(
     confidence: f64,
     horizon_days: f64,
 ) -> f64 {
+    assert!(delta.is_finite(), "delta must be finite");
+    assert!(gamma.is_finite(), "gamma must be finite");
     validate_params(confidence, annual_volatility, horizon_days);
 
     let z = normal_inv_cdf(confidence);
@@ -133,13 +136,14 @@ pub fn delta_gamma_normal_var(
 /// ```
 pub fn normal_expected_shortfall(mean_loss: f64, std_dev_loss: f64, confidence: f64) -> f64 {
     assert!(
-        (0.0..1.0).contains(&confidence),
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
     assert!(
         std_dev_loss.is_finite() && std_dev_loss >= 0.0,
         "std_dev_loss must be finite and >= 0"
     );
+    assert!(mean_loss.is_finite(), "mean_loss must be finite");
     let z = normal_inv_cdf(confidence);
     mean_loss + std_dev_loss * normal_pdf(z) / (1.0 - confidence)
 }
@@ -155,12 +159,18 @@ pub fn cornish_fisher_var(
     confidence: f64,
 ) -> f64 {
     assert!(
-        (0.0..1.0).contains(&confidence),
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
     assert!(
         std_dev_loss.is_finite() && std_dev_loss >= 0.0,
         "std_dev_loss must be finite and >= 0"
+    );
+    assert!(mean_loss.is_finite(), "mean_loss must be finite");
+    assert!(skewness.is_finite(), "skewness must be finite");
+    assert!(
+        excess_kurtosis.is_finite(),
+        "excess_kurtosis must be finite"
     );
 
     let z = normal_inv_cdf(confidence);
@@ -218,7 +228,7 @@ pub fn rolling_historical_var_from_prices(
     use_log_returns: bool,
 ) -> Vec<f64> {
     assert!(
-        (0.0..1.0).contains(&confidence),
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
     let returns = if use_log_returns {
@@ -254,7 +264,7 @@ pub fn backtest_historical_var_from_prices(
     use_log_returns: bool,
 ) -> VarBacktestResult {
     assert!(
-        (0.0..1.0).contains(&confidence),
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
     let returns = if use_log_returns {
@@ -276,14 +286,18 @@ pub fn backtest_historical_var_from_prices(
 fn validate_inputs(pnl: &[f64], confidence: f64) {
     assert!(!pnl.is_empty(), "pnl must not be empty");
     assert!(
-        (0.0..1.0).contains(&confidence),
+        pnl.iter().all(|value| value.is_finite()),
+        "pnl must contain only finite values"
+    );
+    assert!(
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
 }
 
 fn validate_params(confidence: f64, annual_volatility: f64, horizon_days: f64) {
     assert!(
-        (0.0..1.0).contains(&confidence),
+        confidence.is_finite() && confidence > 0.0 && confidence < 1.0,
         "confidence must be in (0,1)"
     );
     assert!(
@@ -461,5 +475,207 @@ mod tests {
 
         assert_eq!(forecasts.len(), prices.len() - 1 - window);
         assert_eq!(bt, expected);
+    }
+
+    #[test]
+    fn historical_tail_metrics_cover_singleton_interpolation_and_empty_tail() {
+        assert_eq!(historical_var(&[-7.5], 0.975), 7.5);
+
+        // Losses sort to [-1, 2, 3, 4]. At confidence 0.5, VaR is 2.5 and
+        // expected shortfall is the exact average of the two losses above it.
+        let pnl = [-4.0, -3.0, -2.0, 1.0];
+        assert_eq!(historical_var(&pnl, 0.5), 2.5);
+        assert_eq!(historical_expected_shortfall(&pnl, 0.5), 3.5);
+
+        // With an all-profit sample the non-negative VaR floor leaves no
+        // observations in the loss tail, so ES returns that zero floor.
+        let profits = [1.0, 2.0, 3.0];
+        assert_eq!(historical_var(&profits, 0.99), 0.0);
+        assert_eq!(historical_expected_shortfall(&profits, 0.99), 0.0);
+    }
+
+    #[test]
+    fn delta_gamma_var_reduces_to_delta_normal_and_has_exact_gamma_sign_shift() {
+        let delta_only = delta_gamma_normal_var(1.75, 0.0, 0.30, 0.99, 10.0);
+        assert_relative_eq!(
+            delta_only,
+            delta_normal_var(1.75, 0.30, 0.99, 10.0),
+            epsilon = 16.0 * f64::EPSILON
+        );
+        assert_relative_eq!(
+            delta_gamma_normal_var(-1.75, 0.0, 0.30, 0.99, 10.0),
+            delta_only,
+            epsilon = 16.0 * f64::EPSILON
+        );
+
+        let gamma = 2.0;
+        let annual_volatility = 0.30;
+        let horizon_days = 10.0;
+        let positive_gamma =
+            delta_gamma_normal_var(0.0, gamma, annual_volatility, 0.99, horizon_days);
+        let negative_gamma =
+            delta_gamma_normal_var(0.0, -gamma, annual_volatility, 0.99, horizon_days);
+        let sigma_squared = annual_volatility * annual_volatility * horizon_days / 252.0;
+        assert_relative_eq!(
+            negative_gamma - positive_gamma,
+            gamma * sigma_squared,
+            epsilon = 8.0 * f64::EPSILON
+        );
+
+        assert_eq!(delta_gamma_normal_var(0.0, 0.0, 0.20, 0.99, 1.0), 0.0);
+    }
+
+    #[test]
+    fn zero_dispersion_tail_formulas_and_sample_moment_paths_are_exact() {
+        assert_eq!(normal_expected_shortfall(3.25, 0.0, 0.975), 3.25);
+        assert_eq!(cornish_fisher_var(3.25, 0.0, 2.0, 5.0, 0.975), 3.25);
+
+        let constant_losses = [-2.0; 5];
+        assert_eq!(cornish_fisher_var_from_pnl(&constant_losses, 0.99), 2.0);
+        assert_eq!(cornish_fisher_var_from_pnl(&[2.0; 5], 0.99), 0.0);
+        assert_eq!(sample_moments(&[]), (0.0, 0.0, 0.0, 0.0));
+
+        // Population moments of [-2,-1,0,1,2] are mean=0, variance=2,
+        // skew=0 and excess kurtosis=-1.3.
+        let symmetric = [-2.0, -1.0, 0.0, 1.0, 2.0];
+        let moments = sample_moments(&symmetric);
+        assert_eq!(moments.0, 0.0);
+        assert_relative_eq!(moments.1, 2.0_f64.sqrt(), epsilon = f64::EPSILON);
+        assert_eq!(moments.2, 0.0);
+        assert_relative_eq!(moments.3, -1.3, epsilon = 2.0 * f64::EPSILON);
+        assert_relative_eq!(
+            cornish_fisher_var_from_pnl(&symmetric, 0.95),
+            cornish_fisher_var(0.0, 2.0_f64.sqrt(), 0.0, -1.3, 0.95),
+            epsilon = 16.0 * f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn price_series_wrappers_match_explicit_simple_and_log_return_samples() {
+        let prices = [100.0, 102.0, 99.0, 103.0, 101.0, 104.0, 100.0];
+        let simple = simple_returns(&prices);
+        let log = log_returns(&prices);
+
+        assert_eq!(
+            historical_var_from_prices(&prices, 0.80, false),
+            historical_var(&simple, 0.80)
+        );
+        assert_eq!(
+            historical_var_from_prices(&prices, 0.80, true),
+            historical_var(&log, 0.80)
+        );
+        assert_eq!(
+            historical_expected_shortfall_from_prices(&prices, 0.80, false),
+            historical_expected_shortfall(&simple, 0.80)
+        );
+        assert_eq!(
+            historical_expected_shortfall_from_prices(&prices, 0.80, true),
+            historical_expected_shortfall(&log, 0.80)
+        );
+    }
+
+    #[test]
+    fn rolling_forecasts_match_each_explicit_trailing_window_for_both_return_types() {
+        let prices = [
+            100.0, 102.0, 101.0, 104.0, 100.0, 105.0, 103.0, 107.0, 106.0,
+        ];
+        let window = 3;
+        let confidence = 0.75;
+
+        for use_log_returns in [false, true] {
+            let returns = if use_log_returns {
+                log_returns(&prices)
+            } else {
+                simple_returns(&prices)
+            };
+            let forecasts =
+                rolling_historical_var_from_prices(&prices, window, confidence, use_log_returns);
+            let expected = (window..returns.len())
+                .map(|i| historical_var(&returns[(i - window)..i], confidence))
+                .collect::<Vec<_>>();
+            assert_eq!(forecasts, expected);
+
+            let losses = returns[window..].iter().map(|r| -r).collect::<Vec<_>>();
+            assert_eq!(
+                backtest_historical_var_from_prices(&prices, window, confidence, use_log_returns,),
+                backtest_var(&losses, &expected, confidence)
+            );
+        }
+    }
+
+    #[test]
+    fn var_entry_points_reject_non_finite_and_shape_invalid_inputs() {
+        fn panics(f: impl FnOnce() + std::panic::UnwindSafe) -> bool {
+            std::panic::catch_unwind(f).is_err()
+        }
+
+        assert!(panics(|| {
+            historical_var(&[], 0.95);
+        }));
+        assert!(panics(|| {
+            historical_var(&[0.0, f64::NAN], 0.95);
+        }));
+        assert!(panics(|| {
+            historical_expected_shortfall(&[0.0, f64::INFINITY], 0.95);
+        }));
+        for confidence in [0.0, 1.0, f64::NAN] {
+            assert!(panics(|| {
+                historical_var(&[0.0], confidence);
+            }));
+        }
+
+        for (delta, vol, confidence, horizon) in [
+            (f64::NAN, 0.2, 0.99, 1.0),
+            (1.0, f64::INFINITY, 0.99, 1.0),
+            (1.0, -0.2, 0.99, 1.0),
+            (1.0, 0.2, 1.0, 1.0),
+            (1.0, 0.2, 0.99, 0.0),
+            (1.0, 0.2, 0.99, f64::NAN),
+        ] {
+            assert!(panics(|| {
+                delta_normal_var(delta, vol, confidence, horizon);
+            }));
+        }
+        assert!(panics(|| {
+            delta_gamma_normal_var(1.0, f64::NAN, 0.2, 0.99, 1.0);
+        }));
+
+        for (mean, std_dev, confidence) in [
+            (f64::NAN, 1.0, 0.95),
+            (0.0, f64::INFINITY, 0.95),
+            (0.0, -1.0, 0.95),
+            (0.0, 1.0, f64::NAN),
+        ] {
+            assert!(panics(|| {
+                normal_expected_shortfall(mean, std_dev, confidence);
+            }));
+        }
+        for (mean, std_dev, skew, kurtosis, confidence) in [
+            (f64::INFINITY, 1.0, 0.0, 0.0, 0.95),
+            (0.0, -1.0, 0.0, 0.0, 0.95),
+            (0.0, 1.0, f64::NAN, 0.0, 0.95),
+            (0.0, 1.0, 0.0, f64::INFINITY, 0.95),
+            (0.0, 1.0, 0.0, 0.0, 1.0),
+        ] {
+            assert!(panics(|| {
+                cornish_fisher_var(mean, std_dev, skew, kurtosis, confidence);
+            }));
+        }
+
+        let prices = [100.0, 101.0, 102.0, 103.0];
+        for window in [1, prices.len() - 1] {
+            assert!(panics(|| {
+                rolling_historical_var_from_prices(&prices, window, 0.95, false);
+            }));
+            assert!(panics(|| {
+                backtest_historical_var_from_prices(&prices, window, 0.95, true);
+            }));
+        }
+        assert!(panics(|| {
+            rolling_historical_var_from_prices(&prices, 2, 0.0, false);
+        }));
+        assert!(panics(|| {
+            backtest_historical_var_from_prices(&prices, 2, 1.0, false);
+        }));
     }
 }


### PR DESCRIPTION
## What changed

- add 45 exact-contract and branch-focused tests for the rainbow, power, and swing instrument wrappers
- lock every DSL error display/conversion path and make source annotations UTF-8-safe
- cover portfolio aggregation, VaR/ES identities and validation, and liquidation stress/model branches
- cover calibration diagnostics, singular condition numbers, validation, global search, non-convergence, and deterministic fallback improvements
- harden validation defects uncovered by the new tests, including non-finite rainbow/risk inputs, duplicate swing dates, confidence zero, mutable liquidation grids, and non-finite SABR domains

## Why

These were the remaining thin or branch-light areas after the pricing reference hardening work. The tests now assert exact contracts, roundoff-budget identities, or deterministic optimizer improvement instead of broad sanity conditions.

## Validation

- `cargo test --locked --workspace --all-features --quiet`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- workflow-equivalent nightly branch coverage across scalar, SIMD/parallel, JIT, and Python 3.13 bindings
- Python bindings: 245/245 passed
- merged local coverage: 90.90% lines, 91.22% regions, 65.90% branches

Targeted post-change coverage:
- 100% lines: DSL errors, power, rainbow, swing, portfolio, VaR
- 98.14% lines: Hull-White calibration
- 98.63% lines: SABR calibration
- 99.17% lines: liquidation risk
